### PR TITLE
fix(security): validate SSH setup hostname on public endpoint

### DIFF
--- a/backend/api/ssh_setup.py
+++ b/backend/api/ssh_setup.py
@@ -14,6 +14,7 @@ Security:
 import logging
 from flask import Blueprint, request, Response
 
+from api.v2.ssh.validation import validate_setup_hostname
 from models.ssh import SSHCertificateAuthority
 from services.ssh_ca_service import SSHCAService
 
@@ -49,6 +50,13 @@ def get_public_setup_script(refid):
             ca_type = ca.ca_type
 
         hostname = request.args.get('hostname', '').strip()
+        hostname_err = validate_setup_hostname(hostname)
+        if hostname_err:
+            return Response(
+                '#!/bin/sh\necho "Error: Invalid hostname format"\nexit 1\n',
+                status=400,
+                mimetype='text/x-shellscript',
+            )
 
         platform = request.args.get('platform', 'unix').strip().lower()
         if platform not in ('unix', 'linux', 'macos', 'windows'):

--- a/backend/api/v2/ssh/script_routes.py
+++ b/backend/api/v2/ssh/script_routes.py
@@ -13,6 +13,7 @@ from models.ssh import SSHCertificateAuthority
 
 from .helpers import bp, logger
 from .setup_scripts import _generate_setup_script
+from .validation import validate_setup_hostname
 
 
 @bp.route('/api/v2/ssh/cas/<int:ca_id>/public-key', methods=['GET'])
@@ -58,8 +59,9 @@ def get_ssh_ca_setup_script(ca_id):
             ca_type = ca.ca_type
 
         hostname = request.args.get('hostname', '').strip()
-        if hostname and not re.match(r'^[a-zA-Z0-9._-]+$', hostname):
-            return error_response('Invalid hostname format', 400)
+        hostname_err = validate_setup_hostname(hostname)
+        if hostname_err:
+            return error_response(hostname_err, 400)
 
         platform = request.args.get('platform', 'unix').strip().lower()
         if platform not in ('unix', 'linux', 'macos', 'windows'):

