### PR TITLE
docs(acme,hsm): document preferred_chain and PKCS#11 legacy normalization

### DIFF
--- a/docs/ADMIN_GUIDE.md
+++ b/docs/ADMIN_GUIDE.md
@@ -376,6 +376,29 @@ View ACME accounts and orders in the ACME page, or via API:
 curl -k -b cookies.txt https://localhost:8443/api/v2/acme/accounts
 ```
 
+### ACME client accounts — `preferred_chain` (chaînes RFC 8555 / alternates)
+
+UCM peut choisir une chaîne *alternate* annoncée par le CA via `Link: rel="alternate"` (RFC 8555 §7.4.2). Ce choix est piloté par le champ `preferred_chain` sur les **ACME client accounts**.
+
+**Que mettre dans `preferred_chain` ?**
+- Le **CN du trust anchor** au bas de la chaîne visée (ex. `ISRG Root X1` pour Let’s Encrypt gen-Y).
+- Comparaison **case-insensitive** sur le **CN du dernier certificat** fourni dans le PEM : match sur le **subject CN** *ou* sur le **issuer CN** (utile quand le CA “shortens” et **omet le root**).
+
+**Contraintes / sémantique**
+- Longueur max : **255** caractères.
+- Valeur vide (`""`) / non renseignée : UCM conserve la chaîne **default** de la CA (comportement inchangé).
+
+**Portée (client + proxy)**
+- Le même registre (`AcmeClientAccount`) alimente à la fois le client ACME et le **proxy ACME**.
+
+**API (exemple)**
+- Mise à jour via `PATCH /api/v2/acme/client/accounts/<id>` (nécessite `write:acme`) :
+```bash
+curl -k -X PATCH -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  -d '{"preferred_chain":"ISRG Root X1"}' \
+  https://localhost:8443/api/v2/acme/client/accounts/<id>
+```
+
 ### SCEP Administration
 
 View pending SCEP requests in the SCEP page, or via API:

--- a/docs/ADMIN_GUIDE.md
+++ b/docs/ADMIN_GUIDE.md
@@ -376,23 +376,23 @@ View ACME accounts and orders in the ACME page, or via API:
 curl -k -b cookies.txt https://localhost:8443/api/v2/acme/accounts
 ```
 
-### ACME client accounts — `preferred_chain` (chaînes RFC 8555 / alternates)
+### ACME client accounts — `preferred_chain` (RFC 8555 alternate chains)
 
-UCM peut choisir une chaîne *alternate* annoncée par le CA via `Link: rel="alternate"` (RFC 8555 §7.4.2). Ce choix est piloté par le champ `preferred_chain` sur les **ACME client accounts**.
+UCM can select an *alternate* chain advertised by the CA via `Link: rel="alternate"` (RFC 8555 §7.4.2). This choice is driven by the `preferred_chain` field on **ACME client accounts**.
 
