### PR TITLE
Fix SSRF guard bypass via unspecified + IPv4-mapped-IPv6 addresses

### DIFF
--- a/backend/tests/test_ssrf_guard_bypass.py
+++ b/backend/tests/test_ssrf_guard_bypass.py
@@ -1,0 +1,34 @@
+"""Regression tests for the SSRF cloud-metadata/loopback guard (utils/ssrf_protection).
+
+The guard must not be evadable via:
+  * the unspecified address (0.0.0.0 / ::), which routes to loopback on most OSes; or
+  * an IPv4-mapped IPv6 encoding of a denied IPv4 target
+    (e.g. ::ffff:169.254.169.254 for the cloud metadata service).
+It must keep ALLOWING public and RFC1918-private literal IPs — this narrow guard permits
+those by design (UCM is commonly pointed at internal infra).
+"""
+import pytest
+from utils.ssrf_protection import validate_url_not_cloud_metadata
+
+
+@pytest.mark.parametrize("url", [
+    "https://0.0.0.0/",                    # unspecified -> loopback
+    "https://[::]/",                       # unspecified -> loopback
+    "https://127.0.0.1/",                  # loopback
+    "https://[::ffff:127.0.0.1]/",         # IPv4-mapped loopback
+    "https://169.254.169.254/",            # AWS/Azure/GCP metadata
+    "https://[::ffff:169.254.169.254]/",   # metadata via IPv4-mapped IPv6
+    "https://100.100.100.200/",            # Alibaba metadata
+])
+def test_guard_blocks_loopback_and_metadata(url):
+    with pytest.raises(ValueError):
+        validate_url_not_cloud_metadata(url)
+
+
+@pytest.mark.parametrize("url", [
+    "https://93.184.216.34/",   # public literal IP
+    "https://10.0.0.5/",        # RFC1918 private — allowed by this narrow guard by design
+    "https://192.168.1.10/",
+])
+def test_guard_allows_public_and_private_literals(url):
+    validate_url_not_cloud_metadata(url)   # must not raise

--- a/backend/utils/ssrf_protection.py
+++ b/backend/utils/ssrf_protection.py
@@ -69,6 +69,24 @@ _CLOUD_METADATA_HOSTS = {
     'metadata.goog',
 }
 
