### PR TITLE
fix(hsm): fix config key mismatches in auto_register_softhsm

### DIFF
--- a/backend/services/hsm/hsm_service.py
+++ b/backend/services/hsm/hsm_service.py
@@ -582,9 +582,9 @@ class HsmService:
                 status='connected',
             )
             provider.set_config({
-                'library_path': lib_path,
+                'module_path': lib_path,
                 'token_label': 'UCM-Default',
-                'pin': pin,
+                'user_pin': pin,
             })
             db.session.add(provider)
             db.session.commit()


### PR DESCRIPTION
The auto-registered "SoftHSM-Default" provider never works because the config keys don't match what `PKCS11Provider` actually reads.

`PKCS11Provider.__init__` expects `module_path` and `user_pin`, but `auto_register_softhsm` was writing `library_path` and `pin`. So any attempt to test the connection or use the provider would immediately blow up with validation errors.

Two-line fix — just renamed the keys to match the provider's expectations. Tested locally, the default SoftHSM provider now connects successfully after a fresh deploy.