-**Que mettre dans `preferred_chain` ?**
-- Le **CN du trust anchor** au bas de la chaîne visée (ex. `ISRG Root X1` pour Let’s Encrypt gen-Y).
-- Comparaison **case-insensitive** sur le **CN du dernier certificat** fourni dans le PEM : match sur le **subject CN** *ou* sur le **issuer CN** (utile quand le CA “shortens” et **omet le root**).
+**What to put in `preferred_chain`**
+- The **trust anchor CN** at the bottom of the target chain (e.g. `ISRG Root X1` for Let's Encrypt gen-Y).
+- **Case-insensitive** comparison on the **last certificate's CN** in the PEM: match on **subject CN** *or* **issuer CN** (useful when the CA "shortens" the chain and **omits the root**).
 
-**Contraintes / sémantique**
-- Longueur max : **255** caractères.
-- Valeur vide (`""`) / non renseignée : UCM conserve la chaîne **default** de la CA (comportement inchangé).
+**Constraints / semantics**
+- Maximum length: **255** characters.
+- Empty value (`""`) or unset: UCM keeps the CA's **default** chain (unchanged behavior).
 
-**Portée (client + proxy)**
-- Le même registre (`AcmeClientAccount`) alimente à la fois le client ACME et le **proxy ACME**.
+**Scope (client + proxy)**
+- The same registry (`AcmeClientAccount`) backs both the ACME client and the **ACME proxy**.
 
-**API (exemple)**
-- Mise à jour via `PATCH /api/v2/acme/client/accounts/<id>` (nécessite `write:acme`) :
+**API (example)**
+- Update via `PATCH /api/v2/acme/client/accounts/<id>` (requires `write:acme`):
 ```bash
 curl -k -X PATCH -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
   -d '{"preferred_chain":"ISRG Root X1"}' \

--- a/docs/HSM_DOCKER.md
+++ b/docs/HSM_DOCKER.md
@@ -12,20 +12,21 @@ On first start, a default SoftHSM token (`UCM-Default`) is automatically initial
 
 **Auto-registration:** UCM automatically creates an `SoftHSM-Default` provider in the database when it detects the Docker entrypoint initialized a token (`HSM_DEFAULT_PIN` env var). The provider appears immediately in the HSM page — no manual setup needed.
 
-## Normalisation des clés PKCS#11 legacy (upgrade)
+## Legacy PKCS#11 key normalization (upgrade)
 
-Lors de l’upgrade, UCM assure la compatibilité des providers PKCS#11 créés par les anciens chemins de config :
+On upgrade, UCM maintains compatibility for PKCS#11 providers created by older configuration paths:
 
-- Legacy : `library_path` / `pin`
-- Canonique : `module_path` / `user_pin`
+- Legacy: `library_path` / `pin`
+- Canonical: `module_path` / `user_pin`
 
-Le processus se fait à trois niveaux :
+Normalization runs at three levels:
 
-1. **Migration 057** : réécriture automatique des champs JSON legacy dans toutes les lignes `pkcs11` de `hsm_providers`.
-2. **Startup repair** : si la ligne `SoftHSM-Default` existe déjà, UCM normalise aussi sa configuration au démarrage.
-3. **Fallback runtime** : `PKCS11Provider` accepte les alias legacy à la lecture (avant validation).
+1. **Migration 057** — automatically rewrites legacy JSON fields in all `pkcs11` rows in `hsm_providers`.
+2. **Startup repair** — if the `SoftHSM-Default` row already exists, UCM normalizes its configuration at startup as well.
+3. **Runtime fallback** — `PKCS11Provider` accepts legacy aliases on read (before validation).
 
-**Conséquence attendue :** après upgrade, le provider `SoftHSM-Default` ne doit plus échouer sur un test de connexion (pas d’erreur du type `module_path is required`) et l’UI doit afficher `module_path` / `user_pin`.
+**Expected outcome:** after upgrade, the `SoftHSM-Default` provider should no longer fail a connection test (no `module_path is required` error) and the UI should show `module_path` / `user_pin`.
+
 
 ## Persistent Tokens
 

--- a/docs/HSM_DOCKER.md
+++ b/docs/HSM_DOCKER.md
@@ -12,6 +12,21 @@ On first start, a default SoftHSM token (`UCM-Default`) is automatically initial
 
 **Auto-registration:** UCM automatically creates an `SoftHSM-Default` provider in the database when it detects the Docker entrypoint initialized a token (`HSM_DEFAULT_PIN` env var). The provider appears immediately in the HSM page — no manual setup needed.
 
+## Normalisation des clés PKCS#11 legacy (upgrade)
+
+Lors de l’upgrade, UCM assure la compatibilité des providers PKCS#11 créés par les anciens chemins de config :
+
+- Legacy : `library_path` / `pin`
+- Canonique : `module_path` / `user_pin`
+
+Le processus se fait à trois niveaux :
+
+1. **Migration 057** : réécriture automatique des champs JSON legacy dans toutes les lignes `pkcs11` de `hsm_providers`.
+2. **Startup repair** : si la ligne `SoftHSM-Default` existe déjà, UCM normalise aussi sa configuration au démarrage.
+3. **Fallback runtime** : `PKCS11Provider` accepte les alias legacy à la lecture (avant validation).
+
+**Conséquence attendue :** après upgrade, le provider `SoftHSM-Default` ne doit plus échouer sur un test de connexion (pas d’erreur du type `module_path is required`) et l’UI doit afficher `module_path` / `user_pin`.
+
 ## Persistent Tokens
 
 Mount a volume for `/var/lib/softhsm/tokens` to keep HSM keys across container restarts:

--- a/docs/testing/ACME-PROXY-MULTI-CA.md
+++ b/docs/testing/ACME-PROXY-MULTI-CA.md
@@ -79,6 +79,16 @@ cd /opt/ucm/backend && runuser -u ucm -- /opt/ucm/venv/bin/python -m pytest test
 2. Confirmer → `account_url` / clé effacés sur le compte lié
 3. Ré-enregistrer possible
 
+### 7. `preferred_chain` (alternate chains) — optionnel
+
+1. Dans **Comptes CA externes**, éditez le compte CA que vous utilisez pour le proxy (ex. Let’s Encrypt).
+2. Dans le champ **Preferred chain**, saisissez le **CN du trust anchor** (ex. `ISRG Root X1`).
+   - Le match UCM est **case-insensitive** et se fait sur le **CN du dernier certificat** fourni dans le PEM : **subject CN** *ou* **issuer CN** (support des chaînes “short” où le root est omis).
+3. Émettez un certificat via Certbot sur `/acme/proxy/<slug>/directory`.
+4. Vérifiez la chaîne retournée : contrôlez que le **subject CN** *ou* l’**issuer CN** du **dernier certificat** vaut `ISRG Root X1`.
+   - Par exemple (si vous disposez d’un fichier de chaîne type `chain.pem`) :
+     `openssl storeutl -noout -text -certs chain.pem | grep -A1 'Subject:' | tail -2`
+
 ## Tests manuels — API
 
 ```bash


### PR DESCRIPTION
This doc-only PR updates runbooks/guides to reflect recent behavior changes:

1) ACME `preferred_chain` (RFC 8555 alternate chains): matching is case-insensitive on the subject OR issuer CN of the last cert; empty keeps the CA default; field applies to client + proxy.
2) HSM (SoftHSM / PKCS#11): describe legacy JSON key normalization `library_path`/`pin` -> `module_path`/`user_pin` (Migration 057 + startup repair + runtime fallback).

Files updated:
- docs/ADMIN_GUIDE.md
- docs/testing/ACME-PROXY-MULTI-CA.md
- docs/HSM_DOCKER.md
