### PR TITLE
feat(ui): show hex serial number in certificate technical details

### DIFF
--- a/docs/testing/CERT-SERIAL-HEX-VALIDATION.md
+++ b/docs/testing/CERT-SERIAL-HEX-VALIDATION.md
@@ -1,0 +1,81 @@
+# Plan de test — affichage serial hex (détails certificat)
+
+**Branche** : `feat/cert-serial-hex-display`  
+**Portée** : UI certificats — section **Détails techniques** + utilitaire `formatSerialNumberHex`
+
+---
+
+## 1. Tests automatisés (obligatoires)
+
+### Frontend (Vitest)
+
+```bash
+cd frontend
+npm run test -- src/lib/__tests__/utils.test.js --run
+```
+
+| ID | Cas | Attendu |
+|----|-----|---------|
+| T1 | Serial décimal UCM (`4065849396…`) | `47:37:E6:35:…:D3:0B` |
+| T2 | Hex compact (`4737E635…`) | Même sortie colon-séparée uppercase |
+| T3 | Hex déjà avec `:` (minuscules) | Normalisé uppercase |
+| T4 | Entrée vide / invalide | `null` |
+
+Critère : **39/39 passed** (suite `utils.test.js` incluant les 4 cas ci-dessus).
+
+### Backend (pytest — régression)
+
+Pas de changement backend ; exécuter la suite complète avant merge :
+
+```bash
+cd backend
+pytest -q --tb=no
+```
+
+Critère : **0 failed** (warnings acceptables).
+
+---
+
+## 2. Test manuel UI
+
+1. Ouvrir **Certificats** → sélectionner un certificat émis par UCM.
+2. Panneau **Détails techniques** :
+   - **Série** : valeur décimale (ex. `406584939640065587371689749107479415526363616011`)
+   - **Série (hex)** : format navigateur (ex. `47:37:E6:35:30:D7:EA:91:39:2B:51:4E:34:55:DB:E2:2E:A1:D3:0B`)
+3. Copier la valeur hex (bouton copy) → coller dans `openssl x509 -serial` ou comparer au certificat PEM.
+4. Langue FR : libellé **Série (hex)** ; EN : **Serial (hex)**.
+
+---
+
+## 3. Correspondance serial / OCSP
+
+| Décimal (UCM) | Hex (UI / navigateur) |
+|---------------|------------------------|
+| `406584939640065587371689749107479415526363616011` | `47:37:E6:35:30:D7:EA:91:39:2B:51:4E:34:55:DB:E2:2E:A1:D3:0B` |
+| `316154770811771731777519343495635219991455236293` | `37:60:DE:C7:AF:D7:7B:9A:B8:9D:86:BF:BD:08:D1:05:BA:A6:80:C5` |
+
+Vérification OpenSSL :
+
+```bash
+openssl x509 -in cert.pem -noout -serial
+# serial=4737E63530D7EA91392B514E3455DBE22EA1D30B  → même valeur sans les ':'
+```
+
+---
+
+## 4. Résultats validation (2026-07-03)
+
+| Contrôle | Résultat |
+|----------|----------|
+| Vitest `utils.test.js` | **39 passed** |
+| pytest backend | voir CI / exécution locale |
+| Déploiement lab privé | Build + dist déployé, champ visible après hard refresh |
+
+---
+
+## Fichiers modifiés
+
+- `frontend/src/lib/utils.js` — `formatSerialNumberHex()`
+- `frontend/src/components/CertificateDetails.jsx` — champ **Série (hex)**
+- `frontend/src/lib/__tests__/utils.test.js` — tests T1–T4
+- `frontend/src/i18n/locales/*.json` — clé `common.serialHex` (9 langues)

