### PR TITLE
Validate LDAP TLS when "verify SSL" is on but no CA bundle is set

### DIFF
--- a/backend/api/v2/sso/helpers.py
+++ b/backend/api/v2/sso/helpers.py
@@ -84,7 +84,10 @@ def _build_ldap_tls(provider):
             os.close(fd)
         return __import__('ldap3').Tls(ca_certs_file=ca_path, validate=ssl.CERT_REQUIRED)
 
-    return None
+    # verify requested but no explicit CA bundle: validate against the system trust store
+    # (CERT_REQUIRED) rather than returning None, which would leave ldap3 on its default
+    # unvalidated TLS — i.e. a "verify SSL" setting that silently doesn't verify.
+    return __import__('ldap3').Tls(validate=ssl.CERT_REQUIRED)
 
 
 def _encrypt_ldap_password(password: str) -> str:

--- a/backend/tests/test_ldap_tls_validation.py
+++ b/backend/tests/test_ldap_tls_validation.py
@@ -1,0 +1,37 @@
+"""Regression test: LDAP TLS must validate the server certificate when 'verify SSL' is
+enabled, even if no explicit CA bundle is configured. Previously `_build_ldap_tls`
+returned None in that case, leaving ldap3 on its default (unvalidated) TLS — a "verify
+SSL" setting that silently didn't verify (MITM risk on LDAP auth)."""
+import ssl
+from types import SimpleNamespace
+
+from api.v2.sso.helpers import _build_ldap_tls
+
+
+def _provider(**kw):
+    d = dict(ldap_verify_ssl=None, ldap_use_ssl=True, ldap_ca_bundle=None)
+    d.update(kw)
+    return SimpleNamespace(**d)
+
+
+def test_verify_on_without_ca_bundle_still_validates():
+    tls = _build_ldap_tls(_provider(ldap_verify_ssl=True, ldap_ca_bundle=None))
+    assert tls is not None, "verify=on must not yield an unvalidated (None) TLS"
+    assert tls.validate == ssl.CERT_REQUIRED
+
+
+def test_default_verify_is_on_and_validates():
+    # ldap_verify_ssl unset (None) -> defaults to True -> must validate
+    tls = _build_ldap_tls(_provider(ldap_verify_ssl=None, ldap_ca_bundle=None))
+    assert tls is not None and tls.validate == ssl.CERT_REQUIRED
+
+
+def test_verify_off_is_cert_none():
+    tls = _build_ldap_tls(_provider(ldap_verify_ssl=False))
+    assert tls is not None and tls.validate == ssl.CERT_NONE
+
+
+def test_verify_on_with_ca_bundle_validates():
+    pem = "-----BEGIN CERTIFICATE-----\nMIIBmock\n-----END CERTIFICATE-----\n"
+    tls = _build_ldap_tls(_provider(ldap_verify_ssl=True, ldap_ca_bundle=pem))
+    assert tls.validate == ssl.CERT_REQUIRED


### PR DESCRIPTION
## Problem (Medium)
`api/v2/sso/helpers.py::_build_ldap_tls`: when an operator enables "verify SSL" for an
LDAP/SSO provider but has not uploaded a CA bundle, the function returns `None`. ldap3
then falls back to its default TLS, which does **not** validate the server certificate —
so a "verify SSL = on" setting silently performs no verification, leaving LDAP auth open
to a MITM.

## Fix
In that branch, return `ldap3.Tls(validate=ssl.CERT_REQUIRED)` instead of `None`, so the
LDAP server cert is validated against the system trust store. The `verify_ssl=False`
(explicit opt-out → CERT_NONE) and the CA-bundle-supplied paths are unchanged.

## Regression test
`tests/test_ldap_tls_validation.py` (4 tests) — asserts the verify-on/no-CA branch returns
a `Tls` with `validate == CERT_REQUIRED` (not None), verify-off still yields CERT_NONE, and
an uploaded CA still produces a bundle-backed Tls. Red→green: 2 assertions fail pre-fix.

## Testing
Linux: 2258 passed, 0 new failures vs dev.
