### PR TITLE
Fix API-key creation rejecting valid permission resources (csrs, etc.)

### DIFF
--- a/backend/api/v2/account/apikeys.py
+++ b/backend/api/v2/account/apikeys.py
@@ -5,7 +5,7 @@ from flask import request, g, current_app
 from models import db
 from models.api_key import APIKey
 from auth.unified import AuthManager, require_auth, has_permission
-from auth.permissions import get_role_permissions
+from auth.permissions import get_role_permissions, VALID_RESOURCES
 from services.audit_service import AuditService
 from utils.response import success_response, error_response, created_response
 from utils.db_transaction import safe_commit
@@ -63,7 +63,11 @@ def create_api_key():
     # Validate permissions format — users cannot grant permissions they don't have
     user_perms = get_role_permissions(g.current_user.role)
     valid_categories = ['read', 'write', 'delete', 'admin']
-    valid_resources = ['cas', 'certificates', 'acme', 'scep', 'crl', 'settings', 'users', 'system']
+    # Derived from ROLE_PERMISSIONS (single source of truth) so this validator can't drift
+    # from the resources @require_auth actually enforces — the previous hardcoded list was
+    # missing csrs/user_certificates/templates/truststore/est/hsm/ssh/policies/approvals/
+    # key_recovery/audit/groups and listed two non-resources (users/system).
+    valid_resources = VALID_RESOURCES
 
     for perm in data['permissions']:
         if perm == '*':

--- a/backend/auth/permissions.py
+++ b/backend/auth/permissions.py
@@ -53,16 +53,27 @@ ROLE_PERMISSIONS = {
 }
 
 
-# Canonical set of resources referenced anywhere in ROLE_PERMISSIONS. Derived from this
-# single source of truth so that permission validators (e.g. API-key creation) stay in
-# sync with the `action:resource` scopes actually enforced by @require_auth and can't
-# silently drift from them.
-VALID_RESOURCES = sorted({
-    perm.split(':', 1)[1]
-    for perms in ROLE_PERMISSIONS.values()
-    for perm in perms
-    if ':' in perm
-})
+# Resources enforced by @require_auth but reachable ONLY through the '*' (admin) wildcard,
+# so they never appear in a named role's explicit scope list in ROLE_PERMISSIONS above.
+# They must still be scope-able on an API key (e.g. an admin minting a key for user
+# management or SSO config), so they're unioned into VALID_RESOURCES below. Keep in sync
+# with @require_auth usage — tests/test_apikey_valid_resources.py fails if a new enforced
+# scope is added without registering its resource here (or granting it to a role above).
+ADMIN_ONLY_RESOURCES = {'users', 'system', 'sso'}
+
+# Canonical set of resources an API key can be scoped to: every resource granted to a role
+# in ROLE_PERMISSIONS PLUS the admin-only resources above. Derived from these sources of
+# truth so this validator can't silently drift from the `action:resource` scopes that
+# @require_auth actually enforces (the previous hardcoded list had drifted — it was missing
+# csrs/user_certificates/templates/... — and deriving from ROLE_PERMISSIONS alone dropped
+# the admin-only users/system/sso resources).
+VALID_RESOURCES = sorted(
+    {perm.split(':', 1)[1]
+     for perms in ROLE_PERMISSIONS.values()
+     for perm in perms
+     if ':' in perm}
+    | ADMIN_ONLY_RESOURCES
+)
 
 
 def get_role_permissions(role: str) -> list:

--- a/backend/auth/permissions.py
+++ b/backend/auth/permissions.py
@@ -53,6 +53,18 @@ ROLE_PERMISSIONS = {
 }
 
 
+# Canonical set of resources referenced anywhere in ROLE_PERMISSIONS. Derived from this
+# single source of truth so that permission validators (e.g. API-key creation) stay in
+# sync with the `action:resource` scopes actually enforced by @require_auth and can't
+# silently drift from them.
+VALID_RESOURCES = sorted({
+    perm.split(':', 1)[1]
+    for perms in ROLE_PERMISSIONS.values()
+    for perm in perms
+    if ':' in perm
+})
+
+
 def get_role_permissions(role: str) -> list:
     """Get permissions for a role"""
     return ROLE_PERMISSIONS.get(role, [])

