### PR TITLE
feat(cas): RFC 5280 CA profile — digest, Key Usage, EKU

### DIFF
--- a/backend/api/v2/cas/crud.py
+++ b/backend/api/v2/cas/crud.py
@@ -21,6 +21,12 @@ from utils.db_transaction import safe_commit
 from services.ca_service import CAService
 from services.audit_service import AuditService
 from services.notification_service import NotificationService
+from utils.ca_profile import (
+    resolve_digest,
+    validate_ca_key_usage,
+    normalize_ca_eku,
+    default_key_usage_for_ca,
+)
 from models import Certificate, CA, db
 from cryptography import x509
 from cryptography.hazmat.backends import default_backend
@@ -342,11 +348,39 @@ def create_ca():
         if sia_err:
             return error_response(sia_err, 400)
 
+        is_root = not caref
+        raw_digest = data.get('digest') or data.get('hashAlgorithm')
+        digest, digest_err = resolve_digest(raw_digest, key_type)
+        if digest_err:
+            return error_response(digest_err, 400)
+
+        raw_ku = data.get('keyUsage')
+        if raw_ku is None and data.get('key_usage') is not None:
+            raw_ku = data.get('key_usage')
+        if raw_ku is None:
+            key_usage = default_key_usage_for_ca(is_root)
+        else:
+            ku_err = validate_ca_key_usage(raw_ku)
+            if ku_err:
+                return error_response(ku_err, 400)
+            key_usage = list(dict.fromkeys(s.strip() for s in raw_ku if isinstance(s, str)))
+
+        raw_eku = data.get('extendedKeyUsage')
+        if raw_eku is None and data.get('extended_key_usage') is not None:
+            raw_eku = data.get('extended_key_usage')
+        if raw_eku is None:
+            extended_key_usage = None
+        else:
+            extended_key_usage, eku_err = normalize_ca_eku(raw_eku, is_root)
+            if eku_err:
+                return error_response(eku_err, 400)
+
         ca = CAService.create_internal_ca(
             descr=description,
             dn=dn,
             key_type=key_type,
             validity_days=validity_years * 365,
+            digest=digest,
             caref=caref,
             username=username,
             path_length=path_length,
@@ -356,6 +390,8 @@ def create_ca():
             policy_constraints_inhibit=data.get('policyConstraintsInhibit'),
             inhibit_any_policy=inhibit_any_policy,
             sia_urls=sia_urls_validated,
+            key_usage=key_usage,
+            extended_key_usage=extended_key_usage,
             hsm_provider_id=int(hsm_provider_id) if hsm_provider_id else None,
             hsm_key_id=int(hsm_key_id) if hsm_key_id else None,
             hsm_key_label=hsm_key_label,

--- a/backend/api/v2/cas/crud.py
+++ b/backend/api/v2/cas/crud.py
@@ -454,6 +454,7 @@ def get_ca(ca_id):
     # Get parsed certificate details
     try:
         details = CAService.get_ca_details(ca_id)
+        fingerprints = details.get('fingerprints', {})
         # Merge details into response
         ca_data.update({
             'commonName': details.get('subject', {}).get('CN', ca.descr),
@@ -461,11 +462,18 @@ def get_ca(ca_id):
             'country': details.get('subject', {}).get('C', ''),
             'keyAlgo': details.get('public_key', {}).get('algorithm', 'RSA'),
             'keySize': details.get('public_key', {}).get('size', 2048),
-            'fingerprint': details.get('fingerprints', {}).get('sha256', ''),
+            'fingerprint': fingerprints.get('sha256', ''),
+            'thumbprint_sha256': fingerprints.get('sha256', ''),
+            'thumbprint_sha1': fingerprints.get('sha1', ''),
+            'signature_algorithm': details.get('signature_algorithm'),
             'crlStatus': crl_status,
             'nextCrlUpdate': next_crl_update
         })
-    except Exception as e:
+        from utils.serial_format import format_serial_colon
+        serial_raw = details.get('serial_number')
+        if serial_raw:
+            ca_data['serial_number'] = format_serial_colon(serial_raw)
+    except Exception:
         # Fallback if parsing fails
         pass
 

--- a/backend/services/ca/ca_creation.py
+++ b/backend/services/ca/ca_creation.py
@@ -16,6 +16,7 @@ from models import CA, db
 from models.hsm import HsmKey
 from services.audit_service import AuditService
 from services.trust_store import TrustStoreService
+from utils.datetime_utils import to_naive_utc
 from .helpers import save_ca_files
 
 logger = logging.getLogger(__name__)
@@ -136,6 +137,7 @@ class CACreationMixin:
         parent_ocsp_urls = None
         parent_cps_uri = None
         parent_cps_oid = None
+        parent_not_after = None
 
         if caref:
             parent_ca = CA.query.filter_by(refid=caref).first()
@@ -148,6 +150,7 @@ class CACreationMixin:
                 parent_cert_pem, default_backend()
             )
             issuer = parent_cert.subject
+            parent_not_after = to_naive_utc(parent_cert.not_valid_after_utc)
 
             # Load parent CA signing key
             if not parent_ca.has_private_key:
@@ -188,6 +191,7 @@ class CACreationMixin:
             sia_urls=sia_urls,
             key_usage=key_usage,
             extended_key_usage=extended_key_usage,
+            not_valid_after_max=parent_not_after,
         )
 
         # If using local key, use the generated key PEM

--- a/backend/services/ca/ca_creation.py
+++ b/backend/services/ca/ca_creation.py
@@ -45,6 +45,8 @@ class CACreationMixin:
         hsm_key_id: Optional[int] = None,
         hsm_key_label: Optional[str] = None,
         hsm_key_algorithm: Optional[str] = None,
+        key_usage: Optional[List[str]] = None,
+        extended_key_usage: Optional[List[str]] = None,
     ) -> CA:
         """
         Create an internal Certificate Authority.
@@ -184,6 +186,8 @@ class CACreationMixin:
             policy_constraints_inhibit=policy_constraints_inhibit,
             inhibit_any_policy=inhibit_any_policy,
             sia_urls=sia_urls,
+            key_usage=key_usage,
+            extended_key_usage=extended_key_usage,
         )
 
         # If using local key, use the generated key PEM

--- a/backend/services/trust_store/ca_certificate_creation_mixin.py
+++ b/backend/services/trust_store/ca_certificate_creation_mixin.py
@@ -2,14 +2,14 @@
 CA certificate creation mixin for TrustStoreService
 """
 import ipaddress
-from datetime import timedelta
+from datetime import datetime, timedelta
 from typing import List, Optional, Tuple
 
 from cryptography import x509
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.backends import default_backend
 
-from utils.datetime_utils import utc_now
+from utils.datetime_utils import utc_now, to_naive_utc
 from utils.ca_profile import (
     build_extended_key_usage_extension,
     build_key_usage_extension,
@@ -47,6 +47,7 @@ class CACertificateCreationMixin:
         sia_urls: Optional[List[str]] = None,
         key_usage: Optional[List[str]] = None,
         extended_key_usage: Optional[List[str]] = None,
+        not_valid_after_max: Optional[datetime] = None,
     ) -> Tuple[bytes, bytes]:
         """Create a CA certificate."""
         # Normalize URL params: merge singular into list
