### PR TITLE
docs(crl): RFC 5280 AKI, CDP/delta APIs, OpenSSL verify

### DIFF
--- a/docs/ADMIN_GUIDE.md
+++ b/docs/ADMIN_GUIDE.md
@@ -356,10 +356,46 @@ psql -U ucm -h db.example.com ucm < ucm-pg-backup.sql
 
 ### CRL Distribution
 
-**Configure CRL endpoint:**
-1. CRL URL: `https://your-server:8443/crl/<ca-id>.crl`
-2. Configure in CA settings > CRL tab
-3. Set regeneration interval
+Public CDP (HTTP, typically port 8080):
+
+```text
+http://your-server:8080/cdp/<ca_refid>.crl
+http://your-server:8080/cdp/<ca_refid>-delta.crl   # when delta CRL is enabled
+```
+
+Management UI: **CA → CRL / CDP** tab (enable CDP, optional delta, regeneration interval).
+
+**Regenerate via API** (requires `write:crl`):
+
+```bash
+curl -k -X POST -H "Authorization: Bearer $TOKEN" \
+  https://your-server:8443/api/v2/crl/<ca_id>/regenerate
+curl -k -X POST -H "Authorization: Bearer $TOKEN" \
+  https://your-server:8443/api/v2/crl/<ca_id>/delta/regenerate
+```
+
+#### RFC 5280 profile (what UCM puts on the wire)
+
+| Extension / rule | Behaviour | RFC |
+|------------------|-----------|-----|
+| **Authority Key Identifier** | Identifies the **signing CA key**: SKI of the issuing CA certificate (fallback: hash of the CA public key if SKI is absent). **Not** a copy of the CA certificate's own AKI (that points at the parent for intermediates). | §5.2.1 (#202) |
+| **CRL Number** | Monotonic, non-critical; full and delta CRLs share one number sequence | §5.2.3 |
+| **Delta CRL Indicator** | Critical on delta CRLs; `BaseCRLNumber` = last complete CRL | §5.2.4 |
+| **Freshest CRL** | Non-critical on complete CRLs when delta+CDP are configured; points at the delta CDP URL | §5.2.6 |
+| **Serials** | Entries with serials >159 bits are **skipped** (logged); no silent truncation | §4.1.2.2 |
+| **Offline CA** | Cannot regenerate while `ca.offline` | ops |
+
+**Intermediate CAs:** clients that match `CRL.AKI` to the intermediate's SKI will reject a CRL that incorrectly carried the parent's key id. After #202, regenerate CRLs for intermediates so published CDP objects pick up the corrected AKI.
+
+**Verify with OpenSSL** (after fetching PEM from `GET /api/v2/crl/<ca_id>` or CDP):
+
+```bash
+openssl crl -in ca.crl -inform PEM -text -noout | grep -A2 'Authority Key Identifier'
+openssl x509 -in intermediate.pem -noout -text | grep -A1 'Subject Key Identifier'
+# keyIdentifier bytes must match the intermediate SKI, not the parent
+```
+
+**Follow-up (#204):** IDP omitted on both full and delta (§5.2.4 parity), FreshestCRL guarded when CDP is missing, and `reasonCode` hygiene (`unspecified` omitted; `removeFromCRL` on delta only). Track that PR if you rely on strict delta combining.
 
 ### OCSP Configuration
 

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -1305,6 +1305,22 @@ GET /api/v2/crl/{ca_id}
 POST /api/v2/crl/{ca_id}/regenerate
 ```
 
+Requires `write:crl`. Offline CAs return `400`. Response metadata omits PEM by default; fetch PEM with `GET /api/v2/crl/{ca_id}`.
+
+Generated CRLs include **Authority Key Identifier** = issuing CA **Subject Key Identifier** (RFC 5280 §5.2.1).
+
+### Get Delta CRL
+```http
+GET /api/v2/crl/{ca_id}/delta
+```
+
+### Regenerate Delta CRL
+```http
+POST /api/v2/crl/{ca_id}/delta/regenerate
+```
+
+Requires CDP + delta CRL enabled on the CA, and an existing complete CRL.
+
 ### OCSP Status
 ```http
 GET /api/v2/ocsp/status

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -275,7 +275,7 @@ Second consolidated audit. Operator-transparent unless noted.
 | Area | Change | Action required |
 |------|--------|-----------------|
 | **OCSP (RFC 6960)** | Mixed-format serial lookup, cache invalidation on revoke, correct `keyHash`, `nonce` bypasses cache, delegated responder must carry `id-pkix-ocsp-nocheck` | None |
-| **CRL (RFC 5280)** | Mixed-format serial handling, no silent truncation of serials >159 bits, auto-regen of expired CRL on CDP fetch | None |
+| **CRL (RFC 5280)** | Mixed-format serial handling, no silent truncation of serials >159 bits, auto-regen of expired CRL on CDP fetch; CRL AKI = issuing CA SKI (§5.2.1, #202) — not the CA certificate's parent AKI | Regenerate intermediate CRLs after upgrade |
 | **Cert profile (RFC 5280)** | 5 issues fixed in CA/CSR signing paths (SKI/AKI format, BasicConstraints, EKU consistency, KU bit ordering, validity bounds) | None |
 | **ACME (RFC 8555/8737)** | EAB JWK match via thumbprint, JWS algorithm allowlist (asymmetric only), wildcard restricted to DNS-01, ALPN extension marked critical, case-insensitive domains; pre-authz §7.4.1 (migration `033`) | None |
 | **TSA (RFC 3161/5035)** | `signing-certificate-v2` mandatory, body cap 64 KiB, correct `PKIStatus` separation | None |

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -74,6 +74,8 @@ pytest --cov=. --cov-report=term-missing
 | test_audit.py | 33 | Logs, export, cleanup |
 | test_acme.py | 150 | ACME server, client, domains |
 | test_crl.py | 21 | CRL generation, OCSP |
+| test_crl_aki_rfc5280.py | 7+ | RFC 5280 §5.2.1 — CRL AKI = issuing CA SKI (#202/#203) |
+| test_crl_rfc5280_profile.py | — | IDP/FreshestCRL/reasonCode profile (#204, when merged) |
 | test_hsm.py | 52 | HSM providers, keys |
 | test_sso_routes.py | 37 | SSO providers, sessions |
 | test_mtls.py | 25 | mTLS settings, certificates |


### PR DESCRIPTION
## Summary

Documentation-only update for CRL / CDP after [#202](https://github.com/NeySlim/ultimate-ca-manager/issues/202) / [#203](https://github.com/NeySlim/ultimate-ca-manager/pull/203) (AKI = issuing CA SKI).

### Docs updated

| File | Change |
|------|--------|
| `docs/ADMIN_GUIDE.md` | CRL Distribution: CDP URLs, regenerate APIs, RFC 5280 table (AKI/CRLNumber/delta/Freshest/serials), OpenSSL verify recipe, pointer to #204 follow-up |
| `docs/API_REFERENCE.md` | Delta GET/regenerate; note AKI semantics and PEM via GET |
| `docs/SECURITY.md` | CRL hardening row mentions §5.2.1 / #202 + regenerate intermediates after upgrade |
| `docs/TESTING.md` | `test_crl_aki_rfc5280.py`; profile suite reserved for #204 |

### Codepaths covered

- `services/crl/generation.py` — full + delta AKI construction
- `api/v2/crl.py` — regenerate / delta endpoints, offline gate
- Public CDP `/cdp/<refid>.crl` (ops, not code change)

### Knowledge gaps addressed

- Operators did not have a clear statement that CRL AKI must equal the **signing** CA SKI (critical for intermediates).
- Missing OpenSSL verification recipe and CDP URL shape.
- API reference lacked delta CRL endpoints.
- Test inventory lagged #203.

### Out of scope

- Code changes (see #204 for IDP / FreshestCRL / reasonCode).
- Private lab runbook under the ops monorepo (`90-docs-and-runbooks/ucm/CRL-LAB.md`) — not part of this repo.
