### PR TITLE
fix(docker): persist SoftHSM tokens across container re-creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ Starting with v2.48, UCM uses Major.Build versioning (e.g., 2.48, 2.49). Earlier
 
 ## [Unreleased]
 
+### Fixed
+- **SoftHSM token persistence in Docker Compose** — `docker-compose.yml` and `docker-compose.simple.yml` now mount `ucm-hsm-tokens:/var/lib/softhsm/tokens` like `docker-compose.hsm.yml` already did. Without it, the token auto-initialized by the entrypoint was lost on container re-creation, orphaning the `SoftHSM-Default` provider row and any keys stored under it. (#195)
+
 ## [2.192] - 2026-07-11
 
 ### Security

--- a/docker-compose.simple.yml
+++ b/docker-compose.simple.yml
@@ -9,6 +9,9 @@ services:
       - 8080:8080
     volumes:
       - ucm-data:/opt/ucm/data
+      - ucm-hsm-tokens:/var/lib/softhsm/tokens
 volumes:
   ucm-data:
     name: ucm-data
+  ucm-hsm-tokens:
+    name: ucm-hsm-tokens

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,12 @@ services:
     volumes:
       # Persistent data volume (REQUIRED)
       - ucm-data:/opt/ucm/data
-      
+
+      # SoftHSM token storage (the entrypoint auto-initializes a token on
+      # first boot; without this volume it is lost when the container is
+      # re-created, orphaning the SoftHSM-Default provider and its keys)
+      - ucm-hsm-tokens:/var/lib/softhsm/tokens
+
       # Optional: Custom configuration
       # - ./.env:/opt/ucm/.env.custom:ro
       
@@ -151,4 +156,6 @@ networks:
 
 volumes:
   ucm-data:
+    driver: local
+  ucm-hsm-tokens:
     driver: local


### PR DESCRIPTION
## Summary

The Docker entrypoint auto-initializes a SoftHSM token on first boot (`HSM_AUTO_INIT` defaults to `true`) and `auto_register_softhsm()` creates the matching `SoftHSM-Default` provider row — but `docker-compose.yml` and `docker-compose.simple.yml` did not mount `/var/lib/softhsm/tokens`, so the token (and any keys under it) was lost whenever the container was re-created, leaving an orphaned provider row.

`docker-compose.hsm.yml` already mounts `ucm-hsm-tokens:/var/lib/softhsm/tokens`; this brings the main and simple compose files in line.

Fixes #195.

## Changes

- `docker-compose.yml`: add `ucm-hsm-tokens` named volume + mount (with a comment explaining why)
- `docker-compose.simple.yml`: same mount
- CHANGELOG entry under Unreleased

## Test plan

- [x] `docker compose config` passes for `docker-compose.yml`, `docker-compose.simple.yml`, and the `docker-compose.yml` + `docker-compose.prod.yml` overlay
- [x] E2E on a Docker host: fresh `up -d` initializes the `UCM-Default` token in the named volume; after two `up -d --force-recreate` cycles the token survives with the same serial number