@@ -67,9 +68,11 @@ class CACertificateCreationMixin:
             serial if serial else x509.random_serial_number()
         )
         builder = builder.not_valid_before(utc_now())
-        builder = builder.not_valid_after(
-            utc_now() + timedelta(days=validity_days)
-        )
+        not_after = utc_now() + timedelta(days=validity_days)
+        max_end = to_naive_utc(not_valid_after_max)
+        if max_end is not None and not_after > max_end:
+            not_after = max_end
+        builder = builder.not_valid_after(not_after)
 
         # CA extensions — BasicConstraints with configurable pathLenConstraint
         builder = builder.add_extension(

--- a/backend/services/trust_store/ca_certificate_creation_mixin.py
+++ b/backend/services/trust_store/ca_certificate_creation_mixin.py
@@ -10,6 +10,12 @@ from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.backends import default_backend
 
 from utils.datetime_utils import utc_now
+from utils.ca_profile import (
+    build_extended_key_usage_extension,
+    build_key_usage_extension,
+    default_eku_for_ca,
+    default_key_usage_for_ca,
+)
 from .constants import HASH_ALGORITHMS
 from .constraints_mixin import ConstraintsMixin
 
@@ -39,6 +45,8 @@ class CACertificateCreationMixin:
         policy_constraints_inhibit: Optional[int] = None,
         inhibit_any_policy: Optional[int] = None,
         sia_urls: Optional[List[str]] = None,
+        key_usage: Optional[List[str]] = None,
+        extended_key_usage: Optional[List[str]] = None,
     ) -> Tuple[bytes, bytes]:
         """Create a CA certificate."""
         # Normalize URL params: merge singular into list
@@ -69,20 +77,21 @@ class CACertificateCreationMixin:
             critical=True,
         )
 
+        is_root = issuer == subject
+        ku_names = key_usage if key_usage is not None else default_key_usage_for_ca(is_root)
         builder = builder.add_extension(
-            x509.KeyUsage(
-                digital_signature=True,
-                key_encipherment=False,
-                content_commitment=False,
-                data_encipherment=False,
-                key_agreement=False,
-                key_cert_sign=True,
-                crl_sign=True,
-                encipher_only=False,
-                decipher_only=False,
-            ),
+            build_key_usage_extension(ku_names),
             critical=True,
         )
