### PR TITLE
fix(certs): write certificate files to disk on creation

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -146,7 +146,28 @@ def create_app(config_name=None):
     # Initialize extensions
     db.init_app(app)
     migrate = Migrate(app, db)
-    
+
+    # Write cert/CA files to disk immediately after any INSERT so they are
+    # available without waiting for the next service restart.
+    from sqlalchemy import event as sa_event
+    from models import Certificate as _Certificate, CA as _CA
+
+    @sa_event.listens_for(_Certificate, 'after_insert')
+    def _on_cert_insert(mapper, connection, target):
+        try:
+            from services.file_regen_service import write_cert_files
+            write_cert_files(target)
+        except Exception as e:
+            app.logger.warning(f"Could not write files for cert {target.refid}: {e}")
+
+    @sa_event.listens_for(_CA, 'after_insert')
+    def _on_ca_insert(mapper, connection, target):
+        try:
+            from services.file_regen_service import write_ca_files
+            write_ca_files(target)
+        except Exception as e:
+            app.logger.warning(f"Could not write files for CA {target.refid}: {e}")
+
     # Log database type
     app.logger.info(f"✓ Database: {config.DATABASE_TYPE.upper()}")
     

--- a/backend/services/file_regen_service.py
+++ b/backend/services/file_regen_service.py
@@ -16,6 +16,73 @@ from utils.file_naming import (
 logger = logging.getLogger(__name__)
 
 
+def write_cert_files(cert) -> None:
+    """Write certificate, key, and CSR files for a single Certificate object.
+
+    Called immediately after a new certificate is committed so the files
+    are available on disk without waiting for the next service restart.
+    Errors are logged but never raised — a missing file is recoverable at
+    the next startup via regenerate_all_files().
+    """
+    from security.encryption import decrypt_private_key
+
+    Config.CERT_DIR.mkdir(parents=True, exist_ok=True)
+    Config.PRIVATE_DIR.mkdir(parents=True, exist_ok=True)
+
+    cert_path = cert_cert_path(cert)
+    if not cert_path.exists() and cert.crt:
+        try:
+            cert_path.write_bytes(base64.b64decode(cert.crt))
+        except Exception as e:
+            logger.warning(f"Could not write cert file for {cert.descr}: {e}")
+
+    key_path = cert_key_path(cert)
+    if not key_path.exists() and cert.prv:
+        try:
+            key_pem = base64.b64decode(decrypt_private_key(cert.prv))
+            key_path.write_bytes(key_pem)
+            key_path.chmod(0o600)
+        except Exception as e:
+            logger.warning(f"Could not write key file for {cert.descr}: {e}")
+
+    csr_path = cert_csr_path(cert)
+    if not csr_path.exists() and cert.csr:
+        try:
+            csr_data = cert.csr
+            csr_bytes = csr_data.encode() if csr_data.startswith('-----BEGIN') else base64.b64decode(csr_data)
+            csr_path.write_bytes(csr_bytes)
+        except Exception as e:
+            logger.warning(f"Could not write CSR file for {cert.descr}: {e}")
+
+
+def write_ca_files(ca) -> None:
+    """Write certificate and key files for a single CA object.
+
+    Called immediately after a new CA is committed so the files are
+    available on disk without waiting for the next service restart.
+    """
+    from security.encryption import decrypt_private_key
+
+    Config.CA_DIR.mkdir(parents=True, exist_ok=True)
+    Config.PRIVATE_DIR.mkdir(parents=True, exist_ok=True)
+
+    cert_path = ca_cert_path(ca)
+    if not cert_path.exists() and ca.crt:
+        try:
+            cert_path.write_bytes(base64.b64decode(ca.crt))
+        except Exception as e:
+            logger.warning(f"Could not write CA cert file for {ca.descr}: {e}")
+
+    key_path = ca_key_path(ca)
+    if not key_path.exists() and ca.prv:
+        try:
+            key_pem = base64.b64decode(decrypt_private_key(ca.prv))
+            key_path.write_bytes(key_pem)
+            key_path.chmod(0o600)
+        except Exception as e:
+            logger.warning(f"Could not write CA key file for {ca.descr}: {e}")
+
+
 def regenerate_all_files():
     """
     Check and regenerate all certificate/key files from database.


### PR DESCRIPTION
Certificate and CA files were only written to the `data/` directory during service startup (`file_regen_service.regenerate_all_files`). Any certificate or CA created mid-session was only persisted to the database; the corresponding `.crt`, `.key`, and `.csr` files did not appear on disk until the next restart.

## Changes

- **`file_regen_service.py`:** added `write_cert_files(cert)` and `write_ca_files(ca)` helpers that write the files for a single object immediately.

- **`app.py`:** registered SQLAlchemy `after_insert` event listeners on the `Certificate` and `CA` models so these helpers are called automatically whenever any code path commits a new row — covering all creation paths (UI, SCEP, ACME, CSR signing, import, auto-renewal) without modifying each endpoint individually.

The startup regeneration remains in place as a safety net for edge cases (e.g. write failure, files deleted manually between restarts).

## Test plan
- [ ] Create a certificate via the UI — verify the `.crt` file appears in `data/certs/` immediately without a restart
- [ ] Create a CA — verify the `.crt` file appears in `data/ca/` immediately
- [ ] Import a certificate — verify file appears immediately
- [ ] Verify existing startup regeneration still works correctly on restart