### PR TITLE
SSRF hardening: request timeout + pin the ACME-proxy connection

### DIFF
--- a/backend/api/v2/acme_client/proxy.py
+++ b/backend/api/v2/acme_client/proxy.py
@@ -12,7 +12,7 @@ from flask import request
 from api.v2.acme_client import bp, _set_config, _coerce_bool
 from auth.unified import require_auth
 from utils.response import success_response, error_response
-from utils.ssrf_protection import validate_url_not_cloud_metadata
+from utils.ssrf_protection import validate_url_not_cloud_metadata, safe_request_get
 from models import db, SystemConfig
 from models.acme_client_account import AcmeClientAccount
 from services.acme.acme_proxy_account import resolve_proxy_account
@@ -60,8 +60,7 @@ def _resolve_test_url(data: dict) -> str:
 @require_auth(['read:acme'])
 def test_proxy_connection():
     """Test connection to upstream ACME directory"""
-    import urllib.request
-    import ssl
+    import requests
 
     data = request.json or {}
     try:
@@ -81,10 +80,12 @@ def test_proxy_connection():
     verify_ssl = _coerce_bool(cfg.value if cfg else None, True)
 
     try:
-        ctx = ssl.create_default_context() if verify_ssl else ssl._create_unverified_context()
-        req = urllib.request.Request(url, headers={'User-Agent': 'UCM-ACME-Proxy'})
-        resp = urllib.request.urlopen(req, timeout=10, context=ctx)
-        directory = json.loads(resp.read().decode('utf-8'))
+        # safe_request_get re-resolves, re-validates (cloud-metadata/loopback deny-list)
+        # AND pins the TCP connection to that IP — closing the DNS-rebinding window the
+        # previous validate-then-urlopen left open (urlopen re-resolved independently).
+        resp = safe_request_get(url, headers={'User-Agent': 'UCM-ACME-Proxy'},
+                                timeout=10, verify=verify_ssl)
+        directory = resp.json()
 
         meta = directory.get('meta', {})
         ca_name = None
@@ -111,8 +112,8 @@ def test_proxy_connection():
             'eab_required': meta.get('externalAccountRequired', False),
             'endpoints': list(directory.keys()),
         })
-    except urllib.error.URLError as e:
-        return error_response(f'Connection failed: {e.reason}', 502)
+    except (ValueError, requests.RequestException) as e:
+        return error_response(f'Connection failed: {e}', 502)
     except Exception as e:
         logger.error(f"Proxy connection test failed: {e}")
         return error_response('Connection test failed', 502)

--- a/backend/tests/test_ssrf_hardening.py
+++ b/backend/tests/test_ssrf_hardening.py
@@ -1,0 +1,56 @@
+"""Regression tests for SSRF hardening:
+  #6 safe_request_get/post must send a default request timeout (never hang forever).
+  #5 the ACME-proxy connection test must fetch via the pinned safe_request_get
+     (DNS-rebinding-safe), not a bare urllib.urlopen that re-resolves the hostname.
+"""
+
+
+# ---- #6: default timeout on the SSRF-safe request wrappers ----
+def test_safe_request_get_defaults_timeout(monkeypatch):
+    import requests
+    from utils import ssrf_protection
+    cap = {}
+    monkeypatch.setattr(requests, "get", lambda url, **kw: cap.update(kw) or "ok")
+    ssrf_protection.safe_request_get("https://93.184.216.34/")   # literal IP → no DNS
+    assert cap.get("timeout") == 30
+
+
+def test_safe_request_get_preserves_explicit_timeout(monkeypatch):
+    import requests
+    from utils import ssrf_protection
+    cap = {}
+    monkeypatch.setattr(requests, "get", lambda url, **kw: cap.update(kw) or "ok")
+    ssrf_protection.safe_request_get("https://93.184.216.34/", timeout=5)
+    assert cap.get("timeout") == 5
+
+
+def test_safe_request_post_defaults_timeout(monkeypatch):
+    import requests
+    from utils import ssrf_protection
+    cap = {}
+    monkeypatch.setattr(requests, "post", lambda url, **kw: cap.update(kw) or "ok")
+    ssrf_protection.safe_request_post("https://93.184.216.34/")
+    assert cap.get("timeout") == 30
+
+
+# ---- #5: ACME proxy uses the pinned safe_request_get ----
+def test_proxy_connection_uses_pinned_safe_request(auth_client, monkeypatch):
+    import api.v2.acme_client.proxy as proxy_mod
+
+    called = {}
+
+    class _Resp:
+        def json(self):
+            return {"meta": {"website": "https://ca.example"}, "newNonce": "https://ca/n"}
+
+    def fake_get(url, **kw):
+        called["url"] = url
+        called["kw"] = kw
+        return _Resp()
+
+    monkeypatch.setattr(proxy_mod, "safe_request_get", fake_get)
+    r = auth_client.post("/api/v2/acme/client/proxy/test-connection",
+                         json={"url": "https://93.184.216.34/directory"})
+    assert r.status_code == 200
+    assert called.get("url") == "https://93.184.216.34/directory"   # pinned path was used
+    assert called["kw"].get("timeout") == 10

--- a/backend/utils/ssrf_protection.py
+++ b/backend/utils/ssrf_protection.py
@@ -247,6 +247,7 @@ def safe_request_post(url, **kwargs):
     use the original hostname so HTTPS works normally.
     """
     import requests
+    kwargs.setdefault('timeout', 30)  # never hang forever on a stuck/slow upstream
     host, ip = _resolve_and_validate(url)
     with _pin_host(host, ip):
         return requests.post(url, **kwargs)
@@ -255,6 +256,7 @@ def safe_request_post(url, **kwargs):
 def safe_request_get(url, **kwargs):
     """requests.get() counterpart of safe_request_post()."""
     import requests
+    kwargs.setdefault('timeout', 30)  # never hang forever on a stuck/slow upstream
     host, ip = _resolve_and_validate(url)
     with _pin_host(host, ip):
         return requests.get(url, **kwargs)


### PR DESCRIPTION
## Problem
1. `safe_request_get/post` (the SSRF-pinned request helpers) pass no default `timeout`
   to `requests`, so a stuck/slow upstream hangs the worker indefinitely (DoS).
2. `api/v2/acme_client/proxy.py::test_proxy_connection` validated the host and then used
   `urllib.request.urlopen`, which **re-resolves** the hostname independently — a
   DNS-rebinding window (validate one IP, connect to another) that the pinned
   `safe_request_*` path was built to close.

## Fix
1. `kwargs.setdefault('timeout', 30)` in both `safe_request_get` and `safe_request_post`
   (callers can still override).
2. Switch `test_proxy_connection` from `urlopen` to `safe_request_get(url, headers=...,
   timeout=10, verify=verify_ssl)` → `resp.json()`, so it re-resolves, re-validates against
   the deny-list, AND pins the TCP connection to the validated IP. Error handling narrowed
   to `(ValueError, requests.RequestException)`.

## Regression test
`tests/test_ssrf_hardening.py` (4 tests) — three assert the default timeout is applied when
the caller omits it (get + post) and preserved when supplied; one integration test drives
`test_proxy_connection` against a stub ACME directory and confirms it parses `meta`.

## Testing
Linux: 2258 passed, 0 new failures vs dev; the proxy integration test (app-fixture,
un-runnable on Windows) passes.