--- a/frontend/src/components/CertificateDetails.jsx
+++ b/frontend/src/components/CertificateDetails.jsx
@@ -18,7 +18,7 @@
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { getAppTimezone } from '../stores/timezoneStore'
-import { formatDate as formatDateUtil } from '../lib/utils'
+import { formatDate as formatDateUtil, formatSerialNumberHex } from '../lib/utils'
 import { 
   Certificate, 
   Key, 
@@ -131,6 +131,7 @@ export function CertificateDetails({
   if (!certificate) return null
   
   const cert = certificate
+  const serialHex = formatSerialNumberHex(cert.serial_number)
   const status = cert.revoked ? 'revoked' : (cert.status || 'valid')
   
   // Status badge config
@@ -284,6 +285,9 @@ export function CertificateDetails({
       <CompactSection title={t('common.technicalDetails')} icon={Key} iconClass="icon-bg-purple">
         <CompactGrid>
           <CompactField icon={Hash} label={t('common.serial')} value={cert.serial_number} mono copyable />
+          {serialHex && (
+            <CompactField icon={Hash} label={t('common.serialHex')} value={serialHex} mono copyable />
+          )}
           <CompactField autoIcon="keyType" label={t('common.keyType')} value={cert.key_type} />
           <CompactField autoIcon="signatureAlgorithm" label={t('common.signatureAlgorithm')} value={cert.signature_algorithm} />
           <CompactField autoIcon="certType" label={t('details.certType')} value={formatCertType(cert.cert_type, t)} />

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -233,6 +233,7 @@
     "viewCertificate": "Zertifikat anzeigen",
     "aboutCSRs": "Über CSRs",
     "serial": "Seriennummer",
+    "serialHex": "Seriennummer (hex)",
     "codeSigning": "Codesignierung",
     "custom": "Benutzerdefiniert",
     "ca": "CA",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -234,6 +234,7 @@
     "viewCertificate": "View Certificate",
     "aboutCSRs": "About CSRs",
     "serial": "Serial",
+    "serialHex": "Serial (hex)",
     "codeSigning": "Code Signing",
     "custom": "Custom",
     "ca": "CA",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -233,6 +233,7 @@
     "viewCertificate": "Ver Certificado",
     "aboutCSRs": "Acerca de CSRs",
     "serial": "Serial",
+    "serialHex": "Serial (hex)",
     "codeSigning": "Firma de código",
     "custom": "Personalizado",
     "ca": "CA",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -1052,6 +1052,7 @@
     "viewCertificate": "Voir le certificat",
     "aboutCSRs": "À propos des CSR",
     "serial": "Série",
+    "serialHex": "Série (hex)",
     "codeSigning": "Signature de code",
     "custom": "Personnalisé",
     "ca": "AC",

--- a/frontend/src/i18n/locales/it.json
+++ b/frontend/src/i18n/locales/it.json
@@ -233,6 +233,7 @@
     "viewCertificate": "Visualizza Certificato",
     "aboutCSRs": "Informazioni sulle CSR",
     "serial": "Seriale",
+    "serialHex": "Seriale (hex)",
     "codeSigning": "Firma codice",
     "custom": "Personalizzato",
     "ca": "CA",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -233,6 +233,7 @@
     "viewCertificate": "証明書を表示",
     "aboutCSRs": "CSRについて",
     "serial": "シリアル番号",
+    "serialHex": "シリアル番号 (hex)",
     "codeSigning": "コード署名",
     "custom": "カスタム",
     "ca": "CA",

--- a/frontend/src/i18n/locales/pt.json
+++ b/frontend/src/i18n/locales/pt.json
@@ -233,6 +233,7 @@
     "viewCertificate": "Ver Certificate",
     "aboutCSRs": "Acerca CSRs",
     "serial": "Série",
+    "serialHex": "Série (hex)",
     "codeSigning": "Assinatura de código",
     "custom": "Personalizado",
     "ca": "CA",

--- a/frontend/src/i18n/locales/uk.json
+++ b/frontend/src/i18n/locales/uk.json
@@ -233,6 +233,7 @@
     "viewCertificate": "Переглянути сертифікат",
     "aboutCSRs": "Про CSR",
     "serial": "Серійний номер",
+    "serialHex": "Серійний номер (hex)",
     "codeSigning": "Підпис коду",
     "custom": "Користувацький",
     "ca": "CA",

--- a/frontend/src/i18n/locales/zh.json
+++ b/frontend/src/i18n/locales/zh.json
@@ -233,6 +233,7 @@
     "viewCertificate": "查看证书",
     "aboutCSRs": "关于 CSR",
     "serial": "序列号",
+    "serialHex": "序列号 (hex)",
     "codeSigning": "代码签名",
     "custom": "自定义",
     "ca": "CA",

--- a/frontend/src/lib/__tests__/utils.test.js
+++ b/frontend/src/lib/__tests__/utils.test.js
@@ -5,6 +5,7 @@ import {
   extractCN, 
   extractData, 
   formatDate,
+  formatSerialNumberHex,
   exportToCSV,
   exportToJSON
 } from '../utils'
@@ -99,6 +100,29 @@ describe('utils', () => {
 
     it('returns custom fallback', () => {
       expect(extractData(null, 'key', 'default')).toBe('default')
+    })
+  })
+
+  describe('formatSerialNumberHex', () => {
+    it('formats decimal serial as colon-separated hex', () => {
+      expect(formatSerialNumberHex('406584939640065587371689749107479415526363616011'))
+        .toBe('47:37:E6:35:30:D7:EA:91:39:2B:51:4E:34:55:DB:E2:2E:A1:D3:0B')
+    })
+
+    it('normalizes compact hex', () => {
+      expect(formatSerialNumberHex('4737E63530D7EA91392B514E3455DBE22EA1D30B'))
+        .toBe('47:37:E6:35:30:D7:EA:91:39:2B:51:4E:34:55:DB:E2:2E:A1:D3:0B')
+    })
+
+    it('normalizes colon-separated hex', () => {
+      expect(formatSerialNumberHex('47:37:e6:35:30:d7:ea:91:39:2b:51:4e:34:55:db:e2:2e:a1:d3:0b'))
+        .toBe('47:37:E6:35:30:D7:EA:91:39:2B:51:4E:34:55:DB:E2:2E:A1:D3:0B')
+    })
+
+    it('returns null for empty or invalid input', () => {
+      expect(formatSerialNumberHex(null)).toBeNull()
+      expect(formatSerialNumberHex('')).toBeNull()
+      expect(formatSerialNumberHex('not-a-serial')).toBeNull()
     })
   })
 

--- a/frontend/src/lib/utils.js
+++ b/frontend/src/lib/utils.js
@@ -159,3 +159,40 @@ export function downloadBlob(blob, filename) {
   URL.revokeObjectURL(url)
 }
 
+/**
+ * Format an X.509 serial number as colon-separated uppercase hex (browser/OpenSSL style).
+ * Accepts decimal strings (UCM DB), compact hex, 0x-prefixed hex, or colon-separated hex.
+ */
+export function formatSerialNumberHex(serial) {
+  if (serial == null || serial === '') return null
+
+  const raw = String(serial).trim()
+  if (!raw) return null
+
+  if (/^([0-9A-Fa-f]{2}:)+[0-9A-Fa-f]{2}$/.test(raw)) {
+    return raw.toUpperCase()
+  }
+
+  const stripped = raw.replace(/^0x/i, '').replace(/:/g, '')
+  if (!/^[0-9A-Fa-f]+$/.test(stripped)) return null
+
+  let hex
+  if (/[A-Fa-f]/.test(stripped)) {
+    hex = stripped.toUpperCase()
+  } else if (/^\d+$/.test(stripped)) {
+    try {
+      hex = BigInt(stripped).toString(16).toUpperCase()
+    } catch {
+      return null
+    }
+  } else {
+    return null
+  }
+
+  if (hex.length % 2 !== 0) {
+    hex = `0${hex}`
+  }
+
+  return hex.match(/.{2}/g).join(':')
+}
+


### PR DESCRIPTION
## Summary

- Add `formatSerialNumberHex()` to convert UCM decimal serials (or compact/colon hex) to browser/OpenSSL colon-separated uppercase hex.
- Display **Serial (hex)** in certificate **Technical Details** (`CertificateDetails.jsx`), copyable alongside the existing decimal serial.
- i18n: `common.serialHex` in all 9 UI languages.
- Test plan: `docs/testing/CERT-SERIAL-HEX-VALIDATION.md`

## Test plan

- [x] `cd frontend && npm run test -- src/lib/__tests__/utils.test.js --run` — **39 passed**
- [x] Manual: decimal `406584939640065587371689749107479415526363616011` → hex `47:37:E6:35:30:D7:EA:91:39:2B:51:4E:34:55:DB:E2:2E:A1:D3:0B` (matches browser/OCSP)
- [x] Validated on private lab (frontend dist deploy)
- [ ] `cd backend && pytest -q` — **2047 passed, 5 failed** on local dev (pre-existing: `test_cas` CDP, `test_crl` auto-regen, `test_sso_routes` SAML metadata — unrelated to this UI-only change)


Made with [Cursor](https://cursor.com)