### PR TITLE
fix(rfc5280): CSR SKI/AKI, CA AIA caIssuers, invalidityDate, unhold delta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,22 @@ Starting with v2.48, UCM uses Major.Build versioning (e.g., 2.48, 2.49). Earlier
 ## [Unreleased]
 
 ### Fixed
+- **CSR SKI/AKI injection** — Subject Key Identifier and Authority Key Identifier from a client CSR are no longer copied into the issued certificate. SKI is always derived from the subject public key; AKI always from the issuing CA's SKI (public-key fallback). Prevents enrollee-controlled key-identifier spoofing (RFC 5280 §4.2.1.1 / §4.2.1.2).
+- **EE and intermediate AKI** — end-entity and intermediate certificates set AKI from the issuer certificate's SKI when present, matching CRL AKI behaviour.
+- **CA AIA caIssuers** — intermediate CA certificates now include AIA `caIssuers` (and OCSP) from the parent CA when configured, mirroring the end-entity path (RFC 5280 §4.2.2.1).
+- **CRL invalidityDate** — optional `invalidity_at` / API `invalidity_date` on revoke is emitted as CRL entry extension §5.3.2 (migration **058**).
+- **Unhold + delta CRL** — lifting `certificateHold` emits a delta CRL entry with reason `removeFromCRL` when delta CRL is enabled, then regenerates the full CRL (§5.3.1).
 - **CRL Authority Key Identifier (RFC 5280 §5.2.1)** — full and delta CRLs now set AKI from the issuing CA's Subject Key Identifier (with public-key fallback if SKI is absent), instead of copying the CA certificate's AKI (which points at the parent for intermediates). Clients that match CRL AKI to the signing CA SKI no longer reject intermediate CRLs. (#202)
 - **CRL RFC 5280 profile follow-up** — omit `IssuingDistributionPoint` on delta CRLs so base+delta both omit IDP (§5.2.4); guard `FreshestCRL` so missing CDP no longer raises (§5.2.6); omit `unspecified` reasonCode and restrict `removeFromCRL` to delta CRLs (§5.3.1); shared AKI helper; accurate `revoked_count`.
 
 ### Tests
 - Regression coverage for #202: intermediate full/delta CRL AKI≠parent, root CRL, SKI-missing fallback, and unauthenticated regenerate gates.
 - RFC 5280 CRL profile suite: IDP parity, FreshestCRL, reasonCode, AKI smoke, auth gates, openssl lab text dump.
+- Cert/CRL profile gaps suite: CSR SKI/AKI overwrite, CA AIA caIssuers, invalidityDate, unhold removeFromCRL, auth gates, openssl lab.
+- Lab scripts: `scripts/lab_crl_openssl_verify.py`, `scripts/lab_rfc5280_cert_crl_profile.py`.
+
+### Docs
+- ADMIN_GUIDE / SECURITY / TESTING / API_REFERENCE updated for CRL profile, CSR SKI/AKI policy, and optional `invalidity_date`.
 
 ## [2.193] - 2026-07-17
 

--- a/backend/api/v2/certificates/cert_lifecycle.py
+++ b/backend/api/v2/certificates/cert_lifecycle.py
@@ -63,6 +63,19 @@ def revoke_certificate(cert_id):
 
     data = request.json
     reason = data.get('reason', 'unspecified') if data else 'unspecified'
+    invalidity_raw = None
+    if data:
+        invalidity_raw = data.get('invalidity_date') or data.get('invalidity_at')
+
+    invalidity_at = None
+    if invalidity_raw:
+        from datetime import datetime
+        from utils.datetime_utils import to_naive_utc
+        try:
+            raw = str(invalidity_raw).strip().replace('Z', '+00:00')
+            invalidity_at = to_naive_utc(datetime.fromisoformat(raw))
+        except (ValueError, TypeError, OverflowError) as e:
+            return error_response(f'Invalid invalidity_date: {e}', 400)
 
     cert = db.session.get(Certificate, cert_id)
     if not cert:
@@ -79,7 +92,8 @@ def revoke_certificate(cert_id):
         cert = CertificateService.revoke_certificate(
             cert_id=cert_id,
             reason=reason,
-            username=username
+            username=username,
+            invalidity_at=invalidity_at,
         )
 
         # A cert issued through a Microsoft CA connection: try to propagate the
@@ -185,10 +199,30 @@ def unhold_certificate(cert_id):
 
     try:
         username = g.current_user.username if hasattr(g, 'current_user') else 'system'
+        from utils.datetime_utils import utc_now
+
+        ca = None
+        if cert.caref:
+            ca = CA.query.filter_by(refid=cert.caref).first()
+
+        # RFC 5280 §5.3.1 — when delta CRLs are enabled, emit removeFromCRL on
+        # a delta before clearing the hold so relying parties drop the entry.
+        if ca and ca.delta_crl_enabled and ca.cdp_enabled:
+            try:
+                cert.revoke_reason = 'removeFromCRL'
+                cert.revoked_at = utc_now()
+                db.session.commit()
+                from services.crl_service import CRLService
+                CRLService.generate_delta_crl(ca.id, username=username)
+            except Exception as e:
+                logger.warning(f"Failed to emit removeFromCRL delta before unhold: {e}")
+                db.session.rollback()
+                cert = db.session.get(Certificate, cert_id)
 
         cert.revoked = False
         cert.revoked_at = None
         cert.revoke_reason = None
+        cert.invalidity_at = None
         db.session.commit()
 
         # Audit log
@@ -203,12 +237,10 @@ def unhold_certificate(cert_id):
 
         # Regenerate CRL for the issuing CA
         try:
-            if cert.caref:
-                ca = CA.query.filter_by(refid=cert.caref).first()
-                if ca:
-                    from services.crl_service import CRLService
-                    CRLService.generate_crl(ca.id, username=username)
-                    logger.info(f"Regenerated CRL for CA {ca.id} after unhold")
+            if ca:
+                from services.crl_service import CRLService
+                CRLService.generate_crl(ca.id, username=username)
+                logger.info(f"Regenerated CRL for CA {ca.id} after unhold")
         except Exception as e:
             logger.warning(f"Failed to regenerate CRL after unhold: {e}")
 

--- a/backend/migrations/058_certificate_invalidity_at.py
+++ b/backend/migrations/058_certificate_invalidity_at.py
@@ -1,0 +1,69 @@
+"""Migration 058: add invalidity_at to certificates for CRL entry extension.
+
+RFC 5280 §5.3.2 optional invalidityDate — the date on which it is known or
+suspected that the private key was compromised or the certificate otherwise
+became invalid (may precede revocationDate).
+"""
+
+import logging
+import sqlite3
+
+logger = logging.getLogger(__name__)
+pg_compatible = True
+
+
+def _upgrade_sqlite(conn):
+    cur = conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='certificates'"
+    )
+    if not cur.fetchone():
+        logger.info("058: certificates table absent, skipping")
+        return
+
+    cur = conn.execute("PRAGMA table_info(certificates)")
+    cols = {row[1] for row in cur.fetchall()}
+    if 'invalidity_at' in cols:
+        logger.info("058: invalidity_at already present, skipping")
+        return
+
+    conn.execute("ALTER TABLE certificates ADD COLUMN invalidity_at DATETIME")
+    conn.commit()
+    logger.info("058: added invalidity_at column to certificates (SQLite)")
+
+
+def _upgrade_pg(conn):
+    from sqlalchemy import inspect, text
+
+    insp = inspect(conn)
+    if 'certificates' not in set(insp.get_table_names()):
+        logger.info("058: certificates table absent, skipping")
+        return
+
+    cols = {c['name'] for c in insp.get_columns('certificates')}
+    if 'invalidity_at' in cols:
+        logger.info("058: invalidity_at already present, skipping")
+        return
+
+    conn.execute(text("ALTER TABLE certificates ADD COLUMN invalidity_at TIMESTAMP"))
+    logger.info("058: added invalidity_at column to certificates (PostgreSQL)")
+
+
+def upgrade(conn):
+    if isinstance(conn, sqlite3.Connection):
+        _upgrade_sqlite(conn)
+    else:
+        _upgrade_pg(conn)
+
+
+def downgrade(conn):
+    if isinstance(conn, sqlite3.Connection):
+        try:
+            conn.execute("ALTER TABLE certificates DROP COLUMN invalidity_at")
+            conn.commit()
+        except Exception:
+            pass
+    else:
+        from sqlalchemy import text
+        conn.execute(text(
+            "ALTER TABLE certificates DROP COLUMN IF EXISTS invalidity_at"
+        ))