--- a/backend/tests/test_apikey_valid_resources.py
+++ b/backend/tests/test_apikey_valid_resources.py
@@ -1,0 +1,85 @@
+"""Regression tests for the API-key permission-resource validator (PR #178).
+
+`POST /api/v2/account/apikeys` rejects any scope whose resource is not in
+`auth.permissions.VALID_RESOURCES`. The original bug was a hardcoded list that had
+drifted from the scopes `@require_auth` actually enforces (so valid scopes like
+`write:csrs` were rejected). Deriving `VALID_RESOURCES` purely from `ROLE_PERMISSIONS`
+fixed that but re-introduced a narrower drift: admin-only resources (`users`, `system`,
+`sso`) are reachable only through the `*` wildcard, so they never appear in a named
+role's scope list and were dropped — meaning an admin could no longer mint an API key
+scoped to user management, system/discovery, or SSO config.
+
+These tests pin the invariant so it can't drift again: the set of resources an API key
+may be scoped to must cover EVERY resource the app enforces via `@require_auth`.
+"""
+import ast
+import os
+
+from auth.permissions import VALID_RESOURCES
+
+BACKEND_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+_SKIP_DIRS = {"tests", "migrations", "__pycache__", "venv", ".venv", "node_modules", ".git"}
+_ACTIONS = {"read", "write", "delete", "admin"}
+
+
+def _resources_in_call(call):
+    """Yield resource names from the string scopes passed to a require_auth(...) call.
+
+    Walks the call so both `require_auth(['read:users'])` and `require_auth('read:users')`
+    (and multiple scopes) are covered. Only literal scopes are seen — which is exactly the
+    enforced surface we care about.
+    """
+    for node in ast.walk(call):
+        if isinstance(node, ast.Constant) and isinstance(node.value, str) and ":" in node.value:
+            action, _, resource = node.value.partition(":")
+            if action in _ACTIONS and resource and resource != "*":
+                yield resource
+
+
+def enforced_resources():
+    """Map every resource referenced in a real `@require_auth(...)` decorator across the
+    backend to an example file. AST-based, so docstring 'Usage:' examples are ignored."""
+    found = {}
+    for dirpath, dirnames, filenames in os.walk(BACKEND_ROOT):
+        dirnames[:] = [d for d in dirnames if d not in _SKIP_DIRS]
+        for fn in filenames:
+            if not fn.endswith(".py"):
+                continue
+            path = os.path.join(dirpath, fn)
+            try:
+                tree = ast.parse(open(path, encoding="utf-8").read())
+            except (SyntaxError, UnicodeDecodeError):
+                continue
+            for node in ast.walk(tree):
+                if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                    continue
+                for dec in node.decorator_list:
+                    if not isinstance(dec, ast.Call):
+                        continue
+                    name = dec.func.attr if isinstance(dec.func, ast.Attribute) else getattr(dec.func, "id", None)
+                    if name != "require_auth":
+                        continue
+                    for res in _resources_in_call(dec):
+                        found.setdefault(res, os.path.relpath(path, BACKEND_ROOT))
+    return found
+
+
+def test_valid_resources_covers_every_enforced_scope():
+    """VALID_RESOURCES must be a superset of every resource `@require_auth` enforces —
+    otherwise an admin can't scope an API key to a route the server actually guards."""
+    enforced = enforced_resources()
+    missing = {r: loc for r, loc in enforced.items() if r not in VALID_RESOURCES}
+    assert not missing, (
+        "VALID_RESOURCES is missing resources that @require_auth enforces "
+        "(API keys can't be scoped to them): "
+        + ", ".join(f"{r} (e.g. {loc})" for r, loc in sorted(missing.items()))
+    )
+
+
+def test_valid_resources_includes_known_regressions():
+    """Explicit anchors for the exact resources behind the PR #178 bug + the collateral
+    regression it introduced."""
+    for resource in ("csrs", "users", "system", "sso"):
+        assert resource in VALID_RESOURCES, (
+            f"{resource!r} is enforced by @require_auth but not scope-able on an API key"
+        )


### PR DESCRIPTION
`POST /api/v2/account/apikeys` validates `permissions` against a hardcoded `valid_resources` list in `apikeys.py` that has drifted from `ROLE_PERMISSIONS` in `auth/permissions.py` — it's missing `csrs`, `user_certificates`, `templates`, `truststore`, `est`, `hsm`, `ssh`, `policies`, `approvals`, `key_recovery`, `audit`, `groups`, and lists two non-resources (`users`, `system`).

So an API key can't be scoped to those resources. For example `write:csrs` — required by `POST /api/v2/csrs/<id>/sign` — is rejected with `400 "Invalid permission resource: csrs"`, leaving CSR signing reachable only by a full `*` admin key.

**Fix:** derive the allowed resources from `ROLE_PERMISSIONS` (the source of truth `@require_auth` already uses) so the two can't drift again. The existing "can only grant permissions you already have" check is unchanged.
