### PR TITLE
Migrate SCEP off unmaintained pyCrypto to pyca/cryptography

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -26,8 +26,7 @@ pyotp>=2.9.0
 qrcode>=7.4
 Pillow>=10.0.0
 
-# SCEP Support
-pycryptodome==3.23.0
+# SCEP Support (pycryptodome dropped — SCEP now uses pyca/cryptography's ciphers)
 pyasn1==0.6.3
 pyasn1-modules==0.4.2
 

--- a/backend/services/scep/crypto_helpers.py
+++ b/backend/services/scep/crypto_helpers.py
@@ -7,7 +7,7 @@ from typing import Optional
 import asn1crypto.cms
 import asn1crypto.core
 import asn1crypto.x509
-from Crypto.Cipher import AES
+from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 from cryptography import x509
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import padding as asym_padding
@@ -72,11 +72,11 @@ def encrypt_for_client(
     content_key = secrets.token_bytes(32)   # AES-256
     iv = secrets.token_bytes(16)            # AES block size
 
-    cipher = AES.new(content_key, AES.MODE_CBC, iv)
     block_size = 16
     padding_len = block_size - (len(data) % block_size)
     padded_data = data + bytes([padding_len] * padding_len)
-    encrypted_content = cipher.encrypt(padded_data)
+    encryptor = Cipher(algorithms.AES(content_key), modes.CBC(iv)).encryptor()
+    encrypted_content = encryptor.update(padded_data) + encryptor.finalize()
 
     encrypted_key = client_public_key.encrypt(content_key, asym_padding.PKCS1v15())
 

--- a/backend/services/scep/message_parser.py
+++ b/backend/services/scep/message_parser.py
@@ -8,7 +8,8 @@ from typing import Dict, Any, Optional
 import asn1crypto.cms
 import asn1crypto.core
 import asn1crypto.x509
-from Crypto.Cipher import DES3, AES
+from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+from cryptography.hazmat.decrepit.ciphers.algorithms import TripleDES
 from cryptography import x509
 from cryptography.exceptions import InvalidSignature
 from cryptography.hazmat.backends import default_backend
@@ -267,19 +268,19 @@ def decrypt_scep_envelope(encrypted_bytes: bytes, ca_key) -> bytes:
         raise ValueError("DES encryption is not supported — use AES or 3DES")
     elif "1.2.840.113549.3.7" in alg_oid:  # 3DES
         logger.warning("SCEP client using 3DES encryption — deprecated, prefer AES")
-        cipher = DES3.new(content_encryption_key, DES3.MODE_CBC, iv)
-        plaintext = cipher.decrypt(encrypted_content_bytes)
+        decryptor = Cipher(TripleDES(content_encryption_key), modes.CBC(iv)).decryptor()
+        plaintext = decryptor.update(encrypted_content_bytes) + decryptor.finalize()
         pad_len = plaintext[-1]
-        if pad_len < 1 or pad_len > DES3.block_size or not all(
+        if pad_len < 1 or pad_len > 8 or not all(  # 3DES block size = 8 bytes
             b == pad_len for b in plaintext[-pad_len:]
         ):
             raise ValueError("Invalid PKCS#7 padding in SCEP message")
         return plaintext[:-pad_len]
     elif "2.16.840.1.101.3.4.1" in alg_oid:  # AES (any variant)
-        cipher = AES.new(content_encryption_key, AES.MODE_CBC, iv)
-        plaintext = cipher.decrypt(encrypted_content_bytes)
+        decryptor = Cipher(algorithms.AES(content_encryption_key), modes.CBC(iv)).decryptor()
+        plaintext = decryptor.update(encrypted_content_bytes) + decryptor.finalize()
         pad_len = plaintext[-1]
-        if pad_len < 1 or pad_len > AES.block_size or not all(
+        if pad_len < 1 or pad_len > 16 or not all(  # AES block size = 16 bytes
             b == pad_len for b in plaintext[-pad_len:]
         ):
             raise ValueError("Invalid PKCS#7 padding in SCEP message")

--- a/backend/tests/test_scep_crypto_migration.py
+++ b/backend/tests/test_scep_crypto_migration.py
@@ -1,0 +1,51 @@
+"""Regression test for the SCEP pyCrypto -> cryptography migration.
+
+The SCEP crypto modules must not import the unmaintained pyCrypto (`Crypto`), and the
+CBC ciphers they now use (AES-256-CBC and 3DES-CBC) must round-trip. These are standard
+algorithms, so the ciphertext is byte-identical to what pyCrypto produced — existing SCEP
+clients' messages keep decrypting unchanged.
+"""
+import ast
+import os
+import secrets
+
+from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+from cryptography.hazmat.decrepit.ciphers.algorithms import TripleDES
+
+SCEP = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "services", "scep")
+
+
+def _imports_pycrypto(path):
+    tree = ast.parse(open(path, encoding="utf-8").read())
+    for n in ast.walk(tree):
+        if isinstance(n, ast.ImportFrom) and (n.module or "").split(".")[0] == "Crypto":
+            return True
+        if isinstance(n, ast.Import) and any(a.name.split(".")[0] == "Crypto" for a in n.names):
+            return True
+    return False
+
+
+def test_scep_modules_do_not_import_pycrypto():
+    offenders = [f for f in ("crypto_helpers.py", "message_parser.py")
+                 if _imports_pycrypto(os.path.join(SCEP, f))]
+    assert not offenders, f"SCEP still imports the unmaintained pyCrypto: {offenders}"
+
+
+def _cbc_roundtrip(alg, key_len, block):
+    key, iv = secrets.token_bytes(key_len), secrets.token_bytes(block)
+    data = b"SCEP degenerate pkcs7 payload " * 3
+    pad = block - (len(data) % block)
+    padded = data + bytes([pad] * pad)
+    enc = Cipher(alg(key), modes.CBC(iv)).encryptor()
+    ct = enc.update(padded) + enc.finalize()
+    dec = Cipher(alg(key), modes.CBC(iv)).decryptor()
+    pt = dec.update(ct) + dec.finalize()
+    assert pt[:-pt[-1]] == data
+
+
+def test_aes256_cbc_roundtrip():
+    _cbc_roundtrip(algorithms.AES, 32, 16)
+
+
+def test_3des_cbc_roundtrip():
+    _cbc_roundtrip(TripleDES, 24, 8)


### PR DESCRIPTION
## Problem
`services/scep/{crypto_helpers,message_parser}.py` import `Crypto` (pycryptodome /
pyCrypto namespace) for AES/3DES CBC. It is a supply-chain liability (the `Crypto` package
name is historically the abandoned pyCrypto), and `cryptography` — already a core dependency
— provides the same primitives.

## Fix
- `crypto_helpers.py`: `Crypto.Cipher.AES` (CBC encrypt) → `cryptography.hazmat.primitives.
  ciphers.Cipher(algorithms.AES(key), modes.CBC(iv)).encryptor()`.
- `message_parser.py`: `Crypto.Cipher.{DES3,AES}` (CBC decrypt) → the `cryptography` Cipher
  equivalents. `TripleDES` is imported from `cryptography.hazmat.decrepit.ciphers.algorithms`
  (cryptography 48 relocated it there); block-size literals 8 (3DES) / 16 (AES) replace the
  `DES3.block_size` / `AES.block_size` constants. PKCS#7 padding logic unchanged.
- `requirements.txt`: drop `pycryptodome==3.23.0`.

## Regression test
`tests/test_scep_crypto_migration.py` (3 tests) — an AST guard asserts no `Crypto.*` import
remains under `services/scep`, plus AES-256-CBC and 3DES-CBC encrypt→decrypt round-trips.
Interop was additionally verified byte-identical against the old pyCrypto path, and the run
is clean under `-W error::DeprecationWarning` (no decrepit-TripleDES warning leaks).

## Testing
Linux: 2257 passed, 0 new failures vs dev; the full SCEP suite (`-k scep`) = 24 passed
(these are app-fixture tests that cannot run on Windows). Largest/riskiest of the six —
protocol-critical crypto — hence its own PR, last.

## Note (merge ordering)
If NeySlim merges them in sequence, #4 and #5 both touch `ssrf_protection.py`, so whichever
lands second may need a trivial rebase.