--- a/backend/models/certificate.py
+++ b/backend/models/certificate.py
@@ -50,6 +50,8 @@ class Certificate(db.Model):
     revoked = db.Column(db.Boolean, default=False)
     revoked_at = db.Column(db.DateTime)
     revoke_reason = db.Column(db.String(100))
+    # RFC 5280 §5.3.2 — optional; may precede revoked_at (key compromise time)
+    invalidity_at = db.Column(db.DateTime)
     archived = db.Column(db.Boolean, default=False)  # For renewed certificates
     
     # Metadata
@@ -436,6 +438,7 @@ class Certificate(db.Model):
             "revoked": self.revoked,
             "revoked_at": utc_isoformat(self.revoked_at),
             "revoke_reason": self.revoke_reason,
+            "invalidity_at": utc_isoformat(self.invalidity_at),
             "archived": self.archived or False,
             "imported_from": self.imported_from,
             "created_at": utc_isoformat(self.created_at),

--- a/backend/services/ca/ca_creation.py
+++ b/backend/services/ca/ca_creation.py
@@ -133,8 +133,10 @@ class CACreationMixin:
         # Get parent CA if intermediate
         issuer = None
         issuer_private_key = None
+        parent_cert = None
         parent_cdp_urls = None
         parent_ocsp_urls = None
+        parent_aia_urls = None
         parent_cps_uri = None
         parent_cps_oid = None
         parent_not_after = None
@@ -160,12 +162,17 @@ class CACreationMixin:
             # Increment parent CA serial
             parent_ca.serial = (parent_ca.serial or 0) + 1
 
-            # Resolve parent CDP/OCSP URLs
+            # Resolve parent CDP/OCSP/AIA URLs
             if parent_ca.cdp_enabled:
                 parent_cdp_urls = [url.replace('{ca_refid}', parent_ca.refid or '')
                                   for url in parent_ca.get_cdp_urls()]
             if parent_ca.ocsp_enabled:
                 parent_ocsp_urls = parent_ca.get_ocsp_urls()
+            if parent_ca.aia_ca_issuers_enabled:
+                parent_aia_urls = [
+                    url.replace('{ca_refid}', parent_ca.refid or '')
+                    for url in parent_ca.get_aia_urls()
+                ]
             if parent_ca.cps_enabled and parent_ca.cps_uri:
                 parent_cps_uri = parent_ca.cps_uri
                 parent_cps_oid = parent_ca.cps_oid
@@ -176,10 +183,12 @@ class CACreationMixin:
             private_key=private_key,
             issuer=issuer,
             issuer_private_key=issuer_private_key,
+            issuer_cert=parent_cert,
             validity_days=validity_days,
             digest=digest,
             ocsp_uris=parent_ocsp_urls,
             cdp_urls=parent_cdp_urls,
+            aia_ca_issuers_urls=parent_aia_urls,
             cps_uri=parent_cps_uri,
             cps_oid=parent_cps_oid,
             path_length=path_length,

