### PR TITLE
fix(ui): correct login theme tooltip and center loading spinners

### DIFF
--- a/frontend/src/pages/ACMEPage.jsx
+++ b/frontend/src/pages/ACMEPage.jsx
@@ -998,7 +998,7 @@ export default function ACMEPage() {
 
   if (loading) {
     return (
-      <div className="flex items-center justify-center h-full">
+      <div className="flex items-center justify-center h-full w-full">
         <LoadingSpinner />
       </div>
     )

--- a/frontend/src/pages/AccountPage.jsx
+++ b/frontend/src/pages/AccountPage.jsx
@@ -823,7 +823,7 @@ export default function AccountPage() {
 
   if (loading) {
     return (
-      <div className="flex items-center justify-center h-full">
+      <div className="flex items-center justify-center h-full w-full">
         <LoadingSpinner message={t('account.loadingAccount')} />
       </div>
     )

--- a/frontend/src/pages/AuditLogsPage.jsx
+++ b/frontend/src/pages/AuditLogsPage.jsx
@@ -709,7 +709,7 @@ export default function AuditLogsPage() {
 
   if (loading) {
     return (
-      <div className="flex items-center justify-center h-full">
+      <div className="flex items-center justify-center h-full w-full">
         <LoadingSpinner />
       </div>
     );

--- a/frontend/src/pages/CRLOCSPPage.jsx
+++ b/frontend/src/pages/CRLOCSPPage.jsx
@@ -1035,7 +1035,7 @@ export default function CRLOCSPPage() {
 
   if (loading) {
     return (
-      <div className="flex items-center justify-center h-full">
+      <div className="flex items-center justify-center h-full w-full">
         <LoadingSpinner />
       </div>
     )

--- a/frontend/src/pages/DashboardPage.jsx
+++ b/frontend/src/pages/DashboardPage.jsx
@@ -381,7 +381,7 @@ export default function DashboardPage() {
 
   if (loading) {
     return (
-      <div className="flex items-center justify-center h-full">
+      <div className="flex items-center justify-center h-full w-full">
         <LoadingSpinner message={t('dashboard.loading')} />
       </div>
     )

--- a/frontend/src/pages/LoginPage.jsx
+++ b/frontend/src/pages/LoginPage.jsx
@@ -859,7 +859,7 @@ export default function LoginPage() {
               <button
                 onClick={() => { setThemeMenuOpen(!themeMenuOpen); setLangMenuOpen(false) }}
                 className="flex items-center justify-center w-9 h-9 rounded-md bg-bg-tertiary hover:bg-bg-secondary border border-border text-text-secondary hover:text-text-primary transition-colors"
-                title={t('settings.tabs.appearance')}
+                title={t('common.theme')}
               >
                 <Palette size={18} />
               </button>

--- a/frontend/src/pages/SettingsPage.jsx
+++ b/frontend/src/pages/SettingsPage.jsx
@@ -1557,7 +1557,7 @@ export default function SettingsPage() {
 
   if (loading) {
     return (
-      <div className="flex items-center justify-center h-full">
+      <div className="flex items-center justify-center h-full w-full">
         <LoadingSpinner message={t('settings.loadingSettings')} />
       </div>
     )


### PR DESCRIPTION
## Summary
- Login page's theme icon showed "Appearance & Language" as its tooltip, but the icon only controls theme — language has its own separate flag icon. Now shows "Theme".
- The loading spinner on Dashboard, ACME, Audit Logs, Account, Settings, and CRL/OCSP pages rendered against the far-left edge instead of centered. Root cause: `AppShell`'s content area is a `flex` row wrapping `<Outlet />`, and these pages' loading-state wrapper `div` lacked `w-full`, so it shrank to content width instead of stretching to center within the page. Added `w-full`, matching the fix already present on SCEP/EST/TSA pages.

## Test plan
- [x] Verified on a live UCM instance: login footer theme icon now tooltips "Theme"
- [x] Verified loading spinner is centered on Dashboard and ACME pages after the fix
- [ ] Reviewer to confirm on Audit Logs, Account, Settings, and CRL/OCSP pages