### PR TITLE
fix(certs): persist auto-added SANs to DB columns

### DIFF
--- a/backend/api/v2/certificates.py
+++ b/backend/api/v2/certificates.py
@@ -560,7 +560,14 @@ def create_certificate():
                 existing_emails = [str(s.value) for s in san_list if isinstance(s, x509.RFC822Name)]
                 if subject_email not in existing_emails:
                     san_list.append(x509.RFC822Name(subject_email))
-        
+
+        # Derive final SAN lists from san_list so auto-added entries are
+        # reflected in the DB columns, not just the X.509 extension.
+        final_san_dns = [s.value for s in san_list if isinstance(s, x509.DNSName)]
+        final_san_ip = [str(s.value) for s in san_list if isinstance(s, x509.IPAddress)]
+        final_san_email = [s.value for s in san_list if isinstance(s, x509.RFC822Name)]
+        final_san_uri = [s.value for s in san_list if isinstance(s, x509.UniformResourceIdentifier)]
+
         if san_list:
             builder = builder.add_extension(
                 x509.SubjectAlternativeName(san_list),
@@ -682,10 +689,10 @@ def create_certificate():
             ski=cert_ski,
             valid_from=not_before,
             valid_to=not_after,
-            san_dns=json.dumps(data.get('san_dns', [])),
-            san_ip=json.dumps(data.get('san_ip', [])),
-            san_email=json.dumps(data.get('san_email', [])),
-            san_uri=json.dumps(data.get('san_uri', [])),
+            san_dns=json.dumps(final_san_dns),
+            san_ip=json.dumps(final_san_ip),
+            san_email=json.dumps(final_san_email),
+            san_uri=json.dumps(final_san_uri),
             ocsp_must_staple=bool(data.get('ocsp_must_staple')),
             created_by=g.current_user.username if hasattr(g, 'current_user') else None
         )

