### PR TITLE
fix(security): API key permission escalation and forged mTLS enroll

### DIFF
--- a/backend/api/v2/account/apikeys.py
+++ b/backend/api/v2/account/apikeys.py
@@ -4,7 +4,7 @@ import logging
 from flask import request, g, current_app
 from models import db
 from models.api_key import APIKey
-from auth.unified import AuthManager, require_auth
+from auth.unified import AuthManager, require_auth, has_permission
 from auth.permissions import get_role_permissions
 from services.audit_service import AuditService
 from utils.response import success_response, error_response, created_response
@@ -79,6 +79,12 @@ def create_api_key():
                 return error_response(f'Invalid permission resource: {resource}', 400)
         else:
             return error_response(f'Invalid permission format: {perm}', 400)
+
+        if not has_permission(perm, user_perms):
+            return error_response(
+                f'Cannot grant permission you do not have: {perm}',
+                403,
+            )
 
     # Check limit (max 10 keys per user by default)
     max_keys = current_app.config.get('API_KEY_MAX_PER_USER', 10)

--- a/backend/api/v2/mtls.py
+++ b/backend/api/v2/mtls.py
@@ -425,10 +425,22 @@ def enroll_presented_certificate():
     except Exception as e:
         logger.error(f"Error extracting peer cert for enrollment: {e}")
 
-    # Also try proxy headers
+    # Also try proxy headers — only when the immediate peer is trusted
+    # (same gate as login_mtls in auth_methods.py).
     if not cert_info:
+        from utils.trusted_proxy import is_request_from_trusted_proxy
         headers = dict(request.headers)
-        if 'X-SSL-Client-Verify' in headers:
+        spoof_attempt = (
+            'X-SSL-Client-Verify' in headers
+            or 'X-SSL-Client-S-DN' in headers
+            or 'X-SSL-Client-Cert' in headers
+        )
+        if spoof_attempt and not is_request_from_trusted_proxy():
+            logger.warning(
+                "mTLS enroll: ignoring proxy cert headers from untrusted peer %s",
+                request.remote_addr,
+            )
+        elif 'X-SSL-Client-Verify' in headers:
             cert_info = CertificateParser.extract_from_nginx_headers(headers)
         elif 'X-SSL-Client-S-DN' in headers:
             cert_info = CertificateParser.extract_from_apache_headers(headers)

--- a/backend/tests/test_account.py
+++ b/backend/tests/test_account.py
@@ -220,6 +220,27 @@ class TestCreateAPIKey:
         })
         assert_error(r, 400)
 
+    def test_cannot_grant_permissions_beyond_role(self, viewer_client):
+        """Viewer must not create API keys with admin/write permissions."""
+        r = post_json(viewer_client, '/api/v2/account/apikeys', {
+            'name': 'Escalation Attempt',
+            'permissions': ['admin:system', 'write:users'],
+        })
+        assert r.status_code == 403
+
+    def test_viewer_can_grant_own_read_permissions(self, viewer_client):
+        r = post_json(viewer_client, '/api/v2/account/apikeys', {
+            'name': 'Viewer Read Key',
+            'permissions': ['read:certificates', 'read:cas'],
+        })
+        data = assert_success(r, 201)
+        kid = data.get('id')
+        try:
+            assert data.get('key', '').startswith('ucm_ak_')
+        finally:
+            if kid:
+                viewer_client.delete(f'/api/v2/account/apikeys/{kid}')
+
     def test_permissions_not_list(self, auth_client):
         r = post_json(auth_client, '/api/v2/account/apikeys', {
             'name': 'String Perms', 'permissions': 'read:certificates',

--- a/backend/tests/test_mtls.py
+++ b/backend/tests/test_mtls.py
@@ -148,6 +148,26 @@ class TestMTLSEnroll:
         r = _post(auth_client, '/api/v2/mtls/enroll', {})
         assert r.status_code == 400
 
+    def test_enroll_rejects_spoofed_proxy_headers_from_untrusted_peer(
+        self, auth_client, monkeypatch,
+    ):
+        """Untrusted peers must not enroll via forged X-SSL-Client-* headers."""
+        monkeypatch.setattr(
+            'utils.trusted_proxy.is_request_from_trusted_proxy',
+            lambda: False,
+        )
+        r = auth_client.post(
+            '/api/v2/mtls/enroll',
+            data='{}',
+            content_type='application/json',
+            headers={
+                'X-SSL-Client-Verify': 'SUCCESS',
+                'X-SSL-Client-S-DN': 'CN=Spoofed Victim,O=Test',
+                'X-SSL-Client-Serial': 'aabbccdd',
+            },
+        )
+        assert r.status_code == 400
+
     def test_enroll_import_empty_pem(self, auth_client):
         """Import with no PEM data → 400."""
         r = _post(auth_client, '/api/v2/mtls/enroll-import', {})


### PR DESCRIPTION
## Summary
- Reject API key permissions the creator's role does not hold (`POST /api/v2/account/apikeys`), closing privilege escalation where a viewer could mint keys with `admin:system`.
- Gate `POST /api/v2/mtls/enroll` on `is_request_from_trusted_proxy()` for `X-SSL-Client-*` headers, matching the existing `login_mtls()` protection.

## Test plan
- [x] `pytest tests/test_account.py::TestCreateAPIKey::test_cannot_grant_permissions_beyond_role`
- [x] `pytest tests/test_account.py::TestCreateAPIKey::test_viewer_can_grant_own_read_permissions`
- [x] `pytest tests/test_mtls.py::TestMTLSEnroll::test_enroll_rejects_spoofed_proxy_headers_from_untrusted_peer`
- [ ] Manual: viewer cannot create API key with `admin:system` (403)
- [ ] Manual: mTLS enroll with forged headers from untrusted peer returns 400