--- a/backend/services/cert/mixins/lifecycle.py
+++ b/backend/services/cert/mixins/lifecycle.py
@@ -264,7 +264,8 @@ class LifecycleMixin:
     def revoke_certificate(
         cert_id: int,
         reason: str = 'unspecified',
-        username: str = 'system'
+        username: str = 'system',
+        invalidity_at=None,
     ) -> Certificate:
         """
         Revoke a certificate
@@ -273,6 +274,7 @@ class LifecycleMixin:
             cert_id: Certificate ID
             reason: Revocation reason
             username: User revoking
+            invalidity_at: Optional RFC 5280 §5.3.2 invalidityDate (datetime)
 
         Returns:
             Updated certificate
@@ -287,6 +289,8 @@ class LifecycleMixin:
         certificate.revoked = True
         certificate.revoked_at = utc_now()
         certificate.revoke_reason = reason
+        if invalidity_at is not None:
+            certificate.invalidity_at = invalidity_at
 
         try:
             db.session.commit()

--- a/backend/services/crl/generation.py
+++ b/backend/services/crl/generation.py
@@ -7,12 +7,12 @@ from urllib.parse import urlparse
 from cryptography import x509
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.backends import default_backend
-from cryptography.x509.oid import ExtensionOID
 
 from models import db, CA, Certificate
 from models.crl import CRLMetadata
 from utils.datetime_utils import utc_now
 from utils.serial_format import serial_to_int
+from utils.x509_aki import authority_key_identifier_from_issuer
 from ._constants import REASON_MAP
 from .query import CRLQueryMixin
 
@@ -21,13 +21,27 @@ logger = logging.getLogger(__name__)
 
 def _authority_key_identifier_for_crl(ca_cert: x509.Certificate) -> x509.AuthorityKeyIdentifier:
     """RFC 5280 §5.2.1 — CRL AKI must identify the signing CA key (its SKI)."""
+    return authority_key_identifier_from_issuer(ca_cert)
+
+
+def _apply_invalidity_date(
+    revoked_builder: x509.RevokedCertificateBuilder,
+    cert: Certificate,
+) -> x509.RevokedCertificateBuilder:
+    """RFC 5280 §5.3.2 — emit invalidityDate when known (optional)."""
+    invalidity_at = getattr(cert, 'invalidity_at', None)
+    if not invalidity_at:
+        return revoked_builder
     try:
-        ski = ca_cert.extensions.get_extension_for_oid(
-            ExtensionOID.SUBJECT_KEY_IDENTIFIER
+        return revoked_builder.add_extension(
+            x509.InvalidityDate(invalidity_at),
+            critical=False,
         )
-        return x509.AuthorityKeyIdentifier.from_issuer_subject_key_identifier(ski.value)
-    except x509.ExtensionNotFound:
-        return x509.AuthorityKeyIdentifier.from_issuer_public_key(ca_cert.public_key())
+    except Exception as e:
+        logger.warning(
+            f"CRL: omitting invalidityDate for cert {cert.id}: {e}"
+        )
+        return revoked_builder
 
 
 def _apply_revoke_reason(
@@ -157,6 +171,7 @@ class CRLGenerationMixin:
             revoked_builder = _apply_revoke_reason(
                 revoked_builder, cert.revoke_reason, is_delta=False
             )
+            revoked_builder = _apply_invalidity_date(revoked_builder, cert)
             builder = builder.add_revoked_certificate(revoked_builder.build())
             entries += 1
 
@@ -268,6 +283,7 @@ class CRLGenerationMixin:
             revoked_builder = _apply_revoke_reason(
                 revoked_builder, cert.revoke_reason, is_delta=True
             )
+            revoked_builder = _apply_invalidity_date(revoked_builder, cert)
             builder = builder.add_revoked_certificate(revoked_builder.build())
             entries += 1
 

--- a/backend/services/trust_store/ca_certificate_creation_mixin.py
+++ b/backend/services/trust_store/ca_certificate_creation_mixin.py
@@ -29,12 +29,15 @@ class CACertificateCreationMixin:
         private_key,
         issuer: Optional[x509.Name] = None,
         issuer_private_key = None,
+        issuer_cert: Optional[x509.Certificate] = None,
         validity_days: int = 825,
         digest: str = 'sha256',
         ocsp_uri: Optional[str] = None,
         ocsp_uris: Optional[List[str]] = None,
         cdp_url: Optional[str] = None,
         cdp_urls: Optional[List[str]] = None,
+        aia_ca_issuers_url: Optional[str] = None,
+        aia_ca_issuers_urls: Optional[List[str]] = None,
         cps_uri: Optional[str] = None,
         cps_oid: Optional[str] = None,
         serial: Optional[int] = None,
@@ -53,6 +56,9 @@ class CACertificateCreationMixin:
         # Normalize URL params: merge singular into list
         all_cdp_urls = cdp_urls or ([cdp_url] if cdp_url else [])
         all_ocsp_uris = ocsp_uris or ([ocsp_uri] if ocsp_uri else [])
+        all_aia_issuers = aia_ca_issuers_urls or (
+            [aia_ca_issuers_url] if aia_ca_issuers_url else []
+        )
 
         # For self-signed, issuer is subject
         if issuer is None:
@@ -104,22 +110,32 @@ class CACertificateCreationMixin:
 
         # Authority Key Identifier (for intermediate CAs)
         if issuer != subject:
-            builder = builder.add_extension(
-                x509.AuthorityKeyIdentifier.from_issuer_public_key(
+            from utils.x509_aki import authority_key_identifier_from_issuer
+            if issuer_cert is not None:
+                aki = authority_key_identifier_from_issuer(issuer_cert)
+            else:
+                aki = x509.AuthorityKeyIdentifier.from_issuer_public_key(
                     issuer_private_key.public_key()
-                ),
-                critical=False,
-            )
+                )
+            builder = builder.add_extension(aki, critical=False)
 
-        # Authority Information Access — OCSP URIs
-        if all_ocsp_uris:
-            aia_descriptions = [
+        # Authority Information Access — OCSP + caIssuers (RFC 5280 §4.2.2.1)
+        aia_descriptions = []
+        for uri in all_ocsp_uris:
+            aia_descriptions.append(
                 x509.AccessDescription(
                     x509.oid.AuthorityInformationAccessOID.OCSP,
                     x509.UniformResourceIdentifier(uri)
                 )
-                for uri in all_ocsp_uris
-            ]
+            )
+        for url in all_aia_issuers:
+            aia_descriptions.append(
+                x509.AccessDescription(
+                    x509.oid.AuthorityInformationAccessOID.CA_ISSUERS,
+                    x509.UniformResourceIdentifier(url)
+                )
+            )
+        if aia_descriptions:
             builder = builder.add_extension(
                 x509.AuthorityInformationAccess(aia_descriptions),
                 critical=False,

--- a/backend/services/trust_store/certificate_creation_mixin.py
+++ b/backend/services/trust_store/certificate_creation_mixin.py
@@ -170,11 +170,10 @@ class CertificateCreationMixin:
             critical=False,
         )
 
-        # Authority Key Identifier
+        # Authority Key Identifier (issuer SKI when present — RFC 5280 §4.2.1.1)
+        from utils.x509_aki import authority_key_identifier_from_issuer
         builder = builder.add_extension(
-            x509.AuthorityKeyIdentifier.from_issuer_public_key(
-                ca_private_key.public_key()
-            ),
+            authority_key_identifier_from_issuer(ca_cert),
             critical=False,
         )
 

--- a/backend/services/trust_store/csr_operations_mixin.py
+++ b/backend/services/trust_store/csr_operations_mixin.py
@@ -143,7 +143,16 @@ class CSROperationsMixin:
         # SCEP / ACME enrollee could submit a CSR with BasicConstraints(ca=True)
         # and receive a working subordinate CA (trust escalation).
         issuing_ca = cert_type == 'intermediate_ca'
+        # Never copy SKI/AKI from the CSR — an enrollee could inject a wrong
+        # key identifier (RFC 5280 §4.2.1.1 / §4.2.1.2). Always set them from
+        # the subject public key and the issuing CA certificate below.
+        _skip_from_csr = {
+            ExtensionOID.SUBJECT_KEY_IDENTIFIER,
+            ExtensionOID.AUTHORITY_KEY_IDENTIFIER,
+        }
         for extension in csr.extensions:
+            if extension.oid in _skip_from_csr:
+                continue
             if not issuing_ca and extension.oid == ExtensionOID.BASIC_CONSTRAINTS:
                 # Force a leaf BasicConstraints regardless of what the CSR asked
                 # for (the policy block below only fires when the CSR omits it).
@@ -348,23 +357,18 @@ class CSROperationsMixin:
                     critical=False
                 )
 
-        # SubjectKeyIdentifier
-        try:
-            csr.extensions.get_extension_for_oid(ExtensionOID.SUBJECT_KEY_IDENTIFIER)
-        except x509.ExtensionNotFound:
-            builder = builder.add_extension(
-                x509.SubjectKeyIdentifier.from_public_key(csr.public_key()),
-                critical=False
-            )
+        # SubjectKeyIdentifier — always from the CSR subject public key
+        builder = builder.add_extension(
+            x509.SubjectKeyIdentifier.from_public_key(csr.public_key()),
+            critical=False
+        )
 
-        # AuthorityKeyIdentifier
-        try:
-            csr.extensions.get_extension_for_oid(ExtensionOID.AUTHORITY_KEY_IDENTIFIER)
-        except x509.ExtensionNotFound:
-            builder = builder.add_extension(
-                x509.AuthorityKeyIdentifier.from_issuer_public_key(ca_cert.public_key()),
-                critical=False
-            )
+        # AuthorityKeyIdentifier — always from the issuing CA's SKI
+        from utils.x509_aki import authority_key_identifier_from_issuer
+        builder = builder.add_extension(
+            authority_key_identifier_from_issuer(ca_cert),
+            critical=False
+        )
 
         # OCSP Must-Staple
         if ocsp_must_staple:

--- a/backend/tests/test_rfc5280_cert_crl_profile_gaps.py
+++ b/backend/tests/test_rfc5280_cert_crl_profile_gaps.py
@@ -1,0 +1,371 @@
+"""
+RFC 5280 certificate + CRL profile gaps — non-regression / security / lab.
+
+Covers:
+  §4.2.1.1 / §4.2.1.2  CSR must not inject SKI/AKI; always from keys
+  §4.2.1.1             EE/CA AKI from issuer SKI when present
+  §4.2.2.1             CA AIA caIssuers when configured
+  §5.3.2               CRL invalidityDate when invalidity_at set
+  §5.3.1               unhold emits removeFromCRL on delta then clears hold
+  Auth                 revoke/unhold require authentication
+"""
+import base64
+import json
+import os
+import sys
+from datetime import datetime, timedelta
+
+from cryptography import x509
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.x509.oid import (
+    AuthorityInformationAccessOID,
+    CRLEntryExtensionOID,
+    ExtensionOID,
+    NameOID,
+)
+
+from tests.conftest import assert_success, get_json
+from utils.datetime_utils import utc_now
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+CONTENT_JSON = 'application/json'
+CRL_BASE = '/api/v2/crl'
+
+
+def _post_json(client, url, data):
+    return client.post(url, data=json.dumps(data), content_type=CONTENT_JSON)
+
+
+def _ext_or_none(obj, oid):
+    try:
+        return obj.extensions.get_extension_for_oid(oid)
+    except x509.ExtensionNotFound:
+        return None
+
+
+def _load_crl(pem: str):
+    return x509.load_pem_x509_crl(
+        pem.encode() if isinstance(pem, str) else pem,
+        default_backend(),
+    )
+
+
+def _fetch_crl_pem(auth_client, ca_id, *, delta=False):
+    url = f'{CRL_BASE}/{ca_id}/delta' if delta else f'{CRL_BASE}/{ca_id}'
+    r = auth_client.get(url)
+    assert r.status_code == 200, r.data
+    data = get_json(r).get('data', get_json(r))
+    assert data and data.get('crl_pem'), data
+    return data['crl_pem']
+
+
+def _enable_delta(app, ca_id):
+    with app.app_context():
+        from models import CA, db
+        ca = db.session.get(CA, ca_id)
+        ca.cdp_enabled = True
+        ca.delta_crl_enabled = True
+        ca.set_cdp_urls([f'http://cdp.test.local/cdp/{ca.refid}.crl'])
+        db.session.commit()
+        return ca.refid
+
+
+def _self_signed_ca():
+    key = rsa.generate_private_key(65537, 2048)
+    name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, 'Profile Root CA')])
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(name)
+        .issuer_name(name)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(datetime(2020, 1, 1))
+        .not_valid_after(datetime(2035, 1, 1))
+        .add_extension(x509.BasicConstraints(ca=True, path_length=None), critical=True)
+        .add_extension(
+            x509.SubjectKeyIdentifier.from_public_key(key.public_key()),
+            critical=False,
+        )
+        .sign(key, hashes.SHA256())
+    )
+    return cert, key
+
+
+class TestCsrSkiAkiNotInjectable:
+    """Security: enrollee CSR SKI/AKI must be ignored."""
+
+    def test_csr_injected_ski_aki_are_overwritten(self):
+        from services.trust_store import TrustStoreService
+
+        ca_cert, ca_key = _self_signed_ca()
+        leaf_key = rsa.generate_private_key(65537, 2048)
+        fake_ski = x509.SubjectKeyIdentifier(b'\xaa' * 20)
+        fake_aki = x509.AuthorityKeyIdentifier(
+            key_identifier=b'\xbb' * 20,
+            authority_cert_issuer=None,
+            authority_cert_serial_number=None,
+        )
+        csr = (
+            x509.CertificateSigningRequestBuilder()
+            .subject_name(
+                x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, 'inject.example.com')])
+            )
+            .add_extension(fake_ski, critical=False)
+            .add_extension(fake_aki, critical=False)
+            .sign(leaf_key, hashes.SHA256())
+        )
+        pem = TrustStoreService.sign_csr(
+            csr_pem=csr.public_bytes(serialization.Encoding.PEM),
+            ca_cert=ca_cert,
+            ca_private_key=ca_key,
+            validity_days=30,
+        )
+        issued = x509.load_pem_x509_certificate(
+            pem if isinstance(pem, bytes) else pem.encode(),
+            default_backend(),
+        )
+        ski = issued.extensions.get_extension_for_oid(
+            ExtensionOID.SUBJECT_KEY_IDENTIFIER
+        ).value
+        aki = issued.extensions.get_extension_for_oid(
+            ExtensionOID.AUTHORITY_KEY_IDENTIFIER
+        ).value
+        expected_ski = x509.SubjectKeyIdentifier.from_public_key(leaf_key.public_key())
+        expected_aki = x509.AuthorityKeyIdentifier.from_issuer_subject_key_identifier(
+            ca_cert.extensions.get_extension_for_oid(
+                ExtensionOID.SUBJECT_KEY_IDENTIFIER
+            ).value
+        )
+        assert ski.digest == expected_ski.digest
+        assert aki.key_identifier == expected_aki.key_identifier
+        assert ski.digest != fake_ski.digest
+        assert aki.key_identifier != fake_aki.key_identifier
+
+
+class TestEeAkiMatchesIssuerSki:
+    def test_create_certificate_aki_from_issuer_ski(self):
+        from services.trust_store import TrustStoreService
+
+        ca_cert, ca_key = _self_signed_ca()
+        subject = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, 'ee.example.com')])
+        cert_pem, _ = TrustStoreService.create_certificate(
+            subject=subject,
+            ca_cert=ca_cert,
+            ca_private_key=ca_key,
+            validity_days=30,
+        )
+        issued = x509.load_pem_x509_certificate(cert_pem, default_backend())
+        aki = issued.extensions.get_extension_for_oid(
+            ExtensionOID.AUTHORITY_KEY_IDENTIFIER
+        ).value.key_identifier
+        ski = ca_cert.extensions.get_extension_for_oid(
+            ExtensionOID.SUBJECT_KEY_IDENTIFIER
+        ).value.key_identifier
+        assert aki == ski
+
+
+class TestCaAiaCaIssuers:
+    def test_intermediate_carries_ca_issuers_when_configured(self):
+        from services.trust_store import TrustStoreService
+
+        root_cert, root_key = _self_signed_ca()
+        inter_key = rsa.generate_private_key(65537, 2048)
+        subject = x509.Name([
+            x509.NameAttribute(NameOID.COMMON_NAME, 'AIA Intermediate CA'),
+        ])
+        aia_url = 'http://aia.test.local/ca/root.crt'
+        cert_pem, _ = TrustStoreService.create_ca_certificate(
+            subject=subject,
+            private_key=inter_key,
+            issuer=root_cert.subject,
+            issuer_private_key=root_key,
+            issuer_cert=root_cert,
+            validity_days=365,
+            ocsp_uris=['http://ocsp.test.local'],
+            aia_ca_issuers_urls=[aia_url],
+        )
+        issued = x509.load_pem_x509_certificate(cert_pem, default_backend())
+        aia = issued.extensions.get_extension_for_oid(
+            ExtensionOID.AUTHORITY_INFORMATION_ACCESS
+        ).value
+        methods = {d.access_method: d.access_location.value for d in aia}
+        assert AuthorityInformationAccessOID.OCSP in methods
+        assert AuthorityInformationAccessOID.CA_ISSUERS in methods
+        assert methods[AuthorityInformationAccessOID.CA_ISSUERS] == aia_url
+
+        aki = issued.extensions.get_extension_for_oid(
+            ExtensionOID.AUTHORITY_KEY_IDENTIFIER
+        ).value.key_identifier
+        root_ski = root_cert.extensions.get_extension_for_oid(
+            ExtensionOID.SUBJECT_KEY_IDENTIFIER
+        ).value.key_identifier
+        assert aki == root_ski
+
+
+class TestInvalidityDate:
+    def test_invalidity_date_on_crl_when_set(self, app, auth_client, create_ca):
+        ca = create_ca(cn='Invalidity Date CA')
+        with app.app_context():
+            from models import CA, db
+            row = db.session.get(CA, ca['id'])
+            row.cdp_enabled = True
+            db.session.commit()
+
+        r = _post_json(auth_client, '/api/v2/certificates', {
+            'cn': 'invalidity.example.com',
+            'ca_id': ca['id'],
+            'validity_days': 30,
+        })
+        cert = assert_success(r, status=201)
+        invalidity = (utc_now() - timedelta(days=3)).replace(microsecond=0)
+        r = _post_json(auth_client, f'/api/v2/certificates/{cert["id"]}/revoke', {
+            'reason': 'keyCompromise',
+            'invalidity_date': invalidity.isoformat() + 'Z',
+        })
+        assert r.status_code in (200, 201), r.data
+        body = get_json(r).get('data', get_json(r))
+        assert body.get('invalidity_at')
+
+        assert auth_client.post(f'{CRL_BASE}/{ca["id"]}/regenerate').status_code == 200
+        crl = _load_crl(_fetch_crl_pem(auth_client, ca['id']))
+        found = False
+        for entry in crl:
+            ext = _ext_or_none(entry, CRLEntryExtensionOID.INVALIDITY_DATE)
+            if ext:
+                found = True
+                assert ext.critical is False
+                # Compare dates (timezone may differ)
+                inv = ext.value.invalidity_date
+                if getattr(inv, 'tzinfo', None) is not None:
+                    inv = inv.replace(tzinfo=None)
+                assert inv.date() == invalidity.date()
+        assert found, 'expected invalidityDate on at least one CRL entry'
+
+
+class TestUnholdRemoveFromCrl:
+    def test_unhold_emits_remove_from_crl_on_delta(self, app, auth_client, create_ca):
+        ca = create_ca(cn='Unhold Delta CA')
+        _enable_delta(app, ca['id'])
+        assert auth_client.post(f'{CRL_BASE}/{ca["id"]}/regenerate').status_code == 200
+
+        r = _post_json(auth_client, '/api/v2/certificates', {
+            'cn': 'hold.example.com',
+            'ca_id': ca['id'],
+            'validity_days': 30,
+        })
+        cert = assert_success(r, status=201)
+        r = _post_json(auth_client, f'/api/v2/certificates/{cert["id"]}/revoke', {
+            'reason': 'certificateHold',
+        })
+        assert r.status_code in (200, 201), r.data
+        # Ensure hold is after base thisUpdate for delta inclusion
+        with app.app_context():
+            from models import Certificate, db
+            from models.crl import CRLMetadata
+            base = CRLMetadata.query.filter_by(
+                ca_id=ca['id'], is_delta=False
+            ).order_by(CRLMetadata.crl_number.desc()).first()
+            row = db.session.get(Certificate, cert['id'])
+            row.revoked_at = base.this_update + timedelta(minutes=1)
+            db.session.commit()
+
+        r = auth_client.post(f'/api/v2/certificates/{cert["id"]}/unhold')
+        assert r.status_code == 200, r.data
+
+        delta = _load_crl(_fetch_crl_pem(auth_client, ca['id'], delta=True))
+        reasons = [
+            e.value.reason
+            for entry in delta
+            if (e := _ext_or_none(entry, CRLEntryExtensionOID.CRL_REASON))
+        ]
+        assert x509.ReasonFlags.remove_from_crl in reasons
+
+        with app.app_context():
+            from models import Certificate, db
+            row = db.session.get(Certificate, cert['id'])
+            assert row.revoked is False
+            assert row.revoke_reason is None
+
+        full = _load_crl(_fetch_crl_pem(auth_client, ca['id']))
+        # Serial should not appear as still-revoked on the new full CRL
+        with app.app_context():
+            from models import Certificate, db
+            from utils.serial_format import serial_to_int
+            row = db.session.get(Certificate, cert['id'])
+            serial_int = serial_to_int(row.serial_number)
+        for entry in full:
+            assert entry.serial_number != serial_int
+
+
+class TestAuthGates:
+    def test_revoke_requires_auth(self, client, auth_client, create_ca):
+        ca = create_ca(cn='Auth Revoke CA')
+        r = _post_json(auth_client, '/api/v2/certificates', {
+            'cn': 'auth.revoke.test',
+            'ca_id': ca['id'],
+            'validity_days': 30,
+        })
+        cert = assert_success(r, status=201)
+        r = _post_json(client, f'/api/v2/certificates/{cert["id"]}/revoke', {
+            'reason': 'keyCompromise',
+        })
+        assert r.status_code in (401, 403)
+
+    def test_unhold_requires_auth(self, client, auth_client, create_ca):
+        ca = create_ca(cn='Auth Unhold CA')
+        r = _post_json(auth_client, '/api/v2/certificates', {
+            'cn': 'auth.unhold.test',
+            'ca_id': ca['id'],
+            'validity_days': 30,
+        })
+        cert = assert_success(r, status=201)
+        assert _post_json(auth_client, f'/api/v2/certificates/{cert["id"]}/revoke', {
+            'reason': 'certificateHold',
+        }).status_code in (200, 201)
+        r = client.post(f'/api/v2/certificates/{cert["id"]}/unhold')
+        assert r.status_code in (401, 403)
+
+
+class TestLabOpensslTextDump:
+    """Lab-style: openssl crl -text shows invalidityDate when set."""
+
+    def test_openssl_shows_invalidity_date(self, app, auth_client, create_ca):
+        import subprocess
+        import tempfile
+
+        ca = create_ca(cn='Lab Invalidity CA')
+        with app.app_context():
+            from models import CA, db
+            row = db.session.get(CA, ca['id'])
+            row.cdp_enabled = True
+            db.session.commit()
+
+        r = _post_json(auth_client, '/api/v2/certificates', {
+            'cn': 'lab.invalidity.test',
+            'ca_id': ca['id'],
+            'validity_days': 30,
+        })
+        cert = assert_success(r, status=201)
+        invalidity = (utc_now() - timedelta(days=1)).replace(microsecond=0)
+        assert _post_json(auth_client, f'/api/v2/certificates/{cert["id"]}/revoke', {
+            'reason': 'keyCompromise',
+            'invalidity_date': invalidity.isoformat() + 'Z',
+        }).status_code in (200, 201)
+        assert auth_client.post(f'{CRL_BASE}/{ca["id"]}/regenerate').status_code == 200
+        pem = _fetch_crl_pem(auth_client, ca['id'])
+
+        with tempfile.NamedTemporaryFile('w', suffix='.crl', delete=False) as tf:
+            tf.write(pem)
+            path = tf.name
+        try:
+            out = subprocess.run(
+                ['openssl', 'crl', '-in', path, '-text', '-noout'],
+                capture_output=True, text=True, check=True,
+            ).stdout
+        finally:
+            os.unlink(path)
+
+        assert 'Invalidity Date' in out or 'invalidityDate' in out.lower()

--- a/backend/utils/x509_aki.py
+++ b/backend/utils/x509_aki.py
@@ -1,0 +1,25 @@
+"""RFC 5280 Authority Key Identifier helpers.
+
+§4.2.1.1 / §5.2.1 — when the issuer publishes a Subject Key Identifier, AKI
+must identify that same key identifier (not a recomputed hash that can diverge
+from a non-method-1 SKI, and never a value copied from a client CSR).
+"""
+from cryptography import x509
+from cryptography.x509.oid import ExtensionOID
+
+
+def authority_key_identifier_from_issuer(
+    issuer_cert: x509.Certificate,
+) -> x509.AuthorityKeyIdentifier:
+    """Build AKI from the issuer certificate's SKI, with public-key fallback."""
+    try:
+        ski = issuer_cert.extensions.get_extension_for_oid(
+            ExtensionOID.SUBJECT_KEY_IDENTIFIER
+        )
+        return x509.AuthorityKeyIdentifier.from_issuer_subject_key_identifier(
+            ski.value
+        )
+    except x509.ExtensionNotFound:
+        return x509.AuthorityKeyIdentifier.from_issuer_public_key(
+            issuer_cert.public_key()
+        )