+
+        eku_names = (
+            default_eku_for_ca(is_root)
+            if extended_key_usage is None
+            else extended_key_usage
+        )
+        eku_ext = build_extended_key_usage_extension(eku_names)
+        if eku_ext is not None:
+            builder = builder.add_extension(eku_ext, critical=False)
 
         # Subject Key Identifier
         builder = builder.add_extension(

--- a/backend/services/trust_store/fingerprint_mixin.py
+++ b/backend/services/trust_store/fingerprint_mixin.py
@@ -2,7 +2,8 @@
 Fingerprint operations mixin for TrustStoreService
 """
 from cryptography import x509
-from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.backends import default_backend
 from typing import Dict
 
 
@@ -12,7 +13,7 @@ class FingerprintMixin:
     @staticmethod
     def get_certificate_fingerprints(cert_pem: bytes) -> Dict[str, str]:
         """Calculate certificate fingerprints."""
-        cert = x509.load_pem_x509_certificate(cert_pem, serialization.DefaultBackend())
+        cert = x509.load_pem_x509_certificate(cert_pem, default_backend())
 
         sha256_hash = cert.fingerprint(hashes.SHA256()).hex().upper()
         sha1_hash = cert.fingerprint(hashes.SHA1()).hex().upper()

--- a/backend/tests/test_ca_profile.py
+++ b/backend/tests/test_ca_profile.py
@@ -1,0 +1,79 @@
+"""Tests for CA profile helpers (RFC 5280 defaults)."""
+import pytest
+from cryptography import x509
+from cryptography.hazmat.backends import default_backend
+
+from utils.ca_profile import (
+    default_digest_for_key_type,
+    default_key_usage_for_ca,
+    resolve_digest,
+    validate_ca_key_usage,
+    build_key_usage_extension,
+    normalize_ca_eku,
+)
+
+
+class TestDefaultDigest:
+    def test_p384_maps_sha384(self):
+        assert default_digest_for_key_type('secp384r1') == 'sha384'
+
+    def test_p256_maps_sha256(self):
+        assert default_digest_for_key_type('prime256v1') == 'sha256'
+
+    def test_resolve_auto(self):
+        digest, err = resolve_digest('auto', 'secp384r1')
+        assert err is None
+        assert digest == 'sha384'
+
+    def test_resolve_invalid(self):
+        digest, err = resolve_digest('sha1', '2048')
+        assert digest == ''
+        assert err is not None
+
+
+class TestKeyUsageDefaults:
+    def test_root_default_no_digital_signature(self):
+        ku = default_key_usage_for_ca(is_root=True)
+        assert ku == ['keyCertSign', 'cRLSign']
+        assert 'digitalSignature' not in ku
+
+    def test_intermediate_default_includes_digital_signature(self):
+        ku = default_key_usage_for_ca(is_root=False)
+        assert 'digitalSignature' in ku
+        assert 'keyCertSign' in ku
+        assert 'cRLSign' in ku
+
+
+class TestKeyUsageValidation:
+    def test_rejects_missing_key_cert_sign(self):
+        assert validate_ca_key_usage(['cRLSign']) is not None
+
+    def test_rejects_leaf_ku(self):
+        assert validate_ca_key_usage(['keyCertSign', 'keyEncipherment']) is not None
+
+    def test_accepts_le_profile_root(self):
+        assert validate_ca_key_usage(['keyCertSign', 'cRLSign']) is None
+
+
+class TestEkuNormalization:
+    def test_root_rejects_eku(self):
+        oids, err = normalize_ca_eku(['serverAuth'], is_root=True)
+        assert err is not None
+
+    def test_intermediate_accepts_server_auth(self):
+        oids, err = normalize_ca_eku(['serverAuth'], is_root=False)
+        assert err is None
+        assert oids == ['1.3.6.1.5.5.7.3.1']
+
+    def test_none_uses_defaults_marker(self):
+        oids, err = normalize_ca_eku(None, is_root=False)
+        assert err is None
+        assert oids is None
+
+
+class TestBuildKeyUsage:
+    def test_root_extension_flags(self):
+        ku = build_key_usage_extension(['keyCertSign', 'cRLSign'])
+        assert ku.key_cert_sign
+        assert ku.crl_sign
+        assert not ku.digital_signature

--- a/backend/tests/test_cas.py
+++ b/backend/tests/test_cas.py
@@ -18,6 +18,10 @@ import pytest
 import json
 import os
 import sys
+import base64
+from cryptography import x509
+from cryptography.hazmat.backends import default_backend
+from cryptography.x509.oid import ExtensionOID
 from tests.conftest import get_json, assert_success, assert_error
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
@@ -39,6 +43,13 @@ VALID_ROOT_CA = {
 
 def post_json(client, url, data):
     return client.post(url, data=json.dumps(data), content_type=CONTENT_JSON)
+
+
+def _load_created_cert(data):
+    pem = data.get('pem') or ''
+    if not pem and data.get('crt'):
+        pem = base64.b64decode(data['crt']).decode('utf-8')
+    return x509.load_pem_x509_certificate(pem.encode(), default_backend())
 
 
 def patch_json(client, url, data):
@@ -157,6 +168,53 @@ class TestCreateCA:
         r = post_json(auth_client, '/api/v2/cas', payload)
         data = assert_success(r, status=201)
         assert data['id'] is not None
+
+    def test_create_root_ca_ec_p384_uses_sha384_and_rfc_key_usage(self, auth_client):
+        payload = {
+            **VALID_ROOT_CA,
+            'commonName': 'RFC Root P384',
+            'keyAlgo': 'ECDSA',
+            'keySize': 'secp384r1',
+            'hashAlgorithm': 'auto',
+        }
+        r = post_json(auth_client, '/api/v2/cas', payload)
+        data = assert_success(r, status=201)
+        cert = _load_created_cert(data)
+        assert 'SHA384' in cert.signature_algorithm_oid._name.upper()
+        ku = cert.extensions.get_extension_for_oid(ExtensionOID.KEY_USAGE).value
+        assert ku.key_cert_sign and ku.crl_sign
+        assert not ku.digital_signature
+        with pytest.raises(x509.ExtensionNotFound):
+            cert.extensions.get_extension_for_oid(ExtensionOID.EXTENDED_KEY_USAGE)
+
+    def test_create_intermediate_ca_le_style_profile(self, auth_client, create_ca):
+        root = create_ca(cn='Parent For LE Profile')
+        payload = {
+            **VALID_ROOT_CA,
+            'type': 'intermediate',
+            'commonName': 'LE Style Intermediate',
+            'parentCAId': root['id'],
+            'keyAlgo': 'ECDSA',
+            'keySize': 'secp384r1',
+            'hashAlgorithm': 'sha384',
+        }
+        r = post_json(auth_client, '/api/v2/cas', payload)
+        data = assert_success(r, status=201)
+        cert = _load_created_cert(data)
+        assert 'SHA384' in cert.signature_algorithm_oid._name.upper()
+        ku = cert.extensions.get_extension_for_oid(ExtensionOID.KEY_USAGE).value
+        assert ku.digital_signature and ku.key_cert_sign and ku.crl_sign
+        eku = cert.extensions.get_extension_for_oid(ExtensionOID.EXTENDED_KEY_USAGE).value
+        assert x509.oid.ExtendedKeyUsageOID.SERVER_AUTH in eku
+
+    def test_create_ca_rejects_invalid_key_usage(self, auth_client):
+        payload = {
+            **VALID_ROOT_CA,
+            'commonName': 'Bad KU Root',
+            'keyUsage': ['digitalSignature'],
+        }
+        r = post_json(auth_client, '/api/v2/cas', payload)
+        assert_error(r, 400)
 
 
 # ============================================================

--- a/backend/tests/test_cas.py
+++ b/backend/tests/test_cas.py
@@ -148,6 +148,21 @@ class TestCreateCA:
         data = assert_success(r, status=201)
         assert data['id'] is not None
 
+    def test_intermediate_valid_to_clamped_to_parent(self, auth_client, create_ca):
+        root = create_ca(cn='Clamp Root', validityYears=5)
+        payload = {
+            **VALID_ROOT_CA,
+            'type': 'intermediate',
+            'commonName': 'Clamp Intermediate',
+            'parentCAId': root['id'],
+            'validityYears': 20,
+        }
+        r = post_json(auth_client, '/api/v2/cas', payload)
+        inter = assert_success(r, status=201)
+        root_detail = assert_success(auth_client.get(f'/api/v2/cas/{root["id"]}'))
+        inter_detail = assert_success(auth_client.get(f'/api/v2/cas/{inter["id"]}'))
+        assert inter_detail['valid_to'] <= root_detail['valid_to']
+
     def test_create_intermediate_ca_invalid_parent(self, auth_client):
         payload = {
             **VALID_ROOT_CA,
@@ -278,6 +293,18 @@ class TestGetCA:
         r = auth_client.get(f'/api/v2/cas/{ca["id"]}')
         data = assert_success(r)
         assert 'certs' in data
+
+    def test_get_ca_includes_x509_serial_and_fingerprints(self, auth_client, create_ca):
+        ca = create_ca(cn='SerialFingerprint CA')
+        r = auth_client.get(f'/api/v2/cas/{ca["id"]}')
+        data = assert_success(r)
+        serial = data.get('serial_number', '')
+        assert serial
+        assert ':' in serial
+        assert serial not in ('0', '1')
+        assert data.get('thumbprint_sha256')
+        assert data.get('thumbprint_sha1')
+        assert data.get('fingerprint') == data.get('thumbprint_sha256')
 
     def test_get_ca_not_found(self, auth_client):
         r = auth_client.get('/api/v2/cas/999999')

--- a/backend/utils/ca_profile.py
+++ b/backend/utils/ca_profile.py
@@ -1,0 +1,150 @@
+"""
+CA certificate profile helpers (RFC 5280 §4.2.1.3, §4.2.1.12).
+
+Defaults follow common PKI practice (e.g. Let's Encrypt Root-YR / issuing CA):
+  - Root CA: keyCertSign + cRLSign (no digitalSignature)
+  - Subordinate CA: digitalSignature + keyCertSign + cRLSign + optional serverAuth EKU
+"""
+from typing import List, Optional, Tuple
+
+from cryptography import x509
+
+from utils.eku_validation import normalize_extra_ekus, to_object_identifiers
+
+# Short names accepted in API/UI (aligned with cert_extensions.py labels)
+KU_NAME_TO_ATTR = {
+    'digitalSignature': 'digital_signature',
+    'keyEncipherment': 'key_encipherment',
+    'contentCommitment': 'content_commitment',
+    'nonRepudiation': 'content_commitment',
+    'dataEncipherment': 'data_encipherment',
+    'keyAgreement': 'key_agreement',
+    'keyCertSign': 'key_cert_sign',
+    'cRLSign': 'crl_sign',
+    'encipherOnly': 'encipher_only',
+    'decipherOnly': 'decipher_only',
+}
+
+# RFC 5280 — sensible KU bits for CA certificates (reject leaf-only flags)
+ALLOWED_CA_KEY_USAGE = frozenset({'digitalSignature', 'keyCertSign', 'cRLSign'})
+
+# RFC 5280 §4.2.1.3 — root / offline CA profile (LE ISRG Root X2 style)
+DEFAULT_ROOT_KEY_USAGE = ['keyCertSign', 'cRLSign']
+
+# Subordinate issuing CA (LE E7 / YE1 style KU + typical EKU)
+DEFAULT_INTERMEDIATE_KEY_USAGE = ['digitalSignature', 'keyCertSign', 'cRLSign']
+DEFAULT_INTERMEDIATE_EKU = ['serverAuth']
+
+ALLOWED_DIGESTS = frozenset({'sha256', 'sha384', 'sha512'})
+
+
+def default_digest_for_key_type(key_type: str) -> str:
+    """
+    Map key type to a matching signature hash (NIST SP 800-57 alignment for EC).
+    RSA defaults to SHA-256 unless the caller overrides.
+    """
+    if key_type == 'secp384r1':
+        return 'sha384'
+    if key_type == 'secp521r1':
+        return 'sha512'
+    return 'sha256'
+
+
+def resolve_digest(digest: Optional[str], key_type: str) -> Tuple[str, Optional[str]]:
+    """
+    Resolve digest from API input ('auto', explicit, or None).
+    Returns (digest, error_message).
+    """
+    if digest is None or digest == '' or digest == 'auto':
+        return default_digest_for_key_type(key_type), None
+    normalized = digest.lower().strip()
+    if normalized not in ALLOWED_DIGESTS:
+        return '', f'digest must be one of auto, {", ".join(sorted(ALLOWED_DIGESTS))}'
+    return normalized, None
+
+
+def default_key_usage_for_ca(is_root: bool) -> List[str]:
+    """RFC-aligned default Key Usage for root vs subordinate CA."""
+    if is_root:
+        return list(DEFAULT_ROOT_KEY_USAGE)
+    return list(DEFAULT_INTERMEDIATE_KEY_USAGE)
+
+
+def default_eku_for_ca(is_root: bool) -> List[str]:
+    """Default Extended Key Usage (empty for roots; serverAuth for issuing CAs)."""
+    if is_root:
+        return []
+    return list(DEFAULT_INTERMEDIATE_EKU)
+
+
+def validate_ca_key_usage(usages) -> Optional[str]:
+    """
+    Validate Key Usage list for CA creation.
+    RFC 5280 §4.2.1.3: CA certs MUST assert keyCertSign when KeyUsage is present.
+    """
+    if usages is None:
+        return None
+    if not isinstance(usages, list):
+        return 'keyUsage must be an array'
+    if not usages:
+        return 'keyUsage must not be empty'
+    normalized = []
+    for item in usages:
+        if not isinstance(item, str) or not item.strip():
+            return 'each keyUsage entry must be a non-empty string'
+        name = item.strip()
+        if name not in KU_NAME_TO_ATTR:
+            return f'unknown keyUsage: {name}'
+        if name not in ALLOWED_CA_KEY_USAGE:
+            return (
+                f'keyUsage {name} is not allowed on CA certificates; '
+                f'allowed: {", ".join(sorted(ALLOWED_CA_KEY_USAGE))}'
+            )
+        if name not in normalized:
+            normalized.append(name)
+    if 'keyCertSign' not in normalized:
+        return 'CA certificates MUST include keyCertSign (RFC 5280 §4.2.1.3)'
+    if 'cRLSign' not in normalized:
+        return 'CA certificates SHOULD include cRLSign (RFC 5280 §4.2.1.3)'
+    return None
+
+
+def build_key_usage_kwargs(usage_names: List[str]) -> dict:
+    """Build x509.KeyUsage keyword arguments from short names."""
+    kwargs = {attr: False for attr in KU_NAME_TO_ATTR.values()}
+    for name in usage_names:
+        kwargs[KU_NAME_TO_ATTR[name]] = True
+    return kwargs
+
+
+def build_key_usage_extension(usage_names: List[str]) -> x509.KeyUsage:
+    return x509.KeyUsage(**build_key_usage_kwargs(usage_names))
+
+
+def normalize_ca_eku(eku_items, is_root: bool) -> Tuple[Optional[List[str]], Optional[str]]:
+    """
+    Normalize EKU for CA creation.
+    None input → (None, None) so upstream applies RFC defaults.
+    Empty list → ([], None) for no EKU extension.
+    """
+    if eku_items is None:
+        return None, None
+    if not isinstance(eku_items, list):
+        return [], 'extendedKeyUsage must be an array'
+    if not eku_items:
+        return [], None
+    if is_root:
+        return [], 'Extended Key Usage is not recommended on root CA certificates'
+    oids, err = normalize_extra_ekus(eku_items)
+    if err:
+        return [], err
+    return oids, None
+
+
+def build_extended_key_usage_extension(eku_names: List[str]) -> Optional[x509.ExtendedKeyUsage]:
+    if not eku_names:
+        return None
+    oids, err = normalize_extra_ekus(eku_names)
+    if err:
+        raise ValueError(err)
+    return x509.ExtendedKeyUsage(to_object_identifiers(oids))

--- a/backend/utils/datetime_utils.py
+++ b/backend/utils/datetime_utils.py
@@ -18,6 +18,15 @@ def utc_now() -> datetime:
     return datetime.now(timezone.utc).replace(tzinfo=None)
 
 
+def to_naive_utc(dt: datetime | None) -> datetime | None:
+    """Normalize aware UTC datetimes to naive UTC for DB / utc_now() comparisons."""
+    if dt is None:
+        return None
+    if dt.tzinfo is None:
+        return dt
+    return dt.astimezone(timezone.utc).replace(tzinfo=None)
+
+
 def utc_isoformat(dt):
     """Return an ISO 8601 UTC string ending in 'Z', or None.
 

--- a/backend/utils/serial_format.py
+++ b/backend/utils/serial_format.py
@@ -41,6 +41,20 @@ def serial_to_int(serial: str | int | None) -> int | None:
         return None
 
 
+def format_serial_colon(serial: str | int | None) -> str:
+    """Return serial as colon-separated uppercase hex pairs (OpenSSL display style)."""
+    if serial is None or serial == '':
+        return ''
+    n = serial_to_int(serial)
+    if n is not None:
+        hex_str = format(n, 'X')
+    else:
+        hex_str = str(serial).replace(':', '').upper()
+    if len(hex_str) % 2:
+        hex_str = '0' + hex_str
+    return ':'.join(hex_str[i:i + 2] for i in range(0, len(hex_str), 2))
+
+
 def serial_to_hex(serial: str | int | None) -> str:
     """Return the lowercase hex form of a certificate serial.
 

--- a/docs/testing/CA-DETAILS-POLISH.md
+++ b/docs/testing/CA-DETAILS-POLISH.md
@@ -1,0 +1,73 @@
+# CA details polish — test plan
+
+Follow-up fixes for [PR #164 review](https://github.com/NeySlim/ultimate-ca-manager/pull/164#issuecomment-4882185221) (plaimbock).
+
+## Scope
+
+| Issue | Fix |
+|-------|-----|
+| Duplicate "Validity Period" in Create CA modal | Remove redundant section heading |
+| Serial shows `0`/`1` in Technical Details | `GET /api/v2/cas/:id` exposes X.509 `serial_number` (colon hex) |
+| Empty fingerprints | Fix `DefaultBackend` in fingerprint mixin + API maps `thumbprint_sha256` / `thumbprint_sha1` |
+| Intermediate `notAfter` after parent | Clamp child validity to parent `not_valid_after` |
+
+## Automated tests
+
+```bash
+cd backend
+pytest tests/test_cas.py::TestGetCA::test_get_ca_includes_x509_serial_and_fingerprints -v
+pytest tests/test_cas.py::TestCreateCA::test_intermediate_valid_to_clamped_to_parent -v
+pytest tests/test_cas.py::TestGetCA -v
+pytest tests/test_cas.py::TestCreateCA -v
+```
+
+## Manual validation (UI)
+
+1. **Create CA modal** — open *Create CA*; confirm a single "Validity Period" label (no duplicate heading).
+2. **Root CA details** — create root (e.g. ECDSA P-384, 10 years); open Technical Details:
+   - Serial is colon-separated hex (not `0` or `1`).
+   - Fingerprints section shows SHA-256 and SHA-1.
+3. **Intermediate validity** — create root with 5 years, then intermediate with 20 years under that root:
+   - Intermediate *Valid until* equals root *Valid until* (not 20 years later).
+4. **Cross-check** — compare displayed serial with:
+   ```bash
+   openssl x509 -in /opt/ucm/data/cas/<refid>.crt -noout -serial
+   ```
+
+## Lab deploy (`172.31.10.8`)
+
+Backend paths under `/opt/ucm/backend`, service `ucm`, frontend `/opt/ucm/frontend/dist`.
+
+```bash
+# From dev machine (workspace root)
+cd ultimate-ca-manager
+tar czf /tmp/ucm-ca-polish.tgz -C backend \
+  api/v2/cas/crud.py \
+  services/ca/ca_creation.py \
+  services/trust_store/ca_certificate_creation_mixin.py \
+  services/trust_store/fingerprint_mixin.py \
+  utils/serial_format.py \
+  utils/datetime_utils.py
+
+scp /tmp/ucm-ca-polish.tgz root@172.31.10.8:/tmp/
+
+ssh root@172.31.10.8 '
+  cd /opt/ucm/backend && tar xzf /tmp/ucm-ca-polish.tgz
+  systemctl restart ucm && systemctl is-active ucm
+'
+
+# Frontend (build locally, deploy dist)
+cd frontend && npm run build
+tar czf /tmp/ucm-fe-ca-polish.tgz -C dist .
+scp /tmp/ucm-fe-ca-polish.tgz root@172.31.10.8:/tmp/
+ssh root@172.31.10.8 'rm -rf /opt/ucm/frontend/dist/* && tar xzf /tmp/ucm-fe-ca-polish.tgz -C /opt/ucm/frontend/dist'
+```
+
+## API smoke (authenticated)
+
+```bash
+TOKEN=<api_token>
+curl -s -H "Authorization: Bearer $TOKEN" https://<host>/api/v2/cas/1 | jq '.data | {serial_number, thumbprint_sha256, thumbprint_sha1, valid_to}'
+```
+
+Expected: non-empty `serial_number` with colons; both thumbprints populated.

--- a/docs/testing/CA-PROFILE-RFC5280-VALIDATION.md
+++ b/docs/testing/CA-PROFILE-RFC5280-VALIDATION.md
@@ -1,0 +1,43 @@
+# Validation — profil CA RFC 5280 (digest, KU, EKU)
+
+## Contexte
+
+Le wizard **Create CA** expose désormais :
+
+- **Algorithme de signature** : Auto (aligné sur la clé), SHA-256, SHA-384, SHA-512
+- **Profil certificat (RFC 5280)** : Key Usage + EKU (intermédiaire)
+
+## Defaults (RFC 5280 §4.2.1.3 / pratique LE)
+
+| Type | Courbe P-384 + Auto | Key Usage | EKU |
+|------|---------------------|-----------|-----|
+| Root | ecdsa-with-SHA384 | keyCertSign, cRLSign | — |
+| Intermediate | ecdsa-with-SHA384 | digitalSignature, keyCertSign, cRLSign | serverAuth |
+
+## Test lab
+
+1. **Create CA** → Root → ECDSA P-384 → Signature **Auto** → Create
+2. Export PEM → `openssl x509 -in ca.pem -noout -text | grep -E "Signature Algorithm|Key Usage|Extended"`
+
+Attendu root :
+
+```
+Signature Algorithm: ecdsa-with-SHA384
+Key Usage: Certificate Sign, CRL Sign
+```
+
+3. Créer une **Intermediate** sous cette root (P-384, Auto, serverAuth coché)
+
+Attendu intermediate :
+
+```
+Signature Algorithm: ecdsa-with-SHA384
+Key Usage: Digital Signature, Certificate Sign, CRL Sign
+Extended Key Usage: TLS Web Server Authentication
+```
+
+## Tests automatisés
+
+```bash
+cd backend && python -m pytest tests/test_ca_profile.py tests/test_cas.py::TestCreateCA -q
+```

--- a/frontend/src/components/CADetails.jsx
+++ b/frontend/src/components/CADetails.jsx
@@ -210,7 +210,7 @@ export function CADetails({
       {/* Technical Details */}
       <CompactSection title={t('common.technicalDetails')} icon={Key} iconClass="icon-bg-purple">
         <CompactGrid>
-          <CompactField icon={Hash} label={t('common.serial')} value={ca.serial} mono copyable />
+          <CompactField icon={Hash} label={t('common.serial')} value={ca.serial_number} mono copyable />
           <CompactField autoIcon="keyType" label={t('common.keyType')} value={ca.key_type} />
           <CompactField autoIcon="signatureAlgorithm" label={t('common.signatureAlgorithm')} value={ca.signature_algorithm || ca.hash_algorithm} />
           <CompactField autoIcon="subjectDN" label={t('details.subjectDN')} value={ca.subject} mono colSpan={2} />

--- a/frontend/src/data/help/fr/cas.js
+++ b/frontend/src/data/help/fr/cas.js
@@ -93,9 +93,10 @@ Regroupe les CA par leur champ Organisation (O). Utile pour les configurations m
 1. Cliquez sur **Créer** → **CA racine**
 2. Remplissez les champs du sujet (CN, O, OU, C, ST, L)
 3. Sélectionnez l'algorithme de clé (RSA 2048/4096, ECDSA P-256/P-384)
-4. Définissez la période de validité (typiquement 10-20 ans pour les CA racines)
-5. Sélectionnez optionnellement un modèle de certificat
-6. Cliquez sur **Créer**
+4. Choisissez l'algorithme de signature (Auto, SHA-256/384/512 — Auto aligne P-384 sur SHA-384)
+5. Définissez la période de validité (typiquement 10-20 ans pour les CA racines)
+6. Optionnel : ouvrez **Profil certificat (RFC 5280)** pour ajuster Key Usage / EKU
+7. Cliquez sur **Créer**
 
 ### Créer une CA intermédiaire
 1. Cliquez sur **Créer** → **CA intermédiaire**

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -233,6 +233,7 @@
     "viewCertificate": "Zertifikat anzeigen",
     "aboutCSRs": "Über CSRs",
     "serial": "Seriennummer",
+    "serialHex": "Seriennummer (hex)",
     "codeSigning": "Codesignierung",
     "custom": "Benutzerdefiniert",
     "ca": "CA",
@@ -847,7 +848,12 @@
       "hsmKeyAlgorithm": "HSM-Schlüsselalgorithmus",
       "hsmExistingKey": "Vorhandener HSM-Schlüssel",
       "hsmExistingKeyRequired": "HSM-Schlüssel auswählen",
-      "hsmNoUnusedKeys": "Keine ungenutzten Signaturschlüssel auf diesem Anbieter"
+      "hsmNoUnusedKeys": "Keine ungenutzten Signaturschlüssel auf diesem Anbieter",
+      "digestAuto": "Auto (Schlüsselgröße)",
+      "digestAutoHint": "Verwendet {{digest}} für den gewählten Schlüssel",
+      "certificateProfile": "Zertifikatsprofil (RFC 5280)",
+      "certificateProfileHelp": "Root-CAs: keyCertSign + cRLSign. Ausstellende CAs: digitalSignature und optional serverAuth.",
+      "ekuServerAuth": "Extended Key Usage: TLS Web Server Authentication (serverAuth)"
     },
     "detail": {
       "hsmBacked": "HSM-gesichert",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -234,6 +234,7 @@
     "viewCertificate": "View Certificate",
     "aboutCSRs": "About CSRs",
     "serial": "Serial",
+    "serialHex": "Serial (hex)",
     "codeSigning": "Code Signing",
     "custom": "Custom",
     "ca": "CA",
@@ -847,7 +848,12 @@
       "hsmKeyAlgorithm": "HSM Key Algorithm",
       "hsmExistingKey": "Existing HSM Key",
       "hsmExistingKeyRequired": "Select an HSM key",
-      "hsmNoUnusedKeys": "No unused signing keys on this provider"
+      "hsmNoUnusedKeys": "No unused signing keys on this provider",
+      "digestAuto": "Auto (match key size)",
+      "digestAutoHint": "Will use {{digest}} for the selected key",
+      "certificateProfile": "Certificate Profile (RFC 5280)",
+      "certificateProfileHelp": "Root CAs default to keyCertSign + cRLSign. Issuing CAs add digitalSignature and may include TLS Web Server Authentication (serverAuth).",
+      "ekuServerAuth": "Extended Key Usage: TLS Web Server Authentication (serverAuth)"
     },
     "detail": {
       "hsmBacked": "HSM-backed",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -233,6 +233,7 @@
     "viewCertificate": "Ver Certificado",
     "aboutCSRs": "Acerca de CSRs",
     "serial": "Serial",
+    "serialHex": "Serial (hex)",
     "codeSigning": "Firma de código",
     "custom": "Personalizado",
     "ca": "CA",
@@ -847,7 +848,12 @@
       "hsmKeyAlgorithm": "Algoritmo de clave HSM",
       "hsmExistingKey": "Clave HSM existente",
       "hsmExistingKeyRequired": "Seleccione una clave HSM",
-      "hsmNoUnusedKeys": "No hay claves de firma no utilizadas en este proveedor"
+      "hsmNoUnusedKeys": "No hay claves de firma no utilizadas en este proveedor",
+      "digestAuto": "Auto (según clave)",
+      "digestAutoHint": "Usará {{digest}} para la clave seleccionada",
+      "certificateProfile": "Perfil de certificado (RFC 5280)",
+      "certificateProfileHelp": "CA raíz: keyCertSign + cRLSign. CA emisora: digitalSignature y serverAuth opcional.",
+      "ekuServerAuth": "Extended Key Usage: TLS Web Server Authentication (serverAuth)"
     },
     "detail": {
       "hsmBacked": "Respaldada por HSM",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -671,7 +671,12 @@
       "hsmKeyAlgorithm": "Algorithme de clé HSM",
       "hsmExistingKey": "Clé HSM existante",
       "hsmExistingKeyRequired": "Sélectionnez une clé HSM",
-      "hsmNoUnusedKeys": "Aucune clé de signature inutilisée sur ce fournisseur"
+      "hsmNoUnusedKeys": "Aucune clé de signature inutilisée sur ce fournisseur",
+      "digestAuto": "Auto (aligné sur la clé)",
+      "digestAutoHint": "Utilisera {{digest}} pour la clé sélectionnée",
+      "certificateProfile": "Profil certificat (RFC 5280)",
+      "certificateProfileHelp": "Les CA racines utilisent keyCertSign + cRLSign par défaut. Les CA émettrices ajoutent digitalSignature et peuvent inclure TLS Web Server Authentication (serverAuth).",
+      "ekuServerAuth": "Extended Key Usage : TLS Web Server Authentication (serverAuth)"
     },
     "detail": {
       "hsmBacked": "Adossé HSM",
@@ -1052,6 +1057,7 @@
     "viewCertificate": "Voir le certificat",
     "aboutCSRs": "À propos des CSR",
     "serial": "Série",
+    "serialHex": "Série (hex)",
     "codeSigning": "Signature de code",
     "custom": "Personnalisé",
     "ca": "AC",

--- a/frontend/src/i18n/locales/it.json
+++ b/frontend/src/i18n/locales/it.json
@@ -233,6 +233,7 @@
     "viewCertificate": "Visualizza Certificato",
     "aboutCSRs": "Informazioni sulle CSR",
     "serial": "Seriale",
+    "serialHex": "Seriale (hex)",
     "codeSigning": "Firma codice",
     "custom": "Personalizzato",
     "ca": "CA",
@@ -847,7 +848,12 @@
       "hsmKeyAlgorithm": "Algoritmo chiave HSM",
       "hsmExistingKey": "Chiave HSM esistente",
       "hsmExistingKeyRequired": "Seleziona una chiave HSM",
-      "hsmNoUnusedKeys": "Nessuna chiave di firma inutilizzata su questo provider"
+      "hsmNoUnusedKeys": "Nessuna chiave di firma inutilizzata su questo provider",
+      "digestAuto": "Auto (allineato alla chiave)",
+      "digestAutoHint": "Userà {{digest}} per la chiave selezionata",
+      "certificateProfile": "Profilo certificato (RFC 5280)",
+      "certificateProfileHelp": "CA root: keyCertSign + cRLSign. CA emittenti: digitalSignature e serverAuth opzionale.",
+      "ekuServerAuth": "Extended Key Usage: TLS Web Server Authentication (serverAuth)"
     },
     "detail": {
       "hsmBacked": "Supportata da HSM",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -233,6 +233,7 @@
     "viewCertificate": "証明書を表示",
     "aboutCSRs": "CSRについて",
     "serial": "シリアル番号",
+    "serialHex": "シリアル番号 (hex)",
     "codeSigning": "コード署名",
     "custom": "カスタム",
     "ca": "CA",
@@ -847,7 +848,12 @@
       "hsmKeyAlgorithm": "HSM 鍵アルゴリズム",
       "hsmExistingKey": "既存の HSM 鍵",
       "hsmExistingKeyRequired": "HSM 鍵を選択してください",
-      "hsmNoUnusedKeys": "このプロバイダーに未使用の署名鍵はありません"
+      "hsmNoUnusedKeys": "このプロバイダーに未使用の署名鍵はありません",
+      "digestAuto": "自動（鍵サイズに合わせる）",
+      "digestAutoHint": "選択した鍵に {{digest}} を使用します",
+      "certificateProfile": "証明書プロファイル (RFC 5280)",
+      "certificateProfileHelp": "ルート CA: keyCertSign + cRLSign。発行 CA: digitalSignature と任意で serverAuth。",
+      "ekuServerAuth": "Extended Key Usage: TLS Web Server Authentication (serverAuth)"
     },
     "detail": {
       "hsmBacked": "HSM バック",

--- a/frontend/src/i18n/locales/pt.json
+++ b/frontend/src/i18n/locales/pt.json
@@ -233,6 +233,7 @@
     "viewCertificate": "Ver Certificate",
     "aboutCSRs": "Acerca CSRs",
     "serial": "Série",
+    "serialHex": "Série (hex)",
     "codeSigning": "Assinatura de código",
     "custom": "Personalizado",
     "ca": "CA",
@@ -847,7 +848,12 @@
       "hsmKeyAlgorithm": "Algoritmo de chave HSM",
       "hsmExistingKey": "Chave HSM existente",
       "hsmExistingKeyRequired": "Selecione uma chave HSM",
-      "hsmNoUnusedKeys": "Nenhuma chave de assinatura não utilizada neste provedor"
+      "hsmNoUnusedKeys": "Nenhuma chave de assinatura não utilizada neste provedor",
+      "digestAuto": "Auto (conforme a chave)",
+      "digestAutoHint": "Usará {{digest}} para a chave selecionada",
+      "certificateProfile": "Perfil do certificado (RFC 5280)",
+      "certificateProfileHelp": "CA raiz: keyCertSign + cRLSign. CA emissora: digitalSignature e serverAuth opcional.",
+      "ekuServerAuth": "Extended Key Usage: TLS Web Server Authentication (serverAuth)"
     },
     "detail": {
       "hsmBacked": "Apoiada por HSM",

--- a/frontend/src/i18n/locales/uk.json
+++ b/frontend/src/i18n/locales/uk.json
@@ -233,6 +233,7 @@
     "viewCertificate": "Переглянути сертифікат",
     "aboutCSRs": "Про CSR",
     "serial": "Серійний номер",
+    "serialHex": "Серійний номер (hex)",
     "codeSigning": "Підпис коду",
     "custom": "Користувацький",
     "ca": "CA",
@@ -847,7 +848,12 @@
       "hsmKeyAlgorithm": "Алгоритм ключа HSM",
       "hsmExistingKey": "Наявний ключ HSM",
       "hsmExistingKeyRequired": "Виберіть ключ HSM",
-      "hsmNoUnusedKeys": "Немає невикористаних ключів підписання на цьому постачальнику"
+      "hsmNoUnusedKeys": "Немає невикористаних ключів підписання на цьому постачальнику",
+      "digestAuto": "Авто (відповідно до ключа)",
+      "digestAutoHint": "Буде використано {{digest}} для обраного ключа",
+      "certificateProfile": "Профіль сертифіката (RFC 5280)",
+      "certificateProfileHelp": "Кореневі CA: keyCertSign + cRLSign. Видаючі CA: digitalSignature та опційно serverAuth.",
+      "ekuServerAuth": "Extended Key Usage: TLS Web Server Authentication (serverAuth)"
     },
     "detail": {
       "hsmBacked": "На основі HSM",

--- a/frontend/src/i18n/locales/zh.json
+++ b/frontend/src/i18n/locales/zh.json
@@ -233,6 +233,7 @@
     "viewCertificate": "查看证书",
     "aboutCSRs": "关于 CSR",
     "serial": "序列号",
+    "serialHex": "序列号 (hex)",
     "codeSigning": "代码签名",
     "custom": "自定义",
     "ca": "CA",
@@ -847,7 +848,12 @@
       "hsmKeyAlgorithm": "HSM 密钥算法",
       "hsmExistingKey": "现有 HSM 密钥",
       "hsmExistingKeyRequired": "选择 HSM 密钥",
-      "hsmNoUnusedKeys": "此提供商上没有未使用的签名密钥"
+      "hsmNoUnusedKeys": "此提供商上没有未使用的签名密钥",
+      "digestAuto": "自动（匹配密钥大小）",
+      "digestAutoHint": "将为所选密钥使用 {{digest}}",
+      "certificateProfile": "证书配置文件 (RFC 5280)",
+      "certificateProfileHelp": "根 CA：keyCertSign + cRLSign。签发 CA：digitalSignature，可选 serverAuth。",
+      "ekuServerAuth": "Extended Key Usage: TLS Web Server Authentication (serverAuth)"
     },
     "detail": {
       "hsmBacked": "HSM 支持",

--- a/frontend/src/pages/cas/CreateCAModal.jsx
+++ b/frontend/src/pages/cas/CreateCAModal.jsx
@@ -16,6 +16,18 @@ import { useNotification } from '../../contexts'
 import { useWebSocket } from '../../hooks'
 import { extractData, cn } from '../../lib/utils'
 
+const ROOT_KEY_USAGE = ['keyCertSign', 'cRLSign']
+const INTERMEDIATE_KEY_USAGE = ['digitalSignature', 'keyCertSign', 'cRLSign']
+const CA_KU_OPTIONS = ['digitalSignature', 'keyCertSign', 'cRLSign']
+
+function suggestedDigest(keyAlgo, keySize) {
+  if (keyAlgo === 'ECDSA') {
+    if (keySize === 'secp384r1') return 'sha384'
+    if (keySize === 'secp521r1') return 'sha512'
+  }
+  return 'sha256'
+}
+
 export function CreateCAModal({ open, onClose, cas, onSuccess }) {
   const { t } = useTranslation()
   const { showSuccess, showError } = useNotification()
@@ -28,7 +40,10 @@ export function CreateCAModal({ open, onClose, cas, onSuccess }) {
   const [createFormValidity, setCreateFormValidity] = useState('10')
   const [showAdvanced, setShowAdvanced] = useState(false)
   const [createFormPathLength, setCreateFormPathLength] = useState('')
-  const [createFormOcspMustStaple, setCreateFormOcspMustStaple] = useState(false)
+  const [createFormDigest, setCreateFormDigest] = useState('auto')
+  const [createFormKeyUsage, setCreateFormKeyUsage] = useState(ROOT_KEY_USAGE)
+  const [createFormEkuServerAuth, setCreateFormEkuServerAuth] = useState(false)
+  const [showCertProfile, setShowCertProfile] = useState(false)
 
   // HSM key storage state
   const [createFormKeyStorage, setCreateFormKeyStorage] = useState('local') // 'local' | 'hsm'
@@ -73,6 +88,30 @@ export function CreateCAModal({ open, onClose, cas, onSuccess }) {
     return () => { cancelled = true }
   }, [createFormKeyStorage, createFormHsmKeyMode, createFormHsmProviderId])
 
+  // Apply RFC 5280 defaults when CA type changes
+  useEffect(() => {
+    if (createFormType === 'root') {
+      setCreateFormKeyUsage(ROOT_KEY_USAGE)
+      setCreateFormEkuServerAuth(false)
+    } else {
+      setCreateFormKeyUsage(INTERMEDIATE_KEY_USAGE)
+      setCreateFormEkuServerAuth(true)
+    }
+  }, [createFormType])
+
+  // Reset form when modal closes
+  useEffect(() => {
+    if (open) return
+    setCreateFormType('root')
+    setCreateFormKeyAlgo('RSA')
+    setCreateFormKeySize('2048')
+    setCreateFormDigest('auto')
+    setCreateFormKeyUsage(ROOT_KEY_USAGE)
+    setCreateFormEkuServerAuth(false)
+    setShowCertProfile(false)
+    setShowAdvanced(false)
+  }, [open])
+
   // Reset HSM form state when modal closes
   useEffect(() => {
     if (open) return
@@ -101,6 +140,11 @@ export function CreateCAModal({ open, onClose, cas, onSuccess }) {
       type: createFormType,
       parentCAId: createFormType === 'intermediate' ? createFormParentCAId : null,
       ...(createFormPathLength !== '' && { pathLength: parseInt(createFormPathLength) }),
+      hashAlgorithm: createFormDigest,
+      keyUsage: createFormKeyUsage,
+      ...(createFormType === 'intermediate' && {
+        extendedKeyUsage: createFormEkuServerAuth ? ['serverAuth'] : [],
+      }),
     }
 
     // HSM key storage — replaces local key fields
@@ -236,6 +280,24 @@ export function CreateCAModal({ open, onClose, cas, onSuccess }) {
               ]}
               value={createFormKeySize}
               onChange={(value) => setCreateFormKeySize(value)}
+            />
+            <Select
+              label={t('common.signatureAlgorithm')}
+              options={[
+                { value: 'auto', label: t('cas.create.digestAuto') },
+                { value: 'sha256', label: 'SHA-256' },
+                { value: 'sha384', label: 'SHA-384' },
+                { value: 'sha512', label: 'SHA-512' },
+              ]}
+              value={createFormDigest}
+              onChange={(value) => setCreateFormDigest(value)}
+              helperText={
+                createFormDigest === 'auto'
+                  ? t('cas.create.digestAutoHint', {
+                      digest: suggestedDigest(createFormKeyAlgo, createFormKeySize).toUpperCase(),
+                    })
+                  : undefined
+              }
             />
           </div>
         </div>
@@ -386,6 +448,55 @@ export function CreateCAModal({ open, onClose, cas, onSuccess }) {
               onChange={(value) => setCreateFormParentCAId(value)}
               required
             />
+          )}
+        </div>
+
+        {/* Certificate profile (RFC 5280 Key Usage / EKU) */}
+        <div className="space-y-4">
+          <button
+            type="button"
+            className="flex items-center gap-2 text-sm font-semibold text-text-secondary hover:text-text-primary transition-colors"
+            onClick={() => setShowCertProfile(!showCertProfile)}
+          >
+            {showCertProfile ? <CaretDown size={14} /> : <CaretRight size={14} />}
+            {t('cas.create.certificateProfile')}
+          </button>
+          {showCertProfile && (
+            <div className="space-y-4 pl-2 border-l-2 border-border">
+              <p className="text-xs text-text-secondary">{t('cas.create.certificateProfileHelp')}</p>
+              <fieldset className="space-y-2">
+                <legend className="text-xs font-medium text-text-secondary">{t('common.keyUsage')}</legend>
+                {CA_KU_OPTIONS.map((ku) => (
+                  <label key={ku} className="flex items-center gap-2 text-sm text-text-primary cursor-pointer">
+                    <input
+                      type="checkbox"
+                      className="rounded border-border"
+                      checked={createFormKeyUsage.includes(ku)}
+                      onChange={(e) => {
+                        setCreateFormKeyUsage((prev) => {
+                          if (e.target.checked) {
+                            return prev.includes(ku) ? prev : [...prev, ku]
+                          }
+                          return prev.filter((x) => x !== ku)
+                        })
+                      }}
+                    />
+                    {ku}
+                  </label>
+                ))}
+              </fieldset>
+              {createFormType === 'intermediate' && (
+                <label className="flex items-center gap-2 text-sm text-text-primary cursor-pointer">
+                  <input
+                    type="checkbox"
+                    className="rounded border-border"
+                    checked={createFormEkuServerAuth}
+                    onChange={(e) => setCreateFormEkuServerAuth(e.target.checked)}
+                  />
+                  {t('cas.create.ekuServerAuth')}
+                </label>
+              )}
+            </div>
           )}
         </div>
 

--- a/frontend/src/pages/cas/CreateCAModal.jsx
+++ b/frontend/src/pages/cas/CreateCAModal.jsx
@@ -412,7 +412,6 @@ export function CreateCAModal({ open, onClose, cas, onSuccess }) {
         )}
 
         <div className="space-y-4">
-          <h3 className="text-sm font-semibold text-text-primary">{t('common.validityPeriod')}</h3>
           <Select
             label={t('common.validityPeriod')}
             options={[


### PR DESCRIPTION
Fixes #160

Addresses [Create CA: can not select template?](https://github.com/NeySlim/ultimate-ca-manager/issues/160): the help step about optional certificate templates was obsolete (CA templates removed in migration 017). This PR replaces that gap with explicit **Create CA** controls for signature digest and RFC 5280 Key Usage / EKU, including Let's Encrypt–style defaults (root: P-384 + SHA-384, `keyCertSign` + `cRLSign`; issuing CA: + `digitalSignature`, optional `serverAuth` EKU).

## Summary
- Add configurable signature digest for CA creation (`auto` aligns P-384 → SHA-384, P-521 → SHA-512).
- RFC 5280 defaults: root CA uses `keyCertSign` + `cRLSign` (no `digitalSignature`); issuing CA adds `digitalSignature` and optional `serverAuth` EKU.
- Create CA UI: signature algorithm selector + expandable certificate profile section; update FR help (remove obsolete template step).

## Review follow-up (plaimbock)
- Remove duplicate **Validity Period** label in Create CA modal.
- `GET /api/v2/cas/:id`: expose X.509 `serial_number` (colon hex) and `thumbprint_sha256` / `thumbprint_sha1`.
- Fix fingerprint calculation (`DefaultBackend` → `default_backend()`).
- Clamp intermediate CA `notAfter` to parent certificate expiry.
- Doc: `docs/testing/CA-DETAILS-POLISH.md`

## Test plan
- [x] `pytest tests/test_ca_profile.py`
- [x] `pytest tests/test_cas.py::TestCreateCA::test_create_root_ca_ec_p384_uses_sha384_and_rfc_key_usage`
- [x] `pytest tests/test_cas.py::TestCreateCA::test_create_intermediate_ca_le_style_profile`
- [x] `pytest tests/test_cas.py::TestGetCA::test_get_ca_includes_x509_serial_and_fingerprints`
- [x] `pytest tests/test_cas.py::TestCreateCA::test_intermediate_valid_to_clamped_to_parent`
- [ ] Manual: create root ECDSA P-384 + Auto → `ecdsa-with-SHA384`, KU Certificate Sign + CRL Sign
- [ ] Manual: create intermediate under root → KU includes Digital Signature, EKU serverAuth
- [ ] Manual: CA details → serial hex + fingerprints populated