### PR TITLE
fix(docs): repair broken Installation Guide link in release notes

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -454,7 +454,7 @@ jobs:
           **Change the password immediately after first login!**
           
           ## Documentation
-          - [Installation Guide](docs/INSTALLATION.md)
+          - [Installation Guide](docs/installation/README.md)
           - [API Documentation](https://github.com/NeySlim/ultimate-ca-manager/wiki/API)
           
           INSTALL_EOF


### PR DESCRIPTION
## Summary

Release notes generated by `.github/workflows/build-release.yml` link to `docs/INSTALLATION.md`, which **does not exist** on `main` or `dev`.

Example (404 today): https://github.com/NeySlim/ultimate-ca-manager/blob/main/docs/INSTALLATION.md

Installation documentation lives at:
- `docs/installation/README.md` (DEB/RPM/source)
- `docs/installation/docker.md`

This affects published releases (e.g. **v2.191** release body includes the broken link).

## Fix

Update release notes template to point to `docs/installation/README.md` (consistent with root `README.md` and `docs/README.md`).

## Test plan

- [x] Verified `docs/installation/README.md` exists on `dev` and `main`
- [x] Grep: no other `docs/INSTALLATION.md` references remain