### PR TITLE
fix(security): smart-import write:cas bypass for legacy CA certs without BasicConstraints

### DIFF
--- a/backend/services/smart_import/importer.py
+++ b/backend/services/smart_import/importer.py
@@ -29,6 +29,16 @@ from utils.datetime_utils import utc_now
 logger = logging.getLogger(__name__)
 
 
+def _is_ca_import_target(obj: ParsedObject) -> bool:
+    """True when a certificate belongs in the CA import path (permission-sensitive).
+
+    BasicConstraints CA:true is the primary signal. Legacy roots sometimes omit
+    BC but still assert keyCertSign — treat those as CA material for gating and
+    routing so they cannot slip into the leaf-certificate import path.
+    """
+    return obj.is_ca or obj.key_cert_sign
+
+
 @dataclass
 class ImportResult:
     """Result of an import operation"""
@@ -128,7 +138,7 @@ class SmartImporter:
         
         # Summary
         certs = [o for o in objects if o.type == ObjectType.CERTIFICATE]
-        cas = [o for o in objects if o.type == ObjectType.CERTIFICATE and o.is_ca]
+        cas = [o for o in certs if _is_ca_import_target(o)]
         keys = [o for o in objects if o.type == ObjectType.PRIVATE_KEY]
         csrs = [o for o in objects if o.type == ObjectType.CSR]
         
@@ -238,7 +248,7 @@ class SmartImporter:
         """Import CA certificates"""
         
         # Get all CAs from objects
-        ca_objects = [o for o in objects if o.type == ObjectType.CERTIFICATE and o.is_ca]
+        ca_objects = [o for o in objects if o.type == ObjectType.CERTIFICATE and _is_ca_import_target(o)]
         
         # Sort by chain depth (roots first)
         ca_objects.sort(key=lambda o: o.chain_depth, reverse=True)
@@ -333,7 +343,7 @@ class SmartImporter:
         """Import leaf certificates"""
         
         # Get leaf certificates (not CAs)
-        cert_objects = [o for o in objects if o.type == ObjectType.CERTIFICATE and not o.is_ca]
+        cert_objects = [o for o in objects if o.type == ObjectType.CERTIFICATE and not _is_ca_import_target(o)]
         
         for cert_obj in cert_objects:
             # Check duplicate via (serial_number, issuer) + SHA-256 fingerprint (#85)

--- a/backend/services/smart_import/parser.py
+++ b/backend/services/smart_import/parser.py
@@ -44,6 +44,7 @@ class ParsedObject:
     not_before: Optional[str] = None
     not_after: Optional[str] = None
     is_ca: bool = False
+    key_cert_sign: bool = False
     is_self_signed: bool = False
     san_dns: List[str] = field(default_factory=list)
     san_ip: List[str] = field(default_factory=list)
@@ -75,6 +76,7 @@ class ParsedObject:
             "not_before": self.not_before,
             "not_after": self.not_after,
             "is_ca": self.is_ca,
+            "key_cert_sign": self.key_cert_sign,
             "is_self_signed": self.is_self_signed,
             "san_dns": self.san_dns,
             "san_ip": self.san_ip,
@@ -418,13 +420,18 @@ class SmartParser:
         obj.not_before = cert.not_valid_before_utc.isoformat() if hasattr(cert, 'not_valid_before_utc') else cert.not_valid_before.isoformat()
         obj.not_after = cert.not_valid_after_utc.isoformat() if hasattr(cert, 'not_valid_after_utc') else cert.not_valid_after.isoformat()
         
-        # Check if CA
+        # Check if CA (BasicConstraints) and CA signing capability (KeyUsage)
         try:
             basic_constraints = cert.extensions.get_extension_for_oid(ExtensionOID.BASIC_CONSTRAINTS)
             obj.is_ca = basic_constraints.value.ca
         except x509.ExtensionNotFound:
             obj.is_ca = False
-        
+        try:
+            key_usage = cert.extensions.get_extension_for_oid(ExtensionOID.KEY_USAGE)
+            obj.key_cert_sign = bool(key_usage.value.key_cert_sign)
+        except x509.ExtensionNotFound:
+            obj.key_cert_sign = False
+
         # Check if self-signed
         obj.is_self_signed = (obj.subject == obj.issuer)
         

--- a/backend/tests/test_misc_routes.py
+++ b/backend/tests/test_misc_routes.py
@@ -269,6 +269,73 @@ class TestSmartImport:
         )
         assert r.status_code != 403
 