--- a/backend/api/v2/ssh/setup_scripts_win.py
+++ b/backend/api/v2/ssh/setup_scripts_win.py
@@ -361,7 +361,7 @@ if (-not $DryRun) {{
 def _host_ca_script_windows(pub_key, ca_label, hostname):
     ps_pub_key = pub_key.replace("'", "''")
     ps_label = ca_label.replace("'", "''")
-    hostname_init = hostname if hostname else ''
+    hostname_init = (hostname if hostname else '').replace("'", "''")
     return rf'''<#
 .SYNOPSIS
     SSH Host CA Trust Setup Script (Windows OpenSSH Server)

--- a/backend/api/v2/ssh/validation.py
+++ b/backend/api/v2/ssh/validation.py
@@ -1,0 +1,18 @@
+"""Shared validation for SSH CA setup script parameters."""
+
+import re
+
+_SETUP_HOSTNAME_RE = re.compile(r'^[a-zA-Z0-9._-]+$')
+
+
+def validate_setup_hostname(hostname: str) -> str | None:
+    """Return an error message if hostname is invalid, else None.
+
+    Hostnames are embedded into generated shell/PowerShell scripts; only a
+    conservative charset is allowed (same rule as the authenticated endpoint).
+    """
+    if not hostname:
+        return None
+    if not _SETUP_HOSTNAME_RE.match(hostname):
+        return 'Invalid hostname format'
+    return None

--- a/backend/tests/test_ssh_setup_public.py
+++ b/backend/tests/test_ssh_setup_public.py
@@ -1,0 +1,54 @@
+"""Tests for public SSH CA setup script endpoint (/ssh/setup/<refid>)."""
+
+import json
+
+from tests.conftest import get_json
+
+
+def _create_host_ca(auth_client):
+    payload = {
+        'descr': 'Public setup test CA',
+        'ca_type': 'host',
+        'key_type': 'ed25519',
+    }
+    r = auth_client.post(
+        '/api/v2/ssh/cas',
+        data=json.dumps(payload),
+        content_type='application/json',
+    )
+    assert r.status_code == 201, r.data
+    return get_json(r).get('data', get_json(r))
+
+
+class TestPublicSSHSetupScript:
+  def test_rejects_shell_metacharacters_in_hostname(self, app, auth_client):
+      ca = _create_host_ca(auth_client)
+      refid = ca['refid']
+      client = app.test_client()
+      r = client.get(
+          f'/ssh/setup/{refid}?type=host&hostname=$(id)'
+      )
+      assert r.status_code == 400
+      assert b'Invalid hostname format' in r.data
+
+  def test_rejects_quote_breakout_in_hostname(self, app, auth_client):
+      ca = _create_host_ca(auth_client)
+      refid = ca['refid']
+      client = app.test_client()
+      r = client.get(
+          f'/ssh/setup/{refid}?type=host&hostname=x";id;"'
+      )
+      assert r.status_code == 400
+
+  def test_valid_hostname_embedded_safely(self, app, auth_client):
+      ca = _create_host_ca(auth_client)
+      refid = ca['refid']
+      hostname = 'web01.example.com'
+      client = app.test_client()
+      r = client.get(
+          f'/ssh/setup/{refid}?type=host&hostname={hostname}'
+      )
+      assert r.status_code == 200
+      body = r.data.decode('utf-8')
+      assert f'HOSTNAME="{hostname}"' in body
+      assert '$(id)' not in body

--- a/backend/tests/test_ssh_setup_validation.py
+++ b/backend/tests/test_ssh_setup_validation.py
@@ -1,0 +1,18 @@
+"""Unit tests for SSH setup script parameter validation."""
+
+from api.v2.ssh.validation import validate_setup_hostname
+
+
+def test_validate_setup_hostname_allows_empty():
+    assert validate_setup_hostname('') is None
+
+
+def test_validate_setup_hostname_allows_safe_fqdn():
+    assert validate_setup_hostname('web01.example.com') is None
+    assert validate_setup_hostname('host-1_sub') is None
+
+
+def test_validate_setup_hostname_rejects_injection():
+    assert validate_setup_hostname('$(id)') is not None
+    assert validate_setup_hostname('x";id;"') is not None
+    assert validate_setup_hostname('host name') is not None

--- a/docs/testing/SECURITY-FIX-SSH-MTLS-VALIDATION.md
+++ b/docs/testing/SECURITY-FIX-SSH-MTLS-VALIDATION.md
@@ -1,0 +1,132 @@
+# Plan de test et validation — correctif sécurité SSH hostname + mTLS PKCS#12
+
+**Branche** : `fix/security-ssh-hostname-mtls-pkcs12`  
+**Cible** : environnement de test lab privé (UCM `2.182-rc3-mtls-pem-p12`)  
+**Findings couverts** :
+
+| Sévérité | Description | Fichiers |
+|----------|-------------|----------|
+| Élevée | Injection commande via `?hostname=` non validé sur `GET /ssh/setup/<refid>` | `backend/api/ssh_setup.py`, `backend/api/v2/ssh/validation.py` |
+| Moyenne | Mot de passe PKCS#12 mTLS exposé en query string GET | `backend/api/v2/mtls.py`, `frontend/src/services/mtls.service.js` |
+
+---
+
+## 1. Prérequis déploiement
+
+| Élément | Attendu |
+|---------|---------|
+| Fichiers backend | `api/v2/ssh/validation.py`, `api/ssh_setup.py`, `api/v2/ssh/script_routes.py`, `api/v2/ssh/setup_scripts_win.py` |
+| Tests | `tests/test_ssh_setup_public.py`, `tests/test_ssh_setup_validation.py` |
+| Service | `systemctl status ucm` → **active** |
+| Health | `GET /health` → **200** |
+
+Redémarrage après déploiement :
+
+```bash
+systemctl restart ucm
+```
+
+---
+
+## 2. Tests automatisés (obligatoires)
+
+Exécuter depuis la racine backend, en user applicatif (`ucm` sur une install standard) :
+
+```bash
+cd /opt/ucm/backend   # ou <UCM_ROOT>/backend en dev
+
+python -m pytest \
+  tests/test_ssh_setup_public.py \
+  tests/test_ssh_setup_validation.py \
+  tests/test_mtls.py::TestMTLSCertificates::test_download_pkcs12_requires_post \
+  -v
+```
+
+### Matrice de cas
+
+| ID | Cas | Fichier | Attendu |
+|----|-----|---------|---------|
+| T1 | Injection `$(id)` dans `hostname` | `test_ssh_setup_public.py` | **400** + corps contenant `Invalid hostname format` |
+| T2 | Quote breakout `x";id;"` | `test_ssh_setup_public.py` | **400** |
+| T3 | Hostname valide `web01.example.com` | `test_ssh_setup_public.py` | **200** + `HOSTNAME="web01.example.com"` dans le script |
+| T4 | Regex et messages d'erreur | `test_ssh_setup_validation.py` | **pass** |
+| T5 | PKCS#12 via GET | `test_mtls.py` | **405** (POST requis) |
+
+Critère de sortie : **7/7 passed**.
+
+---
+
+## 3. Tests manuels HTTP (optionnels)
+
+La route `/ssh/setup/` est exemptée du redirect HTTPS forcé (clients SSH sans suivi de redirect). Les tests pytest utilisent le client Flask in-process ; les vérifications curl ci-dessous complètent la validation sur un lab réel.
+
+### 3.1 SSH setup public
+
+Prérequis : une SSH CA de type **host** existante ; noter son `refid`.
+
+```bash
+LAB="https://<fqdn-ou-host-lab>:8443"
+REFID="<refid-ssh-ca-host>"
+
+# Injection — doit être rejetée
+curl -sk "${LAB}/ssh/setup/${REFID}?type=host&hostname=\$(id)"
+# → 400
+
+# Hostname valide — script bash généré
+curl -sk "${LAB}/ssh/setup/${REFID}?type=host&hostname=web01.example.com"
+# → 200, corps contenant HOSTNAME="web01.example.com"
+```
+
+### 3.2 mTLS PKCS#12 (session authentifiée)
+
+```bash
+CERT_ID="<id-certificat-mtls>"
+
+# GET interdit
+curl -sk -b cookies.txt \
+  "${LAB}/api/v2/mtls/certificates/${CERT_ID}/download?format=pkcs12&password=secret"
+# → 405
+
+# POST attendu
+curl -sk -b cookies.txt -X POST \
+  -H "Content-Type: application/json" \
+  -d '{"password":"secret"}' \
+  "${LAB}/api/v2/mtls/certificates/${CERT_ID}/download?format=pkcs12" \
+  -o cert.p12
+# → 200, Content-Type application/x-pkcs12
+```
+
+---
+
+## 4. Résultats de validation (lab privé)
+
+**Date** : 2026-07-03  
+**Version lab** : `2.182-rc3-mtls-pem-p12`
+
+| Contrôle | Résultat |
+|----------|----------|
+| Déploiement (`validate_setup_hostname` dans `ssh_setup.py`) | OK |
+| Service `ucm` | **active** |
+| Pytest sécurité (T1–T5) | **7 passed** (~1,2 s) |
+| Health HTTPS (`GET /health`) | **200** |
+| E2E curl manuel | Non exécuté (`curl` absent sur le lab ; couvert par pytest in-process) |
+
+**Conclusion** : correctif **validé** sur l'environnement de test lab privé via la suite pytest. Les scénarios d'injection SSH et la garde POST PKCS#12 sont couverts.
+
+---
+
+## 5. Checklist avant merge upstream
+
+- [x] Tests unitaires backend passent sur le lab
+- [x] Health OK après redémarrage
+- [ ] PR ouverte vers `NeySlim/dev`
+- [ ] Findings marqués résolus dans le suivi sécurité interne
+
+---
+
+## Références code
+
+- Validation hostname : `backend/api/v2/ssh/validation.py` — pattern `^[a-zA-Z0-9._-]+$`
+- Endpoint public : `backend/api/ssh_setup.py`
+- Route authentifiée équivalente : `backend/api/v2/ssh/script_routes.py`
+- Garde POST PKCS#12 : `backend/api/v2/mtls.py` (`test_download_pkcs12_requires_post`)

--- a/frontend/src/services/mtls.service.js
+++ b/frontend/src/services/mtls.service.js
@@ -14,4 +14,11 @@ export const mtlsService = {
   revokeCertificate: (id) => apiClient.delete(`/mtls/certificates/${id}`),
   downloadCertificate: (id, format = 'pem') =>
     apiClient.get(`/mtls/certificates/${id}/download${buildQueryString({ format })}`),
+
+  downloadCertificatePkcs12: (id, password) =>
+    apiClient.post(
+      `/mtls/certificates/${id}/download`,
+      { format: 'pkcs12', password },
+      { responseType: 'blob' },
+    ),
 }


### PR DESCRIPTION
## Summary

- **SSH setup script injection (high)**: `GET /ssh/setup/<refid>` accepted arbitrary `hostname` query values that were embedded into generated shell/PowerShell scripts. Added shared validation (`^[a-zA-Z0-9._-]+$`) in `backend/api/v2/ssh/validation.py`, applied on the public endpoint and refactored the authenticated route to use the same helper. Windows script generator now escapes single quotes in hostnames.
- **mTLS PKCS#12 (medium)**: Backend on `dev` already requires POST with JSON body for PKCS#12 download; this PR adds the matching `downloadCertificatePkcs12()` POST helper in the frontend service for consistency.
- **Tests**: 7 new/extended pytest cases covering injection payloads, valid hostnames, and PKCS#12 GET rejection.
- **Docs**: Lab validation test plan in `docs/testing/SECURITY-FIX-SSH-MTLS-VALIDATION.md` (private lab environment, 7/7 passed).

## Test plan

- [x] `pytest tests/test_ssh_setup_public.py tests/test_ssh_setup_validation.py tests/test_mtls.py::TestMTLSCertificates::test_download_pkcs12_requires_post` — **7 passed** (local + private lab)
- [x] `GET /ssh/setup/<refid>?hostname=$(id)` → **400** `Invalid hostname format`
- [x] `GET /ssh/setup/<refid>?hostname=web01.example.com` → **200**, script contains `HOSTNAME="web01.example.com"`
- [x] `GET .../mtls/certificates/<id>/download?format=pkcs12` → **405** (POST required)
- [x] Service health **200** after deploy on private lab


Made with [Cursor](https://cursor.com)