--- a/docs/ADMIN_GUIDE.md
+++ b/docs/ADMIN_GUIDE.md
@@ -361,6 +361,22 @@ psql -U ucm -h db.example.com ucm < ucm-pg-backup.sql
 2. Configure in CA settings > CRL tab
 3. Set regeneration interval
 
+**RFC 5280 profile (issuing CA + CRL):**
+- CRL **Authority Key Identifier** identifies the **signing CA** Subject Key Identifier (§5.2.1).
+- Base and delta CRLs both **omit** IssuingDistributionPoint (§5.2.4).
+- **FreshestCRL** points at the delta URL when CDP + delta CRL are enabled (§5.2.6).
+- Reason `unspecified` is omitted; `removeFromCRL` appears only on delta CRLs (§5.3.1).
+- Optional revoke field **`invalidity_date`** is emitted as CRL entry `invalidityDate` (§5.3.2).
+- Lifting a **certificateHold** (unhold) regenerates the full CRL; with delta CRL enabled, UCM first emits a delta entry with reason `removeFromCRL`.
+
+**Certificate issuance profile:**
+- CSR-supplied SKI/AKI extensions are **ignored**; SKI comes from the subject public key and AKI from the issuing CA’s SKI.
+- Intermediate CAs inherit parent **AIA caIssuers** (and OCSP) when the parent has AIA/OCSP configured.
+
+Lab scripts (repo root):
+- `python3 scripts/lab_crl_openssl_verify.py`
+- `python3 scripts/lab_rfc5280_cert_crl_profile.py`
+
 ### OCSP Configuration
 
 OCSP responder runs automatically:

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -641,9 +641,12 @@ Content-Type: application/json
 
 {
   "reason": "keyCompromise",
-  "comments": "Private key was exposed"
+  "comments": "Private key was exposed",
+  "invalidity_date": "2026-07-10T12:00:00Z"
 }
 ```
+
+Optional **`invalidity_date`** / **`invalidity_at`** (ISO 8601): RFC 5280 §5.3.2 date on which the certificate became invalid (may precede revocation). Emitted as CRL entry `invalidityDate` when set.
 
 **Revocation Reasons:**
 - `unspecified`
@@ -652,6 +655,14 @@ Content-Type: application/json
 - `affiliationChanged`
 - `superseded`
 - `cessationOfOperation`
+- `certificateHold` (temporary; can be lifted via unhold)
+
+### Unhold Certificate (lift certificateHold)
+```http
+POST /api/v2/certificates/{cert_id}/unhold
+```
+
+Requires reason `certificateHold` / `certificate_hold`. When the issuing CA has delta CRL enabled, UCM emits a delta entry with reason `removeFromCRL` (RFC 5280 §5.3.1) before regenerating the full CRL.
 
 ### Import Certificate
 ```http

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -275,8 +275,8 @@ Second consolidated audit. Operator-transparent unless noted.
 | Area | Change | Action required |
 |------|--------|-----------------|
 | **OCSP (RFC 6960)** | Mixed-format serial lookup, cache invalidation on revoke, correct `keyHash`, `nonce` bypasses cache, delegated responder must carry `id-pkix-ocsp-nocheck` | None |
