### PR TITLE
Fix ModuleNotFoundError: pwd — api.v2 fails to import on non-POSIX

### DIFF
--- a/backend/api/v2/system/https.py
+++ b/backend/api/v2/system/https.py
@@ -13,7 +13,6 @@ from pathlib import Path
 import os
 import shutil
 import base64
-import pwd
 from datetime import datetime, timedelta, timezone
 import logging
 from utils.datetime_utils import utc_now, utc_isoformat
@@ -151,12 +150,13 @@ def regenerate_https_cert():
         ))
         os.chmod(key_path, 0o600)
 
-        # Set ownership
+        # Set ownership to the ucm service user (POSIX only; skipped elsewhere / if absent)
         try:
+            import pwd  # POSIX-only; import lazily so this module loads on non-POSIX too
             ucm_user = pwd.getpwnam('ucm')
             os.chown(cert_path, ucm_user.pw_uid, ucm_user.pw_gid)
             os.chown(key_path, ucm_user.pw_uid, ucm_user.pw_gid)
-        except KeyError:
+        except (KeyError, ImportError):
             pass
 
         current_app.logger.info(f"Regenerated HTTPS certificate for {common_name}")
@@ -257,13 +257,14 @@ def apply_https_cert():
         key_path.write_text(key_data)
         os.chmod(key_path, 0o600)
 
-        # Set ownership to ucm user (if exists)
+        # Set ownership to ucm user (POSIX only; skipped on non-POSIX or if user absent)
         try:
+            import pwd  # POSIX-only; import lazily so this module loads on non-POSIX too
             ucm_user = pwd.getpwnam('ucm')
             os.chown(cert_path, ucm_user.pw_uid, ucm_user.pw_gid)
             os.chown(key_path, ucm_user.pw_uid, ucm_user.pw_gid)
-        except KeyError:
-            pass  # ucm user doesn't exist, skip chown
+        except (KeyError, ImportError):
+            pass  # ucm user doesn't exist (or non-POSIX), skip chown
 
         current_app.logger.info(f"Applied certificate {cert.refid} as HTTPS cert")
 

--- a/backend/tests/test_no_posix_only_toplevel_imports.py
+++ b/backend/tests/test_no_posix_only_toplevel_imports.py
@@ -1,0 +1,46 @@
+"""Regression test: api.v2 modules must import on non-POSIX platforms.
+
+`api/v2/__init__.py` eagerly imports every submodule, so a single module doing an
+UNCONDITIONAL top-level `import pwd` (or another POSIX-only stdlib module) makes the
+entire `api.v2` package — and therefore the whole test suite — fail to import on
+Windows with `ModuleNotFoundError: No module named 'pwd'`. POSIX-only modules must be
+imported lazily (inside the function that needs them) or guarded, so the module still
+loads everywhere and the POSIX-only behavior degrades gracefully.
+
+Regression for the `api/v2/system/https.py` `import pwd` that broke Windows imports.
+"""
+import ast
+import os
+
+API_V2 = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "api", "v2")
+
+# stdlib modules that only exist on POSIX; a top-level import of any breaks import on Windows.
+POSIX_ONLY = {"pwd", "grp", "fcntl", "termios", "crypt", "spwd", "nis", "posix", "resource", "syslog"}
+
+
+def _toplevel_posix_imports(path):
+    """POSIX-only modules imported UNCONDITIONALLY at module level (direct children of the
+    module body — so lazy imports inside functions and guarded try/except imports are fine)."""
+    tree = ast.parse(open(path, encoding="utf-8").read())
+    hits = []
+    for node in tree.body:
+        if isinstance(node, ast.Import):
+            hits += [(a.name, node.lineno) for a in node.names if a.name.split(".")[0] in POSIX_ONLY]
+        elif isinstance(node, ast.ImportFrom) and (node.module or "").split(".")[0] in POSIX_ONLY:
+            hits.append((node.module, node.lineno))
+    return hits
+
+
+def test_no_toplevel_posix_only_imports_in_api_v2():
+    offenders = {}
+    for dirpath, _, filenames in os.walk(API_V2):
+        for fn in filenames:
+            if fn.endswith(".py"):
+                path = os.path.join(dirpath, fn)
+                hits = _toplevel_posix_imports(path)
+                if hits:
+                    offenders[os.path.relpath(path, API_V2)] = hits
+    assert not offenders, (
+        "api.v2 modules must import on non-POSIX platforms (api/v2/__init__.py imports them all "
+        "eagerly); import POSIX-only modules lazily/guarded instead. Offenders: " + repr(offenders)
+    )


### PR DESCRIPTION
## Problem
`api/v2/system/https.py` has an unconditional top-level `import pwd` (a Unix-only
stdlib module). `api/v2/__init__.py` imports every submodule eagerly, so on Windows
the whole `api.v2` package raises `ModuleNotFoundError: No module named 'pwd'` — it
halts the entire pytest suite at collection. `pwd` is used only for `pwd.getpwnam('ucm')`
at two `chown` sites, both already inside `try/except`.

## Fix
Drop the top-level import; import `pwd` lazily inside each of the two functions and add
`ImportError` to the `except` so the chown is gracefully skipped on non-POSIX. Behaviour
on Linux is unchanged (same chown, same KeyError skip when the `ucm` user is absent).

## Regression test
`tests/test_no_posix_only_toplevel_imports.py` — AST-scans every module under `api/v2`
and asserts none top-level-imports a POSIX-only stdlib module (`pwd`, `grp`, `crypt`, …).
Fails on the pre-fix tree, passes after.

## Testing
Linux (Ubuntu 24.04 / py3.12): full backend suite 2255 passed, 0 new failures vs dev;
`api.v2` now imports cleanly on Windows.
