### PR TITLE
fix(crl): RFC 5280 IDP parity, FreshestCRL guard, reasonCode hygiene

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,7 @@ data/
 CLAUDE.md
 backend/static/
 SECURITY_AUDIT.md
+
+# Local lab secrets (OpenSSL / create_app)
+.env.lab
+.env*.local

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,11 @@ Starting with v2.48, UCM uses Major.Build versioning (e.g., 2.48, 2.49). Earlier
 
 ### Fixed
 - **CRL Authority Key Identifier (RFC 5280 §5.2.1)** — full and delta CRLs now set AKI from the issuing CA's Subject Key Identifier (with public-key fallback if SKI is absent), instead of copying the CA certificate's AKI (which points at the parent for intermediates). Clients that match CRL AKI to the signing CA SKI no longer reject intermediate CRLs. (#202)
+- **CRL RFC 5280 profile follow-up** — omit `IssuingDistributionPoint` on delta CRLs so base+delta both omit IDP (§5.2.4); guard `FreshestCRL` so missing CDP no longer raises (§5.2.6); omit `unspecified` reasonCode and restrict `removeFromCRL` to delta CRLs (§5.3.1); shared AKI helper; accurate `revoked_count`.
 
 ### Tests
 - Regression coverage for #202: intermediate full/delta CRL AKI≠parent, root CRL, SKI-missing fallback, and unauthenticated regenerate gates.
+- RFC 5280 CRL profile suite: IDP parity, FreshestCRL, reasonCode, AKI smoke, auth gates, openssl lab text dump.
 
 ## [2.193] - 2026-07-17
 

--- a/backend/services/crl/generation.py
+++ b/backend/services/crl/generation.py
@@ -2,6 +2,7 @@ import base64
 import logging
 from datetime import timedelta
 from typing import Optional
+from urllib.parse import urlparse
 
 from cryptography import x509
 from cryptography.hazmat.primitives import hashes, serialization
@@ -16,6 +17,96 @@ from ._constants import REASON_MAP
 from .query import CRLQueryMixin
 
 logger = logging.getLogger(__name__)
+
+
+def _authority_key_identifier_for_crl(ca_cert: x509.Certificate) -> x509.AuthorityKeyIdentifier:
+    """RFC 5280 §5.2.1 — CRL AKI must identify the signing CA key (its SKI)."""
+    try:
+        ski = ca_cert.extensions.get_extension_for_oid(
+            ExtensionOID.SUBJECT_KEY_IDENTIFIER
+        )
+        return x509.AuthorityKeyIdentifier.from_issuer_subject_key_identifier(ski.value)
+    except x509.ExtensionNotFound:
+        return x509.AuthorityKeyIdentifier.from_issuer_public_key(ca_cert.public_key())
+
+
+def _apply_revoke_reason(
+    revoked_builder: x509.RevokedCertificateBuilder,
+    revoke_reason: Optional[str],
+    *,
+    is_delta: bool,
+) -> x509.RevokedCertificateBuilder:
+    """Attach CRLReason when RFC-conformant.
+
+    RFC 5280 §5.3.1:
+    - omit the extension instead of emitting ``unspecified``
+    - ``removeFromCRL`` may only appear on delta CRLs
+    """
+    if not revoke_reason:
+        return revoked_builder
+
+    if revoke_reason == 'unspecified':
+        return revoked_builder
+
+    if revoke_reason == 'removeFromCRL' and not is_delta:
+        logger.warning(
+            "CRL: omitting removeFromCRL reason on full CRL (RFC 5280 §5.3.1 — delta only)"
+        )
+        return revoked_builder
+
+    reason = REASON_MAP.get(revoke_reason)
+    if reason is None or reason is x509.ReasonFlags.unspecified:
+        logger.warning(f"CRL: omitting unknown/unspecified revoke_reason={revoke_reason!r}")
+        return revoked_builder
+
+    return revoked_builder.add_extension(x509.CRLReason(reason), critical=False)
+
+
+def _add_freshest_crl(builder: x509.CertificateRevocationListBuilder, ca: CA):
+    """RFC 5280 §5.2.6 — non-critical pointer to the delta CRL (complete CRLs only)."""
+    if not ca.delta_crl_enabled:
+        return builder
+
+    primary_cdp = ca.get_primary_cdp_url()
+    if not primary_cdp:
+        return builder
+
+    try:
+        parsed = urlparse(primary_cdp.replace('{ca_refid}', ca.refid))
+        delta_url = f"{parsed.scheme}://{parsed.netloc}/cdp/{ca.refid}-delta.crl"
+        return builder.add_extension(
+            x509.FreshestCRL([
+                x509.DistributionPoint(
+                    full_name=[x509.UniformResourceIdentifier(delta_url)],
+                    relative_name=None,
+                    reasons=None,
+                    crl_issuer=None,
+                )
+            ]),
+            critical=False,
+        )
+    except Exception as e:
+        logger.warning(f"Could not add FreshestCRL extension: {e}")
+        return builder
+
+
+def _parse_revoked_serial(cert: Certificate, *, context: str) -> Optional[int]:
+    if not cert.serial_number:
+        return None
+    serial_int = serial_to_int(cert.serial_number)
+    if serial_int is None or serial_int <= 0:
+        logger.warning(
+            f"{context}: skipping cert {cert.id} with unparseable serial {cert.serial_number!r}"
+        )
+        return None
+    if serial_int.bit_length() > 159:
+        # RFC 5280 §4.1.2.2 caps serials at 20 octets (≤159 bits effective).
+        logger.error(
+            f"{context}: cert {cert.id} serial exceeds 159 bits "
+            f"({serial_int.bit_length()} bits); skipping — revocation NOT in CRL"
+        )
+        return None
+    return serial_int
 
 
 class CRLGenerationMixin:
@@ -54,74 +145,28 @@ class CRLGenerationMixin:
         builder = builder.last_update(now)
         builder = builder.next_update(now + timedelta(days=validity_days))
 
+        entries = 0
         for cert in revoked_certs:
-            if not cert.serial_number:
-                continue
-
-            serial_int = serial_to_int(cert.serial_number)
-            if serial_int is None or serial_int <= 0:
-                logger.warning(f"CRL: skipping cert {cert.id} with unparseable serial {cert.serial_number!r}")
-                continue
-            if serial_int.bit_length() > 159:
-                # RFC 5280 §4.1.2.2 caps serials at 20 octets (≤159 bits effective).
-                # A cert issued above this bound is itself non-conformant; we cannot
-                # safely truncate (it would change the identity), so skip and log.
-                logger.error(
-                    f"CRL: cert {cert.id} serial exceeds 159 bits "
-                    f"({serial_int.bit_length()} bits); skipping — revocation NOT in CRL"
-                )
+            serial_int = _parse_revoked_serial(cert, context='CRL')
+            if serial_int is None:
                 continue
 
             revoked_builder = x509.RevokedCertificateBuilder()
             revoked_builder = revoked_builder.serial_number(serial_int)
             revoked_builder = revoked_builder.revocation_date(cert.revoked_at or now)
-
-            if cert.revoke_reason:
-                reason = REASON_MAP.get(cert.revoke_reason, x509.ReasonFlags.unspecified)
-                revoked_builder = revoked_builder.add_extension(
-                    x509.CRLReason(reason),
-                    critical=False
-                )
-
-            builder = builder.add_revoked_certificate(revoked_builder.build())
-
-        builder = builder.add_extension(
-            x509.CRLNumber(crl_number),
-            critical=False
-        )
-
-        # RFC 5280 5.2.1: the CRL AKI must identify the key that signs the
-        # CRL, i.e. the issuing CA's own key (its SKI), not the AKI of its
-        # certificate (which points to the parent CA for intermediates).
-        try:
-            ski = ca_cert.extensions.get_extension_for_oid(
-                ExtensionOID.SUBJECT_KEY_IDENTIFIER
+            revoked_builder = _apply_revoke_reason(
+                revoked_builder, cert.revoke_reason, is_delta=False
             )
-            aki = x509.AuthorityKeyIdentifier.from_issuer_subject_key_identifier(ski.value)
-        except x509.ExtensionNotFound:
-            aki = x509.AuthorityKeyIdentifier.from_issuer_public_key(ca_cert.public_key())
-        builder = builder.add_extension(aki, critical=False)
+            builder = builder.add_revoked_certificate(revoked_builder.build())
+            entries += 1
 
-        if ca.delta_crl_enabled:
-            primary_cdp = ca.get_primary_cdp_url()
-            if primary_cdp:
-                from urllib.parse import urlparse
-                parsed = urlparse(primary_cdp.replace('{ca_refid}', ca.refid))
-                delta_url = f"{parsed.scheme}://{parsed.netloc}/cdp/{ca.refid}-delta.crl"
-            try:
-                builder = builder.add_extension(
-                    x509.FreshestCRL([
-                        x509.DistributionPoint(
-                            full_name=[x509.UniformResourceIdentifier(delta_url)],
-                            relative_name=None,
-                            reasons=None,
-                            crl_issuer=None
-                        )
-                    ]),
-                    critical=False
-                )
-            except Exception as e:
-                logger.warning(f"Could not add FreshestCRL extension: {e}")
+        builder = builder.add_extension(x509.CRLNumber(crl_number), critical=False)
+        builder = builder.add_extension(
+            _authority_key_identifier_for_crl(ca_cert), critical=False
+        )
+        # RFC 5280 §5.2.4: base and delta MUST both omit IDP or carry identical IDP.
+        # UCM issues unpartitioned CRLs — omit IDP on both full and delta.
+        builder = _add_freshest_crl(builder, ca)
 
         crl = builder.sign(ca_private_key, hashes.SHA256(), default_backend())
 
@@ -135,7 +180,7 @@ class CRLGenerationMixin:
             next_update=now + timedelta(days=validity_days),
             crl_pem=crl_pem,
             crl_der=crl_der,
-            revoked_count=len(revoked_certs),
+            revoked_count=entries,
             generated_by=username,
             is_delta=False,
             base_crl_number=None
@@ -144,16 +189,21 @@ class CRLGenerationMixin:
         db.session.add(crl_metadata)
 
         from services.audit_service import AuditService
-        AuditService.log_ca('generate_crl', ca,
-                            f"Generated CRL #{crl_number} for CA {ca.descr} with "
-                            f"{len(revoked_certs)} revoked certificates",
-                            username=username)
+        AuditService.log_ca(
+            'generate_crl', ca,
+            f"Generated CRL #{crl_number} for CA {ca.descr} with "
+            f"{entries} revoked certificates",
+            username=username,
+        )
 
         try:
             db.session.commit()
         except Exception as _commit_err:
             db.session.rollback()
-            logger.error(f"Commit failed in services/crl/generation.py:155: {_commit_err}", exc_info=True)
+            logger.error(
+                f"Commit failed in services/crl/generation.py: {_commit_err}",
+                exc_info=True,
+            )
             raise
 
         return crl_metadata
@@ -206,69 +256,29 @@ class CRLGenerationMixin:
         builder = builder.last_update(now)
         builder = builder.next_update(now + timedelta(hours=validity_hours))
 
+        entries = 0
         for cert in revoked_certs:
-            if not cert.serial_number:
-                continue
-            serial_int = serial_to_int(cert.serial_number)
-            if serial_int is None or serial_int <= 0:
-                logger.warning(f"Delta CRL: skipping cert {cert.id} with unparseable serial {cert.serial_number!r}")
-                continue
-            if serial_int.bit_length() > 159:
-                logger.error(
-                    f"Delta CRL: cert {cert.id} serial exceeds 159 bits; skipping — revocation NOT in delta CRL"
-                )
+            serial_int = _parse_revoked_serial(cert, context='Delta CRL')
+            if serial_int is None:
                 continue
 
             revoked_builder = x509.RevokedCertificateBuilder()
             revoked_builder = revoked_builder.serial_number(serial_int)
             revoked_builder = revoked_builder.revocation_date(cert.revoked_at or now)
-
-            if cert.revoke_reason:
-                reason = REASON_MAP.get(cert.revoke_reason, x509.ReasonFlags.unspecified)
-                revoked_builder = revoked_builder.add_extension(
-                    x509.CRLReason(reason), critical=False
-                )
-
+            revoked_builder = _apply_revoke_reason(
+                revoked_builder, cert.revoke_reason, is_delta=True
+            )
             builder = builder.add_revoked_certificate(revoked_builder.build())
+            entries += 1
 
-        builder = builder.add_extension(
-            x509.CRLNumber(crl_number), critical=False
-        )
-
+        builder = builder.add_extension(x509.CRLNumber(crl_number), critical=False)
         builder = builder.add_extension(
             x509.DeltaCRLIndicator(base_crl.crl_number), critical=True
         )
-
-        primary_cdp = ca.get_primary_cdp_url()
-        if primary_cdp:
-            try:
-                cdp_resolved = primary_cdp.replace('{ca_refid}', ca.refid)
-                builder = builder.add_extension(
-                    x509.IssuingDistributionPoint(
-                        full_name=[x509.UniformResourceIdentifier(cdp_resolved)],
-                        relative_name=None,
-                        only_contains_user_certs=False,
-                        only_contains_ca_certs=False,
-                        only_some_reasons=None,
-                        indirect_crl=False,
-                        only_contains_attribute_certs=False
-                    ),
-                    critical=True
-                )
-            except Exception as e:
-                logger.warning(f"Could not add IssuingDistributionPoint to delta CRL: {e}")
-
-        # RFC 5280 5.2.1: the CRL AKI must identify the key that signs the
-        # CRL, i.e. the issuing CA's own key (its SKI), not the AKI of its
-        # certificate (which points to the parent CA for intermediates).
-        try:
-            ski = ca_cert.extensions.get_extension_for_oid(
-                ExtensionOID.SUBJECT_KEY_IDENTIFIER
-            )
-            aki = x509.AuthorityKeyIdentifier.from_issuer_subject_key_identifier(ski.value)
-        except x509.ExtensionNotFound:
-            aki = x509.AuthorityKeyIdentifier.from_issuer_public_key(ca_cert.public_key())
-        builder = builder.add_extension(aki, critical=False)
+        # No IssuingDistributionPoint — must match the base CRL (both omit).
+        builder = builder.add_extension(
+            _authority_key_identifier_for_crl(ca_cert), critical=False
+        )
 
         crl = builder.sign(ca_private_key, hashes.SHA256(), default_backend())
 
@@ -283,7 +293,7 @@ class CRLGenerationMixin:
                 next_update=now + timedelta(hours=validity_hours),
                 crl_pem=crl_pem,
                 crl_der=crl_der,
-                revoked_count=len(revoked_certs),
+                revoked_count=entries,
                 generated_by=username,
                 is_delta=True,
                 base_crl_number=base_crl.crl_number
@@ -292,17 +302,21 @@ class CRLGenerationMixin:
             db.session.add(crl_metadata)
 
             from services.audit_service import AuditService
-            AuditService.log_ca('generate_delta_crl', ca,
-                                f"Generated delta CRL #{crl_number} (base #{base_crl.crl_number}) "
-                                f"with {len(revoked_certs)} new revocations",
-                                username=username)
+            AuditService.log_ca(
+                'generate_delta_crl', ca,
+                f"Generated delta CRL #{crl_number} (base #{base_crl.crl_number}) "
+                f"with {entries} new revocations",
+                username=username,
+            )
 
             db.session.commit()
         except Exception:
             db.session.rollback()
             raise
 
-        logger.info(f"Generated delta CRL #{crl_number} for CA {ca.descr} "
-                    f"(base #{base_crl.crl_number}, {len(revoked_certs)} entries)")
+        logger.info(
+            f"Generated delta CRL #{crl_number} for CA {ca.descr} "
+            f"(base #{base_crl.crl_number}, {entries} entries)"
+        )
 
         return crl_metadata

--- a/backend/tests/test_crl_rfc5280_profile.py
+++ b/backend/tests/test_crl_rfc5280_profile.py
@@ -1,0 +1,335 @@
+"""
+RFC 5280 CRL profile follow-up — non-regression, bug, security, lab checks.
+
+Covers gaps beyond #202 (AKI):
+  §5.2.4  base+delta IDP must both omit or be identical (UCM omits both)
+  §5.2.6  FreshestCRL only when CDP present; never raises on missing CDP
+  §5.3.1  omit unspecified; removeFromCRL delta-only
+  §5.2.1  AKI still == signing CA SKI (smoke)
+  Auth     regenerate endpoints require authentication
+"""
+import base64
+import json
+import os
+import sys
+from datetime import timedelta
+
+from cryptography import x509
+from cryptography.hazmat.backends import default_backend
+from cryptography.x509.oid import CRLEntryExtensionOID, ExtensionOID
+
+from tests.conftest import assert_success, get_json
+from utils.datetime_utils import utc_now
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+CONTENT_JSON = 'application/json'
+CRL_BASE = '/api/v2/crl'
+
+
+def _post_json(client, url, data):
+    return client.post(url, data=json.dumps(data), content_type=CONTENT_JSON)
+
+
+def _ext_or_none(obj, oid):
+    try:
+        return obj.extensions.get_extension_for_oid(oid)
+    except x509.ExtensionNotFound:
+        return None
+
+
+def _load_crl(pem: str):
+    return x509.load_pem_x509_crl(
+        pem.encode() if isinstance(pem, str) else pem,
+        default_backend(),
+    )
+
+
+def _fetch_crl_pem(auth_client, ca_id, *, delta=False):
+    url = f'{CRL_BASE}/{ca_id}/delta' if delta else f'{CRL_BASE}/{ca_id}'
+    r = auth_client.get(url)
+    assert r.status_code == 200, r.data
+    data = get_json(r).get('data', get_json(r))
+    assert data and data.get('crl_pem'), data
+    return data['crl_pem']
+
+
+def _enable_delta(app, ca_id):
+    with app.app_context():
+        from models import CA, db
+        ca = db.session.get(CA, ca_id)
+        ca.cdp_enabled = True
+        ca.delta_crl_enabled = True
+        ca.set_cdp_urls([f'http://cdp.test.local/cdp/{ca.refid}.crl'])
+        db.session.commit()
+        return ca.refid
+
+
+def _make_intermediate(auth_client, create_ca, cn_root, cn_int):
+    root = create_ca(cn=cn_root)
+    r = _post_json(auth_client, '/api/v2/cas', {
+        'type': 'intermediate',
+        'commonName': cn_int,
+        'organization': 'Test Org',
+        'country': 'US',
+        'state': 'CA',
+        'locality': 'Test City',
+        'keyType': 'RSA',
+        'keySize': 2048,
+        'validityYears': 5,
+        'hashAlgorithm': 'sha256',
+        'parentCAId': root['id'],
+    })
+    return root, assert_success(r, status=201)
+
+
+def _issue_and_revoke(auth_client, ca_id, cn, reason):
+    r = _post_json(auth_client, '/api/v2/certificates', {
+        'cn': cn,
+        'ca_id': ca_id,
+        'validity_days': 30,
+    })
+    cert = assert_success(r, status=201)
+    r = _post_json(auth_client, f'/api/v2/certificates/{cert["id"]}/revoke', {
+        'reason': reason,
+    })
+    assert r.status_code in (200, 201), r.data
+    return cert
+
+
+class TestRfc5280IdpParity:
+    """§5.2.4 — base and delta must both omit IDP or carry identical IDP."""
+
+    def test_full_and_delta_both_omit_idp(self, app, auth_client, create_ca):
+        ca = create_ca(cn='IDP Parity CA')
+        _enable_delta(app, ca['id'])
+
+        assert auth_client.post(f'{CRL_BASE}/{ca["id"]}/regenerate').status_code == 200
+        assert auth_client.post(f'{CRL_BASE}/{ca["id"]}/delta/regenerate').status_code == 200
+
+        full = _load_crl(_fetch_crl_pem(auth_client, ca['id']))
+        delta = _load_crl(_fetch_crl_pem(auth_client, ca['id'], delta=True))
+
+        assert _ext_or_none(full, ExtensionOID.ISSUING_DISTRIBUTION_POINT) is None
+        assert _ext_or_none(delta, ExtensionOID.ISSUING_DISTRIBUTION_POINT) is None
+        assert _ext_or_none(delta, ExtensionOID.DELTA_CRL_INDICATOR) is not None
+
+
+class TestRfc5280FreshestCrl:
+    """§5.2.6 — FreshestCRL on complete CRL when delta+CDP configured."""
+
+    def test_freshest_crl_present_when_delta_and_cdp(self, app, auth_client, create_ca):
+        ca = create_ca(cn='Freshest CDP CA')
+        refid = _enable_delta(app, ca['id'])
+        assert auth_client.post(f'{CRL_BASE}/{ca["id"]}/regenerate').status_code == 200
+
+        full = _load_crl(_fetch_crl_pem(auth_client, ca['id']))
+        freshest = _ext_or_none(full, ExtensionOID.FRESHEST_CRL)
+        assert freshest is not None
+        assert freshest.critical is False
+        uris = [
+            n.value
+            for dp in freshest.value
+            for n in (dp.full_name or [])
+        ]
+        assert any(refid in u and 'delta' in u for u in uris)
+
+    def test_freshest_crl_absent_without_cdp_no_crash(self, app, auth_client, create_ca):
+        """Bug: old code referenced delta_url outside the CDP guard."""
+        ca = create_ca(cn='Freshest NoCDP CA')
+        with app.app_context():
+            from models import CA, db
+            row = db.session.get(CA, ca['id'])
+            row.delta_crl_enabled = True
+            row.cdp_enabled = False
+            row.cdp_url = None
+            db.session.commit()
+
+        r = auth_client.post(f'{CRL_BASE}/{ca["id"]}/regenerate')
+        assert r.status_code == 200, r.data
+        full = _load_crl(_fetch_crl_pem(auth_client, ca['id']))
+        assert _ext_or_none(full, ExtensionOID.FRESHEST_CRL) is None
+
+    def test_delta_must_not_carry_freshest_crl(self, app, auth_client, create_ca):
+        ca = create_ca(cn='Freshest Delta CA')
+        _enable_delta(app, ca['id'])
+        assert auth_client.post(f'{CRL_BASE}/{ca["id"]}/regenerate').status_code == 200
+        assert auth_client.post(f'{CRL_BASE}/{ca["id"]}/delta/regenerate').status_code == 200
+        delta = _load_crl(_fetch_crl_pem(auth_client, ca['id'], delta=True))
+        assert _ext_or_none(delta, ExtensionOID.FRESHEST_CRL) is None
+
+
+class TestRfc5280ReasonCode:
+    """§5.3.1 — omit unspecified; removeFromCRL only on delta."""
+
+    def test_unspecified_reason_omitted_from_full_crl(self, app, auth_client, create_ca):
+        ca = create_ca(cn='Reason Unspec CA')
+        cert = _issue_and_revoke(
+            auth_client, ca['id'], 'unspec.reason.test', 'unspecified')
+        assert auth_client.post(f'{CRL_BASE}/{ca["id"]}/regenerate').status_code == 200
+
+        crl = _load_crl(_fetch_crl_pem(auth_client, ca['id']))
+        assert len(list(crl)) >= 1
+        for entry in crl:
+            assert _ext_or_none(entry, CRLEntryExtensionOID.CRL_REASON) is None
+
+    def test_meaningful_reason_present(self, app, auth_client, create_ca):
+        ca = create_ca(cn='Reason KeyComp CA')
+        _issue_and_revoke(auth_client, ca['id'], 'keycomp.reason.test', 'keyCompromise')
+        assert auth_client.post(f'{CRL_BASE}/{ca["id"]}/regenerate').status_code == 200
+        crl = _load_crl(_fetch_crl_pem(auth_client, ca['id']))
+        reasons = []
+        for entry in crl:
+            ext = _ext_or_none(entry, CRLEntryExtensionOID.CRL_REASON)
+            if ext:
+                reasons.append(ext.value.reason)
+        assert x509.ReasonFlags.key_compromise in reasons
+
+    def test_remove_from_crl_omitted_on_full_included_on_delta(
+            self, app, auth_client, create_ca):
+        ca = create_ca(cn='Reason Remove CA')
+        _enable_delta(app, ca['id'])
+
+        # Seed a base CRL first, then plant a removeFromCRL row after thisUpdate.
+        assert auth_client.post(f'{CRL_BASE}/{ca["id"]}/regenerate').status_code == 200
+
+        with app.app_context():
+            from models import CA, Certificate, db
+            from services.cert_service import CertificateService
+            ca_row = db.session.get(CA, ca['id'])
+            # Issue via API path already used above; create+flag directly for reason control
+            r = _post_json(auth_client, '/api/v2/certificates', {
+                'cn': 'remove.reason.test',
+                'ca_id': ca['id'],
+                'validity_days': 30,
+            })
+            cert = assert_success(r, status=201)
+            row = db.session.get(Certificate, cert['id'])
+            row.revoked = True
+            row.revoke_reason = 'removeFromCRL'
+            row.revoked_at = utc_now() + timedelta(seconds=2)
+            db.session.commit()
+            caref = ca_row.refid
+
+        # Full CRL must list the cert without removeFromCRL reason extension
+        assert auth_client.post(f'{CRL_BASE}/{ca["id"]}/regenerate').status_code == 200
+        full = _load_crl(_fetch_crl_pem(auth_client, ca['id']))
+        for entry in full:
+            ext = _ext_or_none(entry, CRLEntryExtensionOID.CRL_REASON)
+            if ext:
+                assert ext.value.reason != x509.ReasonFlags.remove_from_crl
+
+        # Delta after a new base: plant revocation after base thisUpdate
+        with app.app_context():
+            from models import Certificate, db
+            from models.crl import CRLMetadata
+            base = CRLMetadata.query.filter_by(ca_id=ca['id'], is_delta=False).order_by(
+                CRLMetadata.crl_number.desc()).first()
+            row = Certificate.query.filter_by(caref=caref, revoked=True).order_by(
+                Certificate.id.desc()).first()
+            row.revoke_reason = 'removeFromCRL'
+            row.revoked_at = base.this_update + timedelta(minutes=1)
+            db.session.commit()
+
+        assert auth_client.post(f'{CRL_BASE}/{ca["id"]}/delta/regenerate').status_code == 200
+        delta = _load_crl(_fetch_crl_pem(auth_client, ca['id'], delta=True))
+        delta_reasons = [
+            e.value.reason
+            for entry in delta
+            if (e := _ext_or_none(entry, CRLEntryExtensionOID.CRL_REASON))
+        ]
+        assert x509.ReasonFlags.remove_from_crl in delta_reasons
+
+
+class TestRfc5280AkiSmoke:
+    """§5.2.1 smoke — intermediate CRL AKI still equals signing CA SKI."""
+
+    def test_intermediate_crl_aki_equals_ski(self, app, auth_client, create_ca):
+        _, inter = _make_intermediate(
+            auth_client, create_ca, 'RFC AKI Root', 'RFC AKI Intermediate')
+        assert auth_client.post(f'{CRL_BASE}/{inter["id"]}/regenerate').status_code == 200
+        crl = _load_crl(_fetch_crl_pem(auth_client, inter['id']))
+        with app.app_context():
+            from models import CA, db
+            ca = db.session.get(CA, inter['id'])
+            ca_cert = x509.load_pem_x509_certificate(
+                base64.b64decode(ca.crt), default_backend())
+        crl_aki = crl.extensions.get_extension_for_oid(
+            ExtensionOID.AUTHORITY_KEY_IDENTIFIER).value.key_identifier
+        ski = ca_cert.extensions.get_extension_for_oid(
+            ExtensionOID.SUBJECT_KEY_IDENTIFIER).value.digest
+        ca_aki = ca_cert.extensions.get_extension_for_oid(
+            ExtensionOID.AUTHORITY_KEY_IDENTIFIER).value.key_identifier
+        assert crl_aki == ski
+        assert crl_aki != ca_aki
+        assert crl.is_signature_valid(ca_cert.public_key())
+
+
+class TestCrlReasonHelperUnit:
+    def test_apply_revoke_reason_matrix(self):
+        from services.crl.generation import _apply_revoke_reason
+
+        b = x509.RevokedCertificateBuilder().serial_number(1).revocation_date(utc_now())
+        out = _apply_revoke_reason(b, 'unspecified', is_delta=False).build()
+        assert _ext_or_none(out, CRLEntryExtensionOID.CRL_REASON) is None
+
+        b = x509.RevokedCertificateBuilder().serial_number(2).revocation_date(utc_now())
+        out = _apply_revoke_reason(b, 'removeFromCRL', is_delta=False).build()
+        assert _ext_or_none(out, CRLEntryExtensionOID.CRL_REASON) is None
+
+        b = x509.RevokedCertificateBuilder().serial_number(3).revocation_date(utc_now())
+        out = _apply_revoke_reason(b, 'removeFromCRL', is_delta=True).build()
+        ext = _ext_or_none(out, CRLEntryExtensionOID.CRL_REASON)
+        assert ext is not None
+        assert ext.value.reason == x509.ReasonFlags.remove_from_crl
+
+        b = x509.RevokedCertificateBuilder().serial_number(4).revocation_date(utc_now())
+        out = _apply_revoke_reason(b, 'superseded', is_delta=False).build()
+        assert out.extensions.get_extension_for_oid(
+            CRLEntryExtensionOID.CRL_REASON).value.reason == x509.ReasonFlags.superseded
+
+
+class TestCrlSecurityAuth:
+    def test_regenerate_requires_auth(self, client):
+        assert client.post(f'{CRL_BASE}/1/regenerate').status_code == 401
+
+    def test_delta_regenerate_requires_auth(self, client):
+        assert client.post(f'{CRL_BASE}/1/delta/regenerate').status_code == 401
+
+    def test_get_crl_requires_auth(self, client):
+        assert client.get(f'{CRL_BASE}/1').status_code == 401
+
+
+class TestCrlLabOpensslText:
+    """Lab-style: openssl crl -text shows AKI / CRL Number / no IDP on delta."""
+
+    def test_openssl_text_full_and_delta(self, app, auth_client, create_ca):
+        import subprocess
+        import tempfile
+
+        ca = create_ca(cn='OpenSSL Lab CA')
+        _enable_delta(app, ca['id'])
+        _issue_and_revoke(auth_client, ca['id'], 'openssl.lab.test', 'keyCompromise')
+        assert auth_client.post(f'{CRL_BASE}/{ca["id"]}/regenerate').status_code == 200
+        assert auth_client.post(f'{CRL_BASE}/{ca["id"]}/delta/regenerate').status_code == 200
+
+        for delta in (False, True):
+            pem = _fetch_crl_pem(auth_client, ca['id'], delta=delta)
+            with tempfile.NamedTemporaryFile('w', suffix='.crl', delete=False) as f:
+                f.write(pem)
+                path = f.name
+            try:
+                out = subprocess.run(
+                    ['openssl', 'crl', '-in', path, '-text', '-noout'],
+                    capture_output=True, text=True, check=True,
+                ).stdout
+            finally:
+                os.unlink(path)
+
+            assert 'X509v3 Authority Key Identifier' in out
+            assert 'X509v3 CRL Number' in out
+            if delta:
+                assert 'Delta CRL Indicator' in out
+                assert 'Freshest CRL' not in out
+            else:
+                assert 'Freshest CRL' in out

--- a/scripts/lab_crl_openssl_verify.py
+++ b/scripts/lab_crl_openssl_verify.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""Lab: generate a CRL and verify AKI / extensions with openssl crl -text.
+
+Loads SECRET_KEY from repo-root ``.env.lab`` (gitignored). If missing, generates
+ephemeral keys for this run only (create_app refuses INSTALL_TIME_PLACEHOLDER).
+
+Usage:
+  python3 scripts/lab_crl_openssl_verify.py
+"""
+from __future__ import annotations
+
+import base64
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+BACKEND = ROOT / 'backend'
+ENV_LAB = ROOT / '.env.lab'
+
+
+def _load_dotenv(path: Path) -> None:
+    if not path.is_file():
+        return
+    for line in path.read_text(encoding='utf-8').splitlines():
+        line = line.strip()
+        if not line or line.startswith('#') or '=' not in line:
+            continue
+        key, _, val = line.partition('=')
+        os.environ.setdefault(key.strip(), val.strip())
+
+
+def _ensure_secrets() -> None:
+    _load_dotenv(ENV_LAB)
+    if not os.environ.get('SECRET_KEY') or os.environ['SECRET_KEY'] == 'INSTALL_TIME_PLACEHOLDER':
+        import secrets
+        os.environ['SECRET_KEY'] = secrets.token_urlsafe(48)
+        os.environ.setdefault('JWT_SECRET_KEY', secrets.token_urlsafe(48))
+        print('NOTE: no usable SECRET_KEY — using ephemeral key for this run')
+        print(f'      create {ENV_LAB} (gitignored) for a stable lab secret')
+    else:
+        print(f'Loaded secrets from {ENV_LAB}')
+    os.environ.setdefault('JWT_SECRET_KEY', os.environ['SECRET_KEY'])
+    os.environ.setdefault('UCM_ENV', 'lab')
+    os.environ.setdefault('HTTP_REDIRECT', 'false')
+    os.environ.setdefault('CSRF_DISABLED', 'true')
+    os.environ.setdefault('UCM_DEV_MODE', 'true')
+    os.environ.setdefault('INITIAL_ADMIN_PASSWORD', 'changeme123')
+
+
+def main() -> int:
+    _ensure_secrets()
+
+    with tempfile.NamedTemporaryFile(suffix='.db', delete=False) as f:
+        os.environ['UCM_DATABASE_PATH'] = f.name
+        temp_db = f.name
+
+    sys.path.insert(0, str(BACKEND))
+    os.chdir(BACKEND)
+
+    from cryptography import x509
+    from cryptography.hazmat.backends import default_backend
+    from cryptography.x509.oid import ExtensionOID
+    from app import create_app
+    from models import db
+    from services.ca_service import CAService
+    from services.crl_service import CRLService
+
+    app = create_app('testing')
+    app.config['TESTING'] = True
+    app.config['FQDN'] = 'ucm.lab.local'
+
+    try:
+        with app.app_context():
+            db.create_all()
+
+            root = CAService.create_internal_ca(
+                descr='Lab Root CA',
+                dn={'CN': 'Lab Root CA', 'O': 'Lab', 'C': 'US'},
+                key_type='2048',
+                validity_days=3650,
+                username='lab',
+            )
+            inter = CAService.create_internal_ca(
+                descr='Lab Intermediate CA',
+                dn={'CN': 'Lab Intermediate CA', 'O': 'Lab', 'C': 'US'},
+                key_type='2048',
+                validity_days=1825,
+                caref=root.refid,
+                username='lab',
+            )
+
+            inter.cdp_enabled = True
+            inter.delta_crl_enabled = True
+            inter.set_cdp_urls([f'http://cdp.lab.local/cdp/{inter.refid}.crl'])
+            db.session.commit()
+
+            full_meta = CRLService.generate_crl(inter.id, username='lab')
+            delta_meta = CRLService.generate_delta_crl(inter.id, username='lab')
+
+            ca_cert = x509.load_pem_x509_certificate(
+                base64.b64decode(inter.crt), default_backend()
+            )
+            ski = ca_cert.extensions.get_extension_for_oid(
+                ExtensionOID.SUBJECT_KEY_IDENTIFIER
+            ).value.digest.hex()
+            ca_aki = ca_cert.extensions.get_extension_for_oid(
+                ExtensionOID.AUTHORITY_KEY_IDENTIFIER
+            ).value.key_identifier.hex()
+
+            print(f'Intermediate SKI: {ski}')
+            print(f'Intermediate AKI (parent): {ca_aki}')
+            assert ski != ca_aki, 'lab setup broken: intermediate AKI==SKI'
+
+            for label, pem in (('full', full_meta.crl_pem), ('delta', delta_meta.crl_pem)):
+                crl = x509.load_pem_x509_crl(pem.encode(), default_backend())
+                crl_aki = crl.extensions.get_extension_for_oid(
+                    ExtensionOID.AUTHORITY_KEY_IDENTIFIER
+                ).value.key_identifier.hex()
+                match = 'MATCH' if crl_aki == ski else 'MISMATCH'
+                print(f'CRL ({label}) AKI: {crl_aki} → {match} vs SKI')
+                if crl_aki != ski:
+                    return 1
+                assert crl.is_signature_valid(ca_cert.public_key())
+
+                with tempfile.NamedTemporaryFile('w', suffix='.crl', delete=False) as tf:
+                    tf.write(pem)
+                    path = tf.name
+                try:
+                    out = subprocess.run(
+                        ['openssl', 'crl', '-in', path, '-text', '-noout'],
+                        capture_output=True, text=True, check=True,
+                    ).stdout
+                finally:
+                    os.unlink(path)
+
+                print(f'--- openssl crl -text ({label}) ---')
+                for line in out.splitlines():
+                    if any(k in line for k in (
+                        'Authority Key', 'Key Identifier', 'CRL Number',
+                        'Freshest', 'Delta CRL', 'Issuing Distribution',
+                    )):
+                        print(line.rstrip())
+                if 'X509v3 Authority Key Identifier' not in out:
+                    print('ERROR: missing AKI in openssl output')
+                    return 1
+                if label == 'delta' and 'Delta CRL Indicator' not in out:
+                    print('ERROR: missing Delta CRL Indicator')
+                    return 1
+
+            print('LAB OK')
+            return 0
+    finally:
+        if os.path.exists(temp_db):
+            os.unlink(temp_db)
+
+
+if __name__ == '__main__':
+    try:
+        raise SystemExit(main())
+    except Exception as exc:
+        print(f'LAB FAILED: {exc}', file=sys.stderr)
+        raise


### PR DESCRIPTION
## Summary

Follow-up to [#202](https://github.com/NeySlim/ultimate-ca-manager/issues/202) / AKI fix (`88c76c26`): close remaining RFC 5280 CRL profile gaps in `services/crl/generation.py`.

| § | Change |
|---|--------|
| **5.2.4** | Delta no longer adds `IssuingDistributionPoint` — base and delta both **omit** IDP (required when not identical) |
| **5.2.6** | `FreshestCRL` only when CDP URL exists (fixes unbound `delta_url` / silent failure) |
| **5.3.1** | Omit `unspecified` reasonCode; `removeFromCRL` only on delta CRLs |
| **5.2.1** | Shared `_authority_key_identifier_for_crl()` helper (behavior unchanged) |
| meta | `revoked_count` counts entries actually written |

## Test plan

- [x] `pytest tests/test_crl_rfc5280_profile.py tests/test_crl.py` — **34 passed**
- [x] Non-regression: IDP omitted on full **and** delta
- [x] Bug: delta enabled without CDP → regenerate 200, no FreshestCRL, no crash
- [x] FreshestCRL present on full when CDP+delta; absent on delta
- [x] `unspecified` → no CRLReason extension; `keyCompromise` present
- [x] `removeFromCRL` omitted on full, present on delta
- [x] AKI smoke on intermediate (SKI match)
- [x] Security: regenerate / delta / GET → 401 without auth
- [x] Lab: `openssl crl -text` shows AKI + CRL Number; Freshest on full; Delta indicator on delta; no Freshest on delta

## Related

- #202 — CRL AKI (fixed on `dev`)
- #203 — AKI regression tests (complementary)
