### PR TITLE
fix(acme): allow HSM-backed CAs in local domain mapping (#142 follow-up)

### DIFF
--- a/backend/api/v2/acme_local_domains.py
+++ b/backend/api/v2/acme_local_domains.py
@@ -54,7 +54,7 @@ def create_local_domain():
     ca = db.session.get(CA, issuing_ca_id)
     if not ca:
         return error_response('Issuing CA not found', 404)
-    if not ca.prv:
+    if not ca.has_private_key:
         return error_response('Selected CA has no private key', 400)
     
     existing = AcmeLocalDomain.query.filter_by(domain=domain_name).first()
@@ -103,7 +103,7 @@ def update_local_domain(domain_id):
         ca = db.session.get(CA, data['issuing_ca_id'])
         if not ca:
             return error_response('Issuing CA not found', 404)
-        if not ca.prv:
+        if not ca.has_private_key:
             return error_response('Selected CA has no private key', 400)
         domain.issuing_ca_id = data['issuing_ca_id']
     

--- a/backend/tests/test_issue_142_hsm_cert_issuance.py
+++ b/backend/tests/test_issue_142_hsm_cert_issuance.py
@@ -12,6 +12,7 @@ Covers the certificate-issuance paths touched by the fix:
   - POST /api/v2/certificates/<id>/renew
   - bulk CSR signing gate (csrs.py)
   - ACME domain issuing-CA selector gate (acme_domains.py)
+  - ACME local domain issuing-CA selector gate (acme_local_domains.py)
 """
 import json
 import os
@@ -230,6 +231,20 @@ class TestIssue142GatePaths:
             data=json.dumps({
                 'domain': 'hsm-142-issuer.test',
                 'dns_provider_id': dp_id,
+                'issuing_ca_id': ca_id,
+            }),
+            content_type='application/json')
+        assert r.status_code in (200, 201), r.data
+        assert b'no private key' not in r.data.lower(), r.data
+
+    def test_acme_local_domain_issuing_ca_selector_accepts_hsm_ca(
+            self, app, auth_client, hsm_provider_and_key):
+        """acme_local_domains.py gate must allow selecting an HSM-backed issuing CA."""
+        ca_id = _make_hsm_ca(app, hsm_provider_and_key)
+        r = auth_client.post(
+            '/api/v2/acme/local-domains',
+            data=json.dumps({
+                'domain': 'hsm-142-local-issuer.test',
                 'issuing_ca_id': ca_id,
             }),
             content_type='application/json')


### PR DESCRIPTION
## Summary

Fixes a regression from #142: `POST/PUT /api/v2/acme/local-domains` rejected HSM-backed CAs with "Selected CA has no private key" because the gate checked `ca.prv` instead of `ca.has_private_key`.

## Root cause

#142 aligned ACME DNS domain mapping (`acme_domains.py`) and issuance paths with `has_private_key`, but `acme_local_domains.py` was missed.

## Impact

Multi-CA Local ACME deployments using HSM signing keys could not assign per-domain issuing CAs via the API/UI. Issuance could fall back to the global default or another CA, breaking intended trust boundaries.

## Test plan

- [x] `pytest tests/test_issue_142_hsm_cert_issuance.py::TestIssue142GatePaths::test_acme_local_domain_issuing_ca_selector_accepts_hsm_ca`
- [x] `pytest tests/test_acme.py::TestAcmeLocalDomainsCRUD` (20 tests)

## Related

- #142 — original HSM issuance gate fix
- Parity with `acme_domains.py` issuing-CA validation

## Out of scope

- Global ACME settings PATCH CA validation (separate follow-up if desired)
