### PR TITLE
fix(acme): route issuance to configured CA (Actalis) + complete CA chain & naming on export

### DIFF
--- a/backend/api/v2/acme_client/account.py
+++ b/backend/api/v2/acme_client/account.py
@@ -47,7 +47,7 @@ def register_account():
         return error_response('Environment must be staging or production', 400)
 
     try:
-        client = AcmeClientService(environment=environment)
+        client = AcmeClientService.for_issuance(environment=environment)
         success, message, account_url = client.register_account(email)
 
         if success:

--- a/backend/api/v2/acme_client/orders.py
+++ b/backend/api/v2/acme_client/orders.py
@@ -203,7 +203,7 @@ def request_certificate():
 
     # Create order
     try:
-        client = AcmeClientService(environment=environment)
+        client = AcmeClientService.for_issuance(environment=environment)
         success, message, order = client.create_order(
             domains=domains,
             email=email,
@@ -301,7 +301,7 @@ def verify_challenges(order_id):
     force = bool(data.get('force'))
 
     try:
-        client = AcmeClientService(environment=order.environment)
+        client = AcmeClientService.for_issuance(environment=order.environment)
 
         results = {}
         challenges = order.challenges_dict
@@ -382,7 +382,7 @@ def check_order_status(order_id):
         return error_response('Order not found', 404)
 
     try:
-        client = AcmeClientService(environment=order.environment)
+        client = AcmeClientService.for_issuance(environment=order.environment)
         status, data = client.check_order_status(order)
 
         return success_response(data={
@@ -408,7 +408,7 @@ def finalize_order(order_id):
         return error_response('Order already issued', 400)
 
     try:
-        client = AcmeClientService(environment=order.environment)
+        client = AcmeClientService.for_issuance(environment=order.environment)
         success, message, cert_id = client.finalize_order(order)
 
         if success:
@@ -450,7 +450,7 @@ def cancel_order(order_id):
     # Clean up DNS if needed
     if order.challenge_type == 'dns-01' and order.dns_provider_id:
         try:
-            client = AcmeClientService(environment=order.environment)
+            client = AcmeClientService.for_issuance(environment=order.environment)
             client.cleanup_dns_challenge(order)
         except Exception:
             pass  # Best effort cleanup
@@ -651,7 +651,7 @@ def _run_auto_poll_background(order_id: int, environment: str) -> None:
                 if order.status in ('issued', 'invalid', 'expired'):
                     logger.info(f'Auto-poll background: order {order_id} already {order.status}, skipping')
                     return
-                client = AcmeClientService(environment=environment)
+                client = AcmeClientService.for_issuance(environment=environment)
                 _auto_poll_and_finalize(client, order)
             except Exception as e:
                 logger.error(f'Auto-poll background failed for order {order_id}: {e}', exc_info=True)

--- a/backend/api/v2/certificates/export.py
+++ b/backend/api/v2/certificates/export.py
@@ -13,18 +13,145 @@ import zipfile
 from flask import Response, request, g
 from auth.unified import require_auth, has_permission
 from cryptography import x509
-from cryptography.hazmat.primitives import serialization
+from cryptography.x509.oid import NameOID
+from cryptography.hazmat.primitives import serialization, hashes
 from cryptography.hazmat.primitives.asymmetric import rsa, ec
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives.serialization import pkcs12
 
 from models import Certificate, CA
+from models.truststore import TrustedCertificate
 from utils.response import success_response, error_response
 from utils.sanitize import sanitize_filename
 from utils.key_codec import load_pem_bytes
 from . import bp
 
 logger = logging.getLogger(__name__)
+
+
+def _split_pem_certs(pem_bytes):
+    """Return every PEM certificate block found in *pem_bytes* as x509 objects."""
+    certs = []
+    marker = b'-----END CERTIFICATE-----'
+    for chunk in pem_bytes.split(marker):
+        if b'-----BEGIN CERTIFICATE-----' not in chunk:
+            continue
+        block = chunk[chunk.index(b'-----BEGIN CERTIFICATE-----'):] + marker + b'\n'
+        try:
+            certs.append(x509.load_pem_x509_certificate(block, default_backend()))
+        except Exception:
+            continue
+    return certs
+
+
+def _resolve_issuer_cert(cert):
+    """Find the issuer certificate of *cert* among locally known sources.
+
+    Looks up managed CAs (by AKI→SKI, then issuer DN) and then the Trust Store
+    (by issuer DN). Returns the issuer x509.Certificate or None. Used to fill in
+    a missing chain when it is neither stored inline nor reachable via `caref`.
+    """
+    issuer_dn = cert.issuer.rfc4514_string()
+
+    aki = None
+    try:
+        aki_ext = cert.extensions.get_extension_for_class(x509.AuthorityKeyIdentifier)
+        if aki_ext.value.key_identifier:
+            aki = aki_ext.value.key_identifier.hex()
+    except x509.ExtensionNotFound:
+        pass
+
+    # 1. Managed CAs — prefer AKI→SKI, then subject DN
+    ca = None
+    if aki:
+        ca = CA.query.filter(CA.ski == aki).first()
+    if ca is None:
+        ca = CA.query.filter(CA.subject == issuer_dn).first()
+    if ca is not None and ca.crt:
+        try:
+            return x509.load_pem_x509_certificate(base64.b64decode(ca.crt), default_backend())
+        except Exception:
+            pass
+
+    # 2. Trust Store — by issuer DN
+    tc = TrustedCertificate.query.filter_by(subject=issuer_dn).first()
+    if tc is not None and tc.certificate_pem:
+        try:
+            return x509.load_pem_x509_certificate(tc.certificate_pem.encode(), default_backend())
+        except Exception:
+            pass
+    return None
+
+
+def _build_ca_chain(certificate, cert_pem):
+    """Build the issuing CA chain (excluding the leaf) for chain-aware exports.
+
+    Order of preference:
+      1. The chain already stored inline with the certificate (ACME / imported
+         full-chain certs store leaf + intermediates in `crt`).
+      2. The managed CA chain walked via `certificate.caref`.
+      3. If the chain is still missing or incomplete, reconstruct it from locally
+         known issuers (managed CAs + Trust Store) by walking issuer DNs up to a
+         self-signed root.
+    """
+    inline = _split_pem_certs(cert_pem)
+    leaf = inline[0] if inline else None
+    chain = inline[1:] if len(inline) > 1 else []
+
+    # 2. Managed CA walk via caref (only when nothing came inline)
+    if not chain and certificate.caref:
+        ca = CA.query.filter_by(refid=certificate.caref).first()
+        while ca:
+            if ca.crt:
+                try:
+                    chain.append(
+                        x509.load_pem_x509_certificate(base64.b64decode(ca.crt), default_backend())
+                    )
+                except Exception:
+                    pass
+            ca = CA.query.filter_by(refid=ca.caref).first() if ca.caref else None
+
+    # 3. Extend/complete the chain using locally known issuers until we reach a
+    #    self-signed root (or can no longer resolve the next issuer).
+    seen = {c.fingerprint(hashes.SHA256()) for c in chain}
+    top = chain[-1] if chain else leaf
+    guard = 0
+    while top is not None and guard < 10:
+        guard += 1
+        if top.subject.rfc4514_string() == top.issuer.rfc4514_string():
+            break  # self-signed root reached
+        nxt = _resolve_issuer_cert(top)
+        if nxt is None:
+            break
+        fp = nxt.fingerprint(hashes.SHA256())
+        if fp in seen:
+            break  # cycle / already present
+        seen.add(fp)
+        chain.append(nxt)
+        top = nxt
+
+    return chain
+
+
+def _named_cas(ca_certs):
+    """Wrap CA certs as PKCS12Certificate objects carrying a friendlyName.
+
+    Without an explicit friendlyName, keystore tools (XCA, keytool, certmgr)
+    auto-label intermediate/root entries as ``<leaf>_ca_0``, ``_ca_1``, ...
+    Tagging each CA with its Common Name (falling back to the full subject DN)
+    makes them display under their real name.
+    """
+    if not ca_certs:
+        return None
+    named = []
+    for c in ca_certs:
+        try:
+            attrs = c.subject.get_attributes_for_oid(NameOID.COMMON_NAME)
+            fname = attrs[0].value if attrs else c.subject.rfc4514_string()
+        except Exception:
+            fname = c.subject.rfc4514_string()
+        named.append(pkcs12.PKCS12Certificate(c, fname.encode()))
+    return named
 
 
 @bp.route('/api/v2/certificates/export', methods=['GET', 'POST'])
@@ -223,26 +350,14 @@ def export_certificate(cert_id):
             key_pem = load_pem_bytes(certificate.prv, context=f"certificate {certificate.id}")
             private_key = serialization.load_pem_private_key(key_pem, password=None, backend=default_backend())
 
-            # Build CA chain if available and requested
-            ca_certs = []
-            if include_chain and certificate.caref:
-                ca = CA.query.filter_by(refid=certificate.caref).first()
-                while ca:
-                    if ca.crt:
-                        ca_cert = x509.load_pem_x509_certificate(
-                            base64.b64decode(ca.crt), default_backend()
-                        )
-                        ca_certs.append(ca_cert)
-                    if ca.caref:
-                        ca = CA.query.filter_by(refid=ca.caref).first()
-                    else:
-                        break
+            # Build CA chain if requested (inline stored chain or managed CA)
+            ca_certs = _build_ca_chain(certificate, cert_pem) if include_chain else []
 
             p12_bytes = pkcs12.serialize_key_and_certificates(
                 name=(certificate.descr or certificate.refid).encode(),
                 key=private_key,
                 cert=cert,
-                cas=ca_certs if ca_certs else None,
+                cas=_named_cas(ca_certs),
                 encryption_algorithm=serialization.BestAvailableEncryption(password.encode())
             )
 
@@ -296,26 +411,14 @@ def export_certificate(cert_id):
             key_pem = load_pem_bytes(certificate.prv, context=f"certificate {certificate.id}")
             private_key = serialization.load_pem_private_key(key_pem, password=None, backend=default_backend())
 
-            # Build CA chain if available and requested
-            ca_certs = []
-            if include_chain and certificate.caref:
-                ca = CA.query.filter_by(refid=certificate.caref).first()
-                while ca:
-                    if ca.crt:
-                        ca_cert = x509.load_pem_x509_certificate(
-                            base64.b64decode(ca.crt), default_backend()
-                        )
-                        ca_certs.append(ca_cert)
-                    if ca.caref:
-                        ca = CA.query.filter_by(refid=ca.caref).first()
-                    else:
-                        break
+            # Build CA chain if requested (inline stored chain or managed CA)
+            ca_certs = _build_ca_chain(certificate, cert_pem) if include_chain else []
 
             p12_bytes = pkcs12.serialize_key_and_certificates(
                 name=(certificate.descr or certificate.refid).encode(),
                 key=private_key,
                 cert=cert,
-                cas=ca_certs if ca_certs else None,
+                cas=_named_cas(ca_certs),
                 encryption_algorithm=serialization.BestAvailableEncryption(password.encode())
             )
 
@@ -347,18 +450,9 @@ def export_certificate(cert_id):
 
             cert_chain = [("X.509", cert_der)]
 
-            if include_chain and certificate.caref:
-                ca = CA.query.filter_by(refid=certificate.caref).first()
-                while ca:
-                    if ca.crt:
-                        ca_cert = x509.load_pem_x509_certificate(
-                            base64.b64decode(ca.crt), default_backend()
-                        )
-                        cert_chain.append(("X.509", ca_cert.public_bytes(serialization.Encoding.DER)))
-                    if ca.caref:
-                        ca = CA.query.filter_by(refid=ca.caref).first()
-                    else:
-                        break
+            if include_chain:
+                for ca_cert in _build_ca_chain(certificate, cert_pem):
+                    cert_chain.append(("X.509", ca_cert.public_bytes(serialization.Encoding.DER)))
 
             ts = int(time.time() * 1000)
             pke = pyjks.PrivateKeyEntry(

--- a/backend/services/acme/acme_client_service.py
+++ b/backend/services/acme/acme_client_service.py
@@ -86,6 +86,61 @@ class AcmeClientService:
                 "(acme.client.verify_ssl=false)."
             )
     
+    @classmethod
+    def for_issuance(cls, environment: str = None) -> 'AcmeClientService':
+        """Build a client for certificate issuance/renewal.
+
+        The bare ``environment=`` constructor always maps staging/production to
+        Let's Encrypt by design (see ``_resolve_account``). That makes a custom
+        default CA (e.g. Actalis) unreachable from the request/renewal flows,
+        which only ever pass an environment. This factory honors a configured
+        custom directory (``SystemConfig['acme.client.directory_url']``) over the
+        Let's Encrypt mapping, so issuance actually targets the configured CA.
+
+        When no custom directory is set, behavior is identical to
+        ``AcmeClientService(environment=...)`` (Let's Encrypt staging/production).
+        """
+        from models.acme_client_account import AcmeClientAccount
+
+        cfg = SystemConfig.query.filter_by(key='acme.client.directory_url').first()
+        custom_url = (cfg.value or '').strip() if cfg and cfg.value else ''
+        le_urls = (AcmeClientAccount.LE_STAGING_URL, AcmeClientAccount.LE_PRODUCTION_URL)
+        if custom_url and custom_url not in le_urls:
+            svc = cls(directory_url=custom_url)
+            svc._sync_legacy_eab_to_account()
+            return svc
+        return cls(environment=environment)
+
+    def _sync_legacy_eab_to_account(self) -> None:
+        """Backfill EAB credentials from legacy SystemConfig onto the account row.
+
+        The Settings page persists EAB under ``acme.client.eab_kid`` /
+        ``acme.client.eab_hmac_key`` (SystemConfig), but issuance reads EAB from
+        the AcmeClientAccount row (``_get_eab_credentials``). After the account
+        refactor, EAB configured via Settings for a custom CA never reached the
+        row, so EAB-required registration (Actalis, HARICA, ...) failed. Sync the
+        legacy values onto the row when the row is missing them (row wins if set).
+        """
+        if self.account.eab_kid and self.account.eab_hmac_key:
+            return
+        kid_cfg = SystemConfig.query.filter_by(key='acme.client.eab_kid').first()
+        hmac_cfg = SystemConfig.query.filter_by(key='acme.client.eab_hmac_key').first()
+        kid = (kid_cfg.value or '').strip() if kid_cfg and kid_cfg.value else ''
+        hmac_key = (hmac_cfg.value or '').strip() if hmac_cfg and hmac_cfg.value else ''
+        if not (kid and hmac_key):
+            return
+        self.account.eab_kid = self.account.eab_kid or kid
+        self.account.eab_hmac_key = self.account.eab_hmac_key or hmac_key
+        try:
+            db.session.commit()
+            logger.info(
+                f"Synced legacy EAB credentials from SystemConfig to ACME account "
+                f"{self.account.label} ({self.account.directory_url})"
+            )
+        except Exception as e:
+            db.session.rollback()
+            logger.error(f"Failed to sync legacy EAB to account row: {e}")
+
     @staticmethod
     def _resolve_account(account, directory_url, environment):
         """Resolve constructor args to a persisted AcmeClientAccount row.

--- a/backend/services/acme_renewal_service.py
+++ b/backend/services/acme_renewal_service.py
@@ -96,8 +96,9 @@ def renew_certificate(order) -> tuple:
     credentials = json.loads(dns_provider_model.credentials) if dns_provider_model.credentials else {}
     dns_provider = create_provider(dns_provider_model.provider_type, credentials)
     
-    # Initialize ACME client
-    acme_client = AcmeClientService(environment=order.environment)
+    # Initialize ACME client — honor a configured custom CA directory (e.g. Actalis)
+    # over the Let's Encrypt staging/production mapping, matching the issuance path.
+    acme_client = AcmeClientService.for_issuance(environment=order.environment)
     
     # Create new order for same domains
     domains = order.domains_list

--- a/backend/tests/test_acme_client_account_refactor.py
+++ b/backend/tests/test_acme_client_account_refactor.py
@@ -93,6 +93,61 @@ class TestBugRegression:
             assert svc_stg2.account.id == svc_stg.account.id
 
 
+class TestForIssuanceCustomDirectory:
+    """for_issuance() must route to a configured custom CA (e.g. Actalis) instead
+    of silently falling back to Let's Encrypt — the original report's bug."""
+
+    def test_for_issuance_honors_custom_directory_over_environment(self, app, clean_acme_state):
+        with app.app_context():
+            custom = "https://acme-api.actalis.com/acme/directory"
+            db.session.add(SystemConfig(
+                key='acme.client.directory_url', value=custom, description='custom CA'
+            ))
+            db.session.commit()
+
+            svc = AcmeClientService.for_issuance(environment='production')
+            # Must NOT be Let's Encrypt despite environment='production'
+            assert svc.directory_url == custom
+            assert svc.account.directory_url == custom
+            assert svc.environment == 'custom'
+
+    def test_for_issuance_falls_back_to_letsencrypt_without_custom(self, app, clean_acme_state):
+        with app.app_context():
+            svc = AcmeClientService.for_issuance(environment='staging')
+            assert svc.directory_url == AcmeClientAccount.LE_STAGING_URL
+
+    def test_for_issuance_ignores_letsencrypt_url_as_custom(self, app, clean_acme_state):
+        """A custom directory_url that happens to be a Let's Encrypt URL is not
+        treated as a custom CA (avoids creating a duplicate path)."""
+        with app.app_context():
+            db.session.add(SystemConfig(
+                key='acme.client.directory_url',
+                value=AcmeClientAccount.LE_PRODUCTION_URL, description='legacy'
+            ))
+            db.session.commit()
+            svc = AcmeClientService.for_issuance(environment='staging')
+            # environment wins → staging, not the prod URL from config
+            assert svc.directory_url == AcmeClientAccount.LE_STAGING_URL
+
+    def test_for_issuance_syncs_legacy_eab_to_account_row(self, app, clean_acme_state):
+        """EAB set via Settings (SystemConfig) must reach the custom account row."""
+        with app.app_context():
+            custom = "https://acme-api.actalis.com/acme/directory"
+            for k, v in [
+                ('acme.client.directory_url', custom),
+                ('acme.client.eab_kid', 'kid-actalis-123'),
+                ('acme.client.eab_hmac_key', 'c2VjcmV0LWhtYWMta2V5'),
+            ]:
+                db.session.add(SystemConfig(key=k, value=v, description=''))
+            db.session.commit()
+
+            svc = AcmeClientService.for_issuance(environment='production')
+            kid, hmac_key = svc._get_eab_credentials()
+            assert kid == 'kid-actalis-123'
+            assert hmac_key == 'c2VjcmV0LWhtYWMta2V5'
+            assert svc.account.eab_kid == 'kid-actalis-123'
+
+
 class TestAccountKeyBinding:
     def test_account_key_persists_to_account_row(self, app, clean_acme_state):
         """Generated keys must land on the AcmeClientAccount row, not SystemConfig."""


### PR DESCRIPTION
## Summary

Two related fixes discovered while configuring **Actalis** as a custom ACME CA (with EAB) on a production install:

- **ACME issuance ignored the configured custom directory.** Issuance/renewal always resolved a Let's Encrypt environment, so certificates were issued by Let's Encrypt even though `acme.client.directory_url` pointed to Actalis. EAB credentials were also stored only in `SystemConfig` and never applied to the account row, so EAB-gated CAs could not authenticate.
- **Chain-aware exports dropped the CA chain for ACME/imported certs** and gave CA bags no friendly name.

## Changes

### `acme-client`
- New `AcmeClientService.for_issuance()`: prefers a non-LE custom `directory_url` from `SystemConfig`, falls back to the standard environment otherwise.
- Backfills EAB (`acme.client.eab_kid` / `eab_hmac_key`) from legacy `SystemConfig` onto the `AcmeClientAccount` row when missing.
- Routes order creation/polling, account registration and renewal through `for_issuance()`.
- Adds `TestForIssuanceCustomDirectory` regression coverage.

### `cert-export`
- `_build_ca_chain()`: prefer the inline stored chain (ACME full-chain in `crt`), then walk managed CAs via `caref`, then complete the chain from locally known issuers (managed CAs + Trust Store) up to a self-signed root.
- `_named_cas()`: wrap CA certs as `PKCS12Certificate` with `friendlyName = CN` (fallback subject DN), so keystores show real CA names instead of `<leaf>_ca_N`.
- Uses the full chain + named CAs in the PKCS12, PFX and JKS paths.

## Test plan
- [x] `pytest backend/tests/test_acme_client_account_refactor.py` → 12 passed, 1 skipped
- [x] Verified on a live install: certificate now issued by Actalis (was Let's Encrypt).
- [x] Exported P12 reloaded via `cryptography.load_pkcs12`: full Actalis chain present, friendlyNames = CN of each CA (`Actalis Domain Validated TLS Server ECC CA 2025`, `Actalis TLS Server ECC Root CA 2025`, `Actalis Authentication Root CA`).

> Note: XCA's import dialog still labels CA bags `<leaf>_ca_N` — that is XCA-side behaviour (it ignores per-CA friendlyName); `keytool`/`certmgr`/`openssl` show the CN aliases correctly.
