### PR TITLE
Remove dead code in BackupService._encrypt_private_key

### DIFF
--- a/backend/services/backup/backup_service.py
+++ b/backend/services/backup/backup_service.py
@@ -332,4 +332,3 @@ class BackupService(ExportCoreMixin, ExportExtendedMixin, DecryptMixin,
             'nonce': nonce.hex(),
             'ciphertext': ciphertext.hex()
         }
-        return plaintext.decode()


### PR DESCRIPTION
## Problem
`services/backup/backup_service.py::_encrypt_private_key` returns a dict, then has an
unreachable `return plaintext.decode()` on the following line. Dead code; also would have
leaked the plaintext key if ever reached.

## Fix
Delete the unreachable line. One-line diff, no behaviour change.

## Note (finding #8, evaluated and intentionally NOT included)
The "default admin password" finding was checked and dropped: both bootstrap paths
(`app.py` initial-admin and `api/v2/system/database.py` restore) already set
`force_password_change=True`, so the default credential is force-rotated on first login.
Nothing to fix.

## Testing
Linux: 2254 passed, 0 new failures vs dev; module compiles, backup round-trip unaffected.