+# Deny-list as parsed IP objects so an IPv4-mapped IPv6 form (::ffff:a.b.c.d) can't
+# evade a string comparison by re-encoding an IPv4 target as IPv6.
+_CLOUD_METADATA_IP_OBJS = {ipaddress.ip_address(a) for a in _CLOUD_METADATA_IPS}
+
+
+def _forbidden_ip_reason(ip):
+    """Why `ip` (an ipaddress object) is a forbidden SSRF target — cloud metadata,
+    loopback, or unspecified (0.0.0.0 / ::, which route to loopback on most OSes) — or
+    None. IPv4-mapped IPv6 is collapsed to IPv4 first so it can't slip past the checks."""
+    mapped = getattr(ip, 'ipv4_mapped', None)
+    if mapped is not None:
+        ip = mapped
+    if ip in _CLOUD_METADATA_IP_OBJS:
+        return "cloud metadata IP"
+    if ip.is_loopback or ip.is_unspecified:
+        return "loopback/unspecified address"
+    return None
+
 
 def validate_url_not_cloud_metadata(url: str) -> None:
     """Validate that a URL doesn't target cloud metadata services or loopback.
@@ -97,13 +115,12 @@ def validate_url_not_cloud_metadata(url: str) -> None:
     # Check literal IP
     try:
         ip = ipaddress.ip_address(host)
-        if str(ip) in _CLOUD_METADATA_IPS:
-            raise ValueError(f"Host {host} is a cloud metadata IP")
-        if ip.is_loopback:
-            raise ValueError(f"Host {host} is a loopback address")
+        reason = _forbidden_ip_reason(ip)
+        if reason:
+            raise ValueError(f"Host {host} is a {reason}")
         return
     except ValueError as e:
-        if "metadata" in str(e) or "loopback" in str(e):
+        if "metadata" in str(e) or "loopback" in str(e) or "unspecified" in str(e):
             raise
         # Not a literal IP — fall through to DNS resolution
 
@@ -112,10 +129,9 @@ def validate_url_not_cloud_metadata(url: str) -> None:
         addrs = socket.getaddrinfo(host, None)
         for _, _, _, _, sockaddr in addrs:
             ip = ipaddress.ip_address(sockaddr[0])
-            if str(ip) in _CLOUD_METADATA_IPS:
-                raise ValueError(f"Host {host} resolves to cloud metadata IP {ip}")
-            if ip.is_loopback:
-                raise ValueError(f"Host {host} resolves to loopback {ip}")
+            reason = _forbidden_ip_reason(ip)
+            if reason:
+                raise ValueError(f"Host {host} resolves to {reason} {ip}")
     except socket.gaierror:
         # Cannot resolve — not a SSRF risk (can't reach anything)
         pass
@@ -207,13 +223,12 @@ def _resolve_and_validate(url: str) -> tuple:
     # Already a literal IP — validate and pin to itself.
     try:
         ip_obj = ipaddress.ip_address(host)
-        if str(ip_obj) in _CLOUD_METADATA_IPS:
-            raise ValueError(f"Host {host} is a cloud metadata IP")
-        if ip_obj.is_loopback:
-            raise ValueError(f"Host {host} is a loopback address")
+        reason = _forbidden_ip_reason(ip_obj)
+        if reason:
+            raise ValueError(f"Host {host} is a {reason}")
         return host, str(ip_obj)
     except ValueError as e:
-        if "metadata" in str(e) or "loopback" in str(e):
+        if "metadata" in str(e) or "loopback" in str(e) or "unspecified" in str(e):
             raise
         # Not a literal IP — resolve below.
 
@@ -225,10 +240,9 @@ def _resolve_and_validate(url: str) -> tuple:
     chosen = None
     for _, _, _, _, sockaddr in addrs:
         ip = ipaddress.ip_address(sockaddr[0])
-        if str(ip) in _CLOUD_METADATA_IPS:
-            raise ValueError(f"Host {host} resolves to cloud metadata IP {ip}")
-        if ip.is_loopback:
-            raise ValueError(f"Host {host} resolves to loopback {ip}")
+        reason = _forbidden_ip_reason(ip)
+        if reason:
+            raise ValueError(f"Host {host} resolves to {reason} {ip}")
         if chosen is None:
             chosen = str(ip)
 


### PR DESCRIPTION
## Problem
`utils/ssrf_protection.py` guards admin-supplied outbound URLs (webhooks, SSO discovery,
ACME proxy) against loopback + cloud-metadata targets. Two verified bypasses:

| Input | Reaches | Why |
|---|---|---|
| `0.0.0.0`, `::` | loopback | code checked `is_loopback`, not `is_unspecified` |
| `::ffff:169.254.169.254` | AWS metadata (IAM creds) | deny-set matched by string; the IPv4-mapped IPv6 form stringifies differently and slips past |

## Fix
Add `_forbidden_ip_reason(ip)`: collapse IPv4-mapped IPv6 to IPv4 via `.ipv4_mapped`,
compare against a **parsed-IP** deny-set (`_CLOUD_METADATA_IP_OBJS`, not strings), and
treat `is_unspecified` as forbidden alongside `is_loopback`. Wired into all four check
sites (literal-IP and post-DNS, in both `validate_url_not_cloud_metadata` and
`_resolve_and_validate`).

## Regression test
`tests/test_ssrf_guard_bypass.py` (10 tests) — the three bypasses are now blocked; the
legitimate-host and normal-loopback/metadata cases still behave. Red→green.

## Testing
Linux: 2264 passed, 0 new failures vs dev.