+    def test_execute_legacy_ca_without_basic_constraints_requires_write_cas(
+        self, auth_client, app,
+    ):
+        """keyCertSign without BasicConstraints must not bypass the write:cas gate."""
+        from datetime import datetime, timedelta, timezone
+
+        from cryptography import x509
+        from cryptography.hazmat.backends import default_backend
+        from cryptography.hazmat.primitives import hashes, serialization
+        from cryptography.hazmat.primitives.asymmetric import rsa
+        from cryptography.x509.oid import ExtensionOID, NameOID
+
+        key = rsa.generate_private_key(public_exponent=65537, key_size=2048, backend=default_backend())
+        name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, 'legacy-root.example.com')])
+        now = datetime.now(timezone.utc)
+        cert = (
+            x509.CertificateBuilder()
+            .subject_name(name)
+            .issuer_name(name)
+            .public_key(key.public_key())
+            .serial_number(x509.random_serial_number())
+            .not_valid_before(now - timedelta(days=1))
+            .not_valid_after(now + timedelta(days=3650))
+            .add_extension(
+                x509.KeyUsage(
+                    digital_signature=False,
+                    content_commitment=False,
+                    key_encipherment=False,
+                    data_encipherment=False,
+                    key_agreement=False,
+                    key_cert_sign=True,
+                    crl_sign=True,
+                    encipher_only=False,
+                    decipher_only=False,
+                ),
+                critical=True,
+            )
+            .sign(key, hashes.SHA256(), default_backend())
+        )
+        cert_pem = cert.public_bytes(serialization.Encoding.PEM).decode()
+        key_pem = key.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.PKCS8,
+            encryption_algorithm=serialization.NoEncryption(),
+        ).decode()
+        bundle = cert_pem + key_pem
+
+        r = post_json(auth_client, '/api/v2/account/apikeys', {
+            'name': 'legacy-ca-bypass-test',
+            'permissions': ['read:certificates', 'write:certificates'],
+        })
+        created = assert_success(r, 201)
+        api_key = created.get('key')
+        assert api_key
+
+        client = app.test_client()
+        r = client.post(
+            '/api/v2/import/execute',
+            data=json.dumps({
+                'content': bundle,
+                'options': {'import_cas': True},
+            }),
+            content_type=CONTENT_JSON,
+            headers={'X-API-Key': api_key},
+        )
+        assert r.status_code == 403
+
 
 # ============================================================
 # Policies


### PR DESCRIPTION
## Summary

Closes an incomplete fix from #188 (GHSA-rgcp): CA material with **keyCertSign** but **no BasicConstraints** was classified as a leaf certificate, allowing callers with only `write:certificates` to import CA private keys into the `certificates` table.

## Root cause

- Permission gate in `smart_import.py` used `analysis.summary['cas']`, which only counts `BasicConstraints CA:true`.
- `_import_certificates()` imported non-`is_ca` certs with matched private keys, including legacy roots that assert `keyCertSign` without BC.

## Fix

- Parse `keyCertSign` from KeyUsage in the smart-import parser.
- Treat `is_ca OR key_cert_sign` as CA import targets for summary counting, `_import_cas()`, and `_import_certificates()` exclusion.

## Test plan

### Automated (local — green on branch `fix/smart-import-ca-gate-keycertsign`)

```bash
cd backend
pytest tests/test_misc_routes.py::TestSmartImport -x -q
# 7/7 passed (2026-07-11)
```

| Test | Expected |
|------|----------|
| `test_execute_ca_import_requires_write_cas` | API key `write:certificates` only + content with CA → **403** |
| `test_execute_cert_only_import_allowed_without_write_cas` | API key cert-only + `summary.cas=0` → **not 403** (NeySlim #188 regression guard) |
| `test_execute_ca_import_passes_permission_with_write_cas` | API key with `write:cas` + CA content → gate passes |
| `test_execute_legacy_ca_without_basic_constraints_requires_write_cas` | Self-signed RSA, **keyCertSign + crlSign**, **no BasicConstraints**, cert+key bundle, `write:certificates` only → **403** |

Related gate alignment (unchanged, sanity check):

```bash
pytest tests/test_opnsense_import.py -k write_cas -q
# passed
```

### Manual API — attack scenario (403 expected before fix, blocked after)

1. Create API key with `read:certificates`, `write:certificates` — **no** `write:cas`.
2. Build or obtain a legacy-style PEM bundle: self-signed cert with KeyUsage `keyCertSign`/`cRLSign`, **without** BasicConstraints, plus matching private key.
3. `POST /api/v2/import/execute` with `options.import_cas=true` (default).
4. **Before fix:** import succeeds; CA private key stored under `certificates` (privilege escalation).
5. **After fix:** **403** `write:cas permission required to import CAs`.

### Manual API — legitimate cert-only import (must still work)

1. Same API key (no `write:cas`).
2. Import a normal server certificate + key (KeyUsage `digitalSignature` + `keyEncipherment`, no `keyCertSign`).
3. **Expected:** import succeeds; no `write:cas` required.

### Manual API — authorized CA import

1. API key with `write:certificates` + `write:cas`.
2. Import legacy CA bundle (keyCertSign, no BC) or standard CA (BC CA:true).
3. **Expected:** CA routed to `_import_cas()` / `cas` table, not leaf `certificates` path.

### UI smoke (optional)

Settings → Import / smart import: upload legacy CA PEM+key with a cert-only role user → blocked; operator with CA permissions → succeeds.

### Out of scope / not regressed

- OPNsense import gate (`write:cas` on actual CA presence) — separate path, unchanged.
- `#188` user-search / SAML / auth-methods fixes — unrelated.