-| **CRL (RFC 5280)** | Mixed-format serial handling, no silent truncation of serials >159 bits, auto-regen of expired CRL on CDP fetch | None |
-| **Cert profile (RFC 5280)** | 5 issues fixed in CA/CSR signing paths (SKI/AKI format, BasicConstraints, EKU consistency, KU bit ordering, validity bounds) | None |
+| **CRL (RFC 5280)** | AKI from signing CA SKI; IDP omitted on base+delta; FreshestCRL guarded; omit `unspecified` reasonCode; `removeFromCRL` delta-only; optional `invalidityDate`; unhold emits delta `removeFromCRL` when delta CRL enabled | Full relying-party path validation (§6) is out of scope |
+| **Cert profile (RFC 5280)** | SKI/AKI never copied from CSR (forced from subject key + issuer SKI); EE/CA AKI from issuer SKI; CA AIA includes `caIssuers` when configured; BasicConstraints/KU hardening on CSR path | NameConstraints IP subset and policy/`anyPolicy` product choices remain |
 | **ACME (RFC 8555/8737)** | EAB JWK match via thumbprint, JWS algorithm allowlist (asymmetric only), wildcard restricted to DNS-01, ALPN extension marked critical, case-insensitive domains; pre-authz §7.4.1 (migration `033`) | None |
 | **TSA (RFC 3161/5035)** | `signing-certificate-v2` mandatory, body cap 64 KiB, correct `PKIStatus` separation | None |
 | **EST (RFC 7030)** | `serverkeygen` encrypts the generated key under the **client mTLS pubkey**, not the issued cert | None |
