### PR TITLE
fix(settings): Fix CORS logic for port 443

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Starting with v2.48, UCM uses Major.Build versioning (e.g., 2.48, 2.49). Earlier
 
 
 ## [Unreleased]
+- **WebSocket handshake fails when if HTTPS_PORT was set to 443** - `CORS_ORIGINS` always appended `:{HTTPS_PORT}` to every allowed origin, so on port 443 the list contained entries such as `https://ucm.example.com:443`. Browsers omit the port number from the `Origin` header when it is the scheme default so it would never match. As Socket.IO performs server-side checks on `Origin`, WebSocket connections would be silently rejected. `CORS_ORIGINS` now omits the port suffix when `HTTPS_PORT` is 443.
 
 
 ## [2.182] - 2026-07-02

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -219,14 +219,15 @@ class Config:
     
     # CORS - auto-include FQDN and hostname
     _https_port = int(os.getenv("HTTPS_PORT", "8443"))
-    _cors_origins = [f"https://localhost:{_https_port}", f"https://127.0.0.1:{_https_port}"]
+    _port_suffix = "" if _https_port == 443 else f":{_https_port}"
+    _cors_origins = [f"https://localhost{_port_suffix}", f"https://127.0.0.1{_port_suffix}"]
     _fqdn = get_system_fqdn()
     if _fqdn and _fqdn not in ('localhost', '127.0.0.1', 'ucm.example.com', 'ucm.local'):
-        _cors_origins.append(f"https://{_fqdn}:{_https_port}")
+        _cors_origins.append(f"https://{_fqdn}{_port_suffix}")
     # Also add short hostname (e.g. "pve" from "pve.example.com")
     _hostname = os.getenv("HOSTNAME", "") or _fqdn.split(".")[0] if _fqdn else ""
-    if _hostname and _hostname not in ('localhost', '127.0.0.1') and f"https://{_hostname}:{_https_port}" not in _cors_origins:
-        _cors_origins.append(f"https://{_hostname}:{_https_port}")
+    if _hostname and _hostname not in ('localhost', '127.0.0.1') and f"https://{_hostname}{_port_suffix}" not in _cors_origins:
+        _cors_origins.append(f"https://{_hostname}{_port_suffix}")
     # Allow extra origins via env
     _extra = os.getenv("CORS_EXTRA_ORIGINS", "")
     if _extra:


### PR DESCRIPTION
## Problem
When setting the `HTTPS_PORT` environment variable to the scheme standard (443). CORS Origins fail to match as browsers omit the port when sending the Origin header. This causes WebSocket connections to silently be rejected by the server as they fail the Origin check in Socket.IO.

There is currently a workaround to use the `CORS_EXTRA_ORIGINS` environment variable.

## Fix
Implement a check for the scheme standard port of 443 and only append the port number to the `_cors_origins` entries if they are non-standard.