--- a/backend/migrations/027_backfill_san_email.py
+++ b/backend/migrations/027_backfill_san_email.py
@@ -1,0 +1,139 @@
+"""
+Migration 027: Backfill san_email (and san_dns / san_ip / san_uri) from
+the stored X.509 certificate for any row where the DB column is out of sync.
+
+Root cause: certificates.py used data.get('san_email', []) when writing
+san_email to the DB.  Auto-added SANs (CN → RFC822Name for email/combined
+certs, subject email → RFC822Name) were inserted into the X.509 extension
+but the DB column was never updated to match, leaving it as '[]' or NULL.
+
+This migration re-derives all four SAN columns from the actual certificate
+for every row in the certificates table and writes the corrected values.
+Rows where all four columns already match are left untouched.
+
+Multi-backend: runs on both SQLite and PostgreSQL.
+"""
+import base64
+import json
+import logging
+import sqlite3
+
+logger = logging.getLogger(__name__)
+pg_compatible = True
+
+
+def _extract_sans(pem_b64: str):
+    """Return (dns, ip, email, uri) lists from a base64-encoded PEM cert."""
+    from cryptography import x509
+    try:
+        pem = base64.b64decode(pem_b64)
+        cert = x509.load_pem_x509_certificate(pem)
+    except Exception:
+        return None, None, None, None
+
+    try:
+        san_ext = cert.extensions.get_extension_for_class(x509.SubjectAlternativeName)
+        dns = [n.value for n in san_ext.value if isinstance(n, x509.DNSName)]
+        ip = [str(n.value) for n in san_ext.value if isinstance(n, x509.IPAddress)]
+        email = [n.value for n in san_ext.value if isinstance(n, x509.RFC822Name)]
+        uri = [n.value for n in san_ext.value if isinstance(n, x509.UniformResourceIdentifier)]
+    except x509.ExtensionNotFound:
+        dns, ip, email, uri = [], [], [], []
+
+    return dns, ip, email, uri
+
+
+def _backfill(rows, update_fn):
+    """Core logic shared between SQLite and PostgreSQL paths."""
+    updated = 0
+    skipped = 0
+
+    for row in rows:
+        cert_id, crt, db_dns, db_ip, db_email, db_uri = row
+
+        if not crt:
+            skipped += 1
+            continue
+
+        dns, ip, email, uri = _extract_sans(crt)
+        if dns is None:
+            skipped += 1
+            continue
+
+        def _load(v):
+            if not v:
+                return []
+            try:
+                return json.loads(v)
+            except Exception:
+                return []
+
+        needs_update = (
+            sorted(_load(db_dns)) != sorted(dns) or
+            sorted(_load(db_ip)) != sorted(ip) or
+            sorted(_load(db_email)) != sorted(email) or
+            sorted(_load(db_uri)) != sorted(uri)
+        )
+
+        if needs_update:
+            update_fn(cert_id, dns, ip, email, uri)
+            updated += 1
+        else:
+            skipped += 1
+
+    logger.info(f"Migration 027: updated {updated} rows, {skipped} already correct / skipped")
+
+
+def _upgrade_sqlite(conn):
+    cur = conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='certificates'"
+    )
+    if not cur.fetchone():
+        logger.info("Migration 027: certificates table absent, skipping")
+        return
+
+    rows = conn.execute(
+        "SELECT id, crt, san_dns, san_ip, san_email, san_uri FROM certificates"
+    ).fetchall()
+
+    def update_fn(cert_id, dns, ip, email, uri):
+        conn.execute(
+            "UPDATE certificates SET san_dns=?, san_ip=?, san_email=?, san_uri=? WHERE id=?",
+            (json.dumps(dns), json.dumps(ip), json.dumps(email), json.dumps(uri), cert_id)
+        )
+
+    _backfill(rows, update_fn)
+    conn.commit()
+
+
+def _upgrade_pg(engine):
+    from sqlalchemy import inspect, text
+
+    insp = inspect(engine)
+    if 'certificates' not in set(insp.get_table_names()):
+        logger.info("Migration 027: certificates table absent, skipping")
+        return
+
+    with engine.begin() as conn:
+        result = conn.execute(text(
+            "SELECT id, crt, san_dns, san_ip, san_email, san_uri FROM certificates"
+        ))
+        rows = result.fetchall()
+
+        def update_fn(cert_id, dns, ip, email, uri):
+            conn.execute(text(
+                "UPDATE certificates SET san_dns=:dns, san_ip=:ip, san_email=:email, san_uri=:uri WHERE id=:id"
+            ), {"dns": json.dumps(dns), "ip": json.dumps(ip), "email": json.dumps(email), "uri": json.dumps(uri), "id": cert_id})
+
+        _backfill(rows, update_fn)
+
+
+def upgrade(conn):
+    if isinstance(conn, sqlite3.Connection):
+        _upgrade_sqlite(conn)
+    else:
+        _upgrade_pg(conn)
+
+
+def downgrade(conn):
+    pass


### PR DESCRIPTION
When creating an email or combined certificate, the CN (if it is an email address) and the subject email field are auto-added as RFC822Name SANs in the X.509 extension. However, the DB columns were written from `data.get('san_*', [])` — only what was explicitly submitted in the request — so the auto-added entries were never stored. The result: the certificate itself was correct but `san_email` (and `san_dns` for server/combined certs) in the DB were out of sync with the actual extension.

## Changes

- **`certificates.py`:** after all SAN auto-add logic completes, derive the final `san_dns`, `san_ip`, `san_email`, and `san_uri` lists directly from `san_list` (the same source used to build the X.509 extension) before writing to the DB. Fixes `san_email` for email/combined certs and `san_dns` for server/combined certs where the CN was auto-promoted.

- **`migrations/027_backfill_san_email.py`:** backfills all four SAN columns for existing certificates by re-deriving them from the stored X.509 PEM. Rows that are already correct are left untouched. Runs on both SQLite and PostgreSQL.

## Test plan
- [ ] Create an email-type cert where the CN is an email address — verify `san_email` in the DB matches the RFC822Name SAN in the issued certificate
- [ ] Create a server cert — verify `san_dns` in the DB includes the auto-promoted CN hostname
- [ ] Run the migration on an existing database and verify previously out-of-sync rows are corrected