@@ -381,6 +381,7 @@ If you discover a security vulnerability, please report it responsibly:
 
 | Version | Date | Changes |
 |---------|------|---------|
+| Unreleased | 2026-07-17 | CSR SKI/AKI never copied from enrollee CSR; EE/CA AKI from issuer SKI; CA AIA `caIssuers`; CRL `invalidityDate`; unhold → delta `removeFromCRL` |
 | 2.56 | 2026-07-17 | ACME/CSR certificates now include Extended Key Usage (serverAuth), empty subject populated from SAN |
 | 2.55 | 2026-07-17 | DN format fix (RFC 4514), auto-migration corrects existing records |
 | 2.52 | 2026-07-14 | SSRF protection, DNS rebinding prevention, WebAuthn brute-force protection, SSO audit logging, certificate discovery security |

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -74,6 +74,9 @@ pytest --cov=. --cov-report=term-missing
 | test_audit.py | 33 | Logs, export, cleanup |
 | test_acme.py | 150 | ACME server, client, domains |
 | test_crl.py | 21 | CRL generation, OCSP |
+| test_crl_aki_rfc5280.py | — | CRL AKI = signing CA SKI (#202) |
+| test_crl_rfc5280_profile.py | — | IDP, FreshestCRL, reasonCode (#204) |
+| test_rfc5280_cert_crl_profile_gaps.py | — | CSR SKI/AKI, CA AIA, invalidityDate, unhold removeFromCRL |
 | test_hsm.py | 52 | HSM providers, keys |
 | test_sso_routes.py | 37 | SSO providers, sessions |
 | test_mtls.py | 25 | mTLS settings, certificates |

--- a/scripts/lab_rfc5280_cert_crl_profile.py
+++ b/scripts/lab_rfc5280_cert_crl_profile.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env python3
+"""Lab: RFC 5280 cert/CRL profile gaps (CSR SKI/AKI, CA AIA, invalidityDate).
+
+Loads SECRET_KEY from repo-root ``.env.lab`` (gitignored). If missing, generates
+ephemeral keys for this run only.
+
+Usage:
+  python3 scripts/lab_rfc5280_cert_crl_profile.py
+"""
+from __future__ import annotations
+
+import base64
+import os
+import subprocess
+import sys
+import tempfile
+from datetime import timedelta
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+BACKEND = ROOT / 'backend'
+ENV_LAB = ROOT / '.env.lab'
+
+
+def _load_dotenv(path: Path) -> None:
+    if not path.is_file():
+        return
+    for line in path.read_text(encoding='utf-8').splitlines():
+        line = line.strip()
+        if not line or line.startswith('#') or '=' not in line:
+            continue
+        key, _, val = line.partition('=')
+        os.environ.setdefault(key.strip(), val.strip())
+
+
+def _ensure_secrets() -> None:
+    _load_dotenv(ENV_LAB)
+    if not os.environ.get('SECRET_KEY') or os.environ['SECRET_KEY'] == 'INSTALL_TIME_PLACEHOLDER':
+        import secrets
+        os.environ['SECRET_KEY'] = secrets.token_urlsafe(48)
+        os.environ.setdefault('JWT_SECRET_KEY', secrets.token_urlsafe(48))
+        print('NOTE: no usable SECRET_KEY — using ephemeral key for this run')
+        print(f'      create {ENV_LAB} (gitignored) for a stable lab secret')
+    else:
+        print(f'Loaded secrets from {ENV_LAB}')
+    os.environ.setdefault('JWT_SECRET_KEY', os.environ['SECRET_KEY'])
+    os.environ.setdefault('UCM_ENV', 'lab')
+    os.environ.setdefault('HTTP_REDIRECT', 'false')
+    os.environ.setdefault('CSRF_DISABLED', 'true')
+    os.environ.setdefault('UCM_DEV_MODE', 'true')
+    os.environ.setdefault('INITIAL_ADMIN_PASSWORD', 'changeme123')
+
+
+def main() -> int:
+    _ensure_secrets()
+
+    with tempfile.NamedTemporaryFile(suffix='.db', delete=False) as f:
+        os.environ['UCM_DATABASE_PATH'] = f.name
+        temp_db = f.name
+
+    sys.path.insert(0, str(BACKEND))
+    os.chdir(BACKEND)
+
+    from cryptography import x509
+    from cryptography.hazmat.backends import default_backend
+    from cryptography.hazmat.primitives import hashes, serialization
+    from cryptography.hazmat.primitives.asymmetric import rsa
+    from cryptography.x509.oid import (
+        AuthorityInformationAccessOID,
+        ExtensionOID,
+        NameOID,
+    )
+    from app import create_app
+    from models import db
+    from services.ca_service import CAService
+    from services.cert_service import CertificateService
+    from services.crl_service import CRLService
+    from services.trust_store import TrustStoreService
+    from utils.datetime_utils import utc_now
+
+    app = create_app('testing')
+    app.config['TESTING'] = True
+    app.config['FQDN'] = 'ucm.lab.local'
+
+    try:
+        with app.app_context():
+            db.create_all()
+
+            root = CAService.create_internal_ca(
+                descr='Lab Profile Root',
+                dn={'CN': 'Lab Profile Root', 'O': 'Lab', 'C': 'US'},
+                key_type='2048',
+                validity_days=3650,
+                username='lab',
+            )
+            root.aia_ca_issuers_enabled = True
+            root.set_aia_urls([f'http://aia.lab.local/ca/{root.refid}.crt'])
+            root.ocsp_enabled = True
+            root.set_ocsp_urls(['http://ocsp.lab.local'])
+            db.session.commit()
+
+            inter = CAService.create_internal_ca(
+                descr='Lab Profile Intermediate',
+                dn={'CN': 'Lab Profile Intermediate', 'O': 'Lab', 'C': 'US'},
+                key_type='2048',
+                validity_days=1825,
+                caref=root.refid,
+                username='lab',
+            )
+            inter.cdp_enabled = True
+            inter.delta_crl_enabled = True
+            inter.set_cdp_urls([f'http://cdp.lab.local/cdp/{inter.refid}.crl'])
+            db.session.commit()
+
+            # --- CSR SKI/AKI injection must be ignored ---
+            ca_cert = x509.load_pem_x509_certificate(
+                base64.b64decode(inter.crt), default_backend()
+            )
+            from services.hsm.ca_key_loader import get_ca_signing_key
+            ca_key = get_ca_signing_key(inter)
+            leaf_key = rsa.generate_private_key(65537, 2048)
+            csr = (
+                x509.CertificateSigningRequestBuilder()
+                .subject_name(x509.Name([
+                    x509.NameAttribute(NameOID.COMMON_NAME, 'lab.inject.example'),
+                ]))
+                .add_extension(x509.SubjectKeyIdentifier(b'\xaa' * 20), critical=False)
+                .add_extension(
+                    x509.AuthorityKeyIdentifier(
+                        key_identifier=b'\xbb' * 20,
+                        authority_cert_issuer=None,
+                        authority_cert_serial_number=None,
+                    ),
+                    critical=False,
+                )
+                .sign(leaf_key, hashes.SHA256())
+            )
+            pem = TrustStoreService.sign_csr(
+                csr_pem=csr.public_bytes(serialization.Encoding.PEM),
+                ca_cert=ca_cert,
+                ca_private_key=ca_key,
+                validity_days=30,
+            )
+            issued = x509.load_pem_x509_certificate(
+                pem if isinstance(pem, bytes) else pem.encode(), default_backend()
+            )
+            ski = issued.extensions.get_extension_for_oid(
+                ExtensionOID.SUBJECT_KEY_IDENTIFIER
+            ).value.digest
+            expected = x509.SubjectKeyIdentifier.from_public_key(
+                leaf_key.public_key()
+            ).digest
+            assert ski == expected, 'CSR SKI injection not overridden'
+            print('CSR SKI/AKI override: OK')
+
+            # --- Intermediate AIA caIssuers from parent ---
+            inter_cert = ca_cert
+            aia = inter_cert.extensions.get_extension_for_oid(
+                ExtensionOID.AUTHORITY_INFORMATION_ACCESS
+            ).value
+            ca_issuers = [
+                d.access_location.value
+                for d in aia
+                if d.access_method == AuthorityInformationAccessOID.CA_ISSUERS
+            ]
+            assert ca_issuers, 'intermediate missing AIA caIssuers'
+            print(f'Intermediate AIA caIssuers: {ca_issuers[0]}')
+
+            # --- invalidityDate on CRL ---
+            leaf = CertificateService.create_certificate(
+                descr='lab.invalidity.example',
+                caref=inter.refid,
+                dn={'CN': 'lab.invalidity.example', 'O': 'Lab', 'C': 'US'},
+                cert_type='server_cert',
+                validity_days=30,
+                username='lab',
+            )
+            CertificateService.revoke_certificate(
+                leaf.id,
+                reason='keyCompromise',
+                username='lab',
+                invalidity_at=utc_now() - timedelta(days=2),
+            )
+            full = CRLService.generate_crl(inter.id, username='lab')
+            crl = x509.load_pem_x509_crl(full.crl_pem.encode(), default_backend())
+            has_inv = False
+            for entry in crl:
+                try:
+                    entry.extensions.get_extension_for_oid(
+                        x509.oid.CRLEntryExtensionOID.INVALIDITY_DATE
+                    )
+                    has_inv = True
+                except x509.ExtensionNotFound:
+                    pass
+            assert has_inv, 'CRL missing invalidityDate'
+            print('CRL invalidityDate: OK')
+
+            with tempfile.NamedTemporaryFile('w', suffix='.crl', delete=False) as tf:
+                tf.write(full.crl_pem)
+                path = tf.name
+            try:
+                out = subprocess.run(
+                    ['openssl', 'crl', '-in', path, '-text', '-noout'],
+                    capture_output=True, text=True, check=True,
+                ).stdout
+            finally:
+                os.unlink(path)
+            print('--- openssl crl -text (excerpt) ---')
+            for line in out.splitlines():
+                if any(k in line for k in (
+                    'Authority Key', 'Invalidity', 'Serial Number', 'CRL Number',
+                )):
+                    print(line.rstrip())
+            if 'Invalidity Date' not in out and 'invalidityDate' not in out.lower():
+                print('ERROR: openssl text missing Invalidity Date')
+                return 1
+
+            print('LAB OK')
+            return 0
+    finally:
+        if os.path.exists(temp_db):
+            os.unlink(temp_db)
+
+
+if __name__ == '__main__':
+    try:
+        raise SystemExit(main())
+    except Exception as exc:
+        print(f'LAB FAILED: {exc}', file=sys.stderr)
+        raise


### PR DESCRIPTION
## Summary
- **Security / cert profile:** never copy SKI/AKI from enrollee CSRs; always set SKI from subject public key and AKI from the issuing CA SKI (shared `utils/x509_aki` helper).
- **CA AIA:** intermediate CAs now emit AIA `caIssuers` (plus OCSP) from the parent when configured; EE/CA AKI prefer issuer SKI.
- **CRL:** optional revoke `invalidity_date` → entry `invalidityDate` (migration **058**); unhold emits delta `removeFromCRL` when delta CRL is enabled, then regenerates the full CRL.

## Test plan
- [x] `pytest tests/test_rfc5280_cert_crl_profile_gaps.py tests/test_crl_rfc5280_profile.py tests/test_crl_aki_rfc5280.py tests/test_protocol_signing_guards.py` (36 passed)
- [x] `python3 scripts/lab_rfc5280_cert_crl_profile.py`
- [x] `python3 scripts/lab_crl_openssl_verify.py`
- [ ] Review docs: `ADMIN_GUIDE`, `SECURITY`, `TESTING`, `API_REFERENCE`, `CHANGELOG`

## Notes
UCM remains an **issuing CA + CRL** implementation — not a full RFC 5280 §6 relying-party path validator. Remaining product-scope items (e.g. NameConstraints IP subset, policy/`anyPolicy`) are documented in `SECURITY.md`.