### PR TITLE
fix(templates/cert): honor digest, persist template_id, live usage_count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Starting with v2.48, UCM uses Major.Build versioning (e.g., 2.48, 2.49). Earlier
 
 ## [Unreleased]
 
+### Fixed
+- **Template digest on certificate issuance** — `POST /api/v2/certificates` honors template (or request) digest and persists `template_id`. (#207)
+
+
 ## [2.194] - 2026-07-17
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Starting with v2.48, UCM uses Major.Build versioning (e.g., 2.48, 2.49). Earlier
 
 ### Fixed
 - **Template digest on certificate issuance** — `POST /api/v2/certificates` honors template (or request) digest and persists `template_id`. (#207)
+- **Template usage_count** — template API reports live count from `Certificate.template_id` instead of a stuck zero. (#207)
 
 
 ## [2.194] - 2026-07-17

--- a/backend/api/v2/certificates/cert_create.py
+++ b/backend/api/v2/certificates/cert_create.py
@@ -21,6 +21,7 @@ from services.notification_service import NotificationService
 from websocket.emitters import on_certificate_issued
 from utils.datetime_utils import utc_now, utc_isoformat
 from utils.db_transaction import safe_commit
+from services.trust_store.constants import HASH_ALGORITHMS
 from . import bp
 
 logger = logging.getLogger(__name__)
@@ -72,6 +73,21 @@ def create_certificate():
 
     if ca.offline:
         return error_response('CA is offline; restore it before issuing', 400)
+
+    # Optional certificate template (digest / validity defaults)
+    template = None
+    template_id = data.get('template_id')
+    if template_id is not None:
+        try:
+            template_id = int(template_id)
+        except (TypeError, ValueError):
+            return error_response('template_id must be an integer', 400)
+        from models.certificate_template import CertificateTemplate
+
+        template = db.session.get(CertificateTemplate, template_id)
+        if not template or not template.is_active:
+            return error_response('Certificate template not found or inactive', 404)
+        data['template_id'] = template_id
 
     # Policy evaluation — check if approval is required (admins bypass)
     try:
@@ -163,8 +179,11 @@ def create_certificate():
 
         # Validity (cap 1..3650 days; reject 0/negative/non-int)
         MAX_VALIDITY_DAYS = 3650  # ~10 years; CA/B Forum is 398 for public TLS, 3650 OK for internal PKI
+        default_validity = (
+            template.validity_days if template and template.validity_days else 365
+        )
         try:
-            validity_days = int(data.get('validity_days', 365))
+            validity_days = int(data.get('validity_days', default_validity))
         except (TypeError, ValueError):
             return error_response("validity_days must be an integer (1..3650)", 400)
         if validity_days < 1 or validity_days > MAX_VALIDITY_DAYS:
@@ -179,6 +198,17 @@ def create_certificate():
         if not_after > ca_not_after:
             return error_response(
                 f"validity_days exceeds CA expiration ({ca_not_after.isoformat()})", 400)
+
+        digest_name = (
+            data.get('digest') or (template.digest if template else None) or 'sha256'
+        )
+        digest_name = str(digest_name).lower().strip()
+        hash_algo = HASH_ALGORITHMS.get(digest_name)
+        if hash_algo is None:
+            return error_response(
+                f"Unsupported digest '{digest_name}' (use: {', '.join(sorted(HASH_ALGORITHMS))})",
+                400,
+            )
 
         # Build certificate
         builder = x509.CertificateBuilder()
@@ -386,8 +416,8 @@ def create_certificate():
                 critical=False,
             )
 
-        # Sign certificate
-        new_cert = builder.sign(ca_key, hashes.SHA256(), default_backend())
+        # Sign certificate (honor template / request digest — discussion #207)
+        new_cert = builder.sign(ca_key, hash_algo, default_backend())
 
         # Serialize
         cert_pem = new_cert.public_bytes(serialization.Encoding.PEM).decode('utf-8')
@@ -433,6 +463,7 @@ def create_certificate():
             san_uri=json.dumps(final_san_uri),
             san_upn=json.dumps(final_san_upn) if final_san_upn else None,
             ocsp_must_staple=bool(data.get('ocsp_must_staple')),
+            template_id=data.get('template_id'),
             created_by=g.current_user.username if hasattr(g, 'current_user') else None
         )
 

--- a/backend/models/certificate_template.py
+++ b/backend/models/certificate_template.py
@@ -47,6 +47,12 @@ class CertificateTemplate(db.Model):
     def to_dict(self):
         """Convert to dictionary"""
         import json
+        from models.certificate import Certificate
+
+        usage_count = 0
+        if self.id is not None:
+            usage_count = Certificate.query.filter_by(template_id=self.id).count()
+
         return {
             "id": self.id,
             "name": self.name,
@@ -59,6 +65,7 @@ class CertificateTemplate(db.Model):
             "extensions_template": json.loads(self.extensions_template) if self.extensions_template else {},
             "is_system": self.is_system,
             "is_active": self.is_active,
+            "usage_count": usage_count,
             "created_at": utc_isoformat(self.created_at),
             "created_by": self.created_by,
             "updated_at": utc_isoformat(self.updated_at),

--- a/backend/tests/test_template_digest_issuance.py
+++ b/backend/tests/test_template_digest_issuance.py
@@ -1,0 +1,48 @@
+"""Issuance must honor template digest and persist template_id (#207)."""
+from tests.conftest import get_json
+
+
+def test_issue_honors_template_digest_and_template_id(app, auth_client, create_ca):
+    ca = create_ca(cn="Digest CA")
+    r = auth_client.post(
+        "/api/v2/templates",
+        json={
+            "name": "SHA384 Web",
+            "description": "lab",
+            "template_type": "web_server",
+            "key_type": "RSA-2048",
+            "digest": "sha384",
+            "validity_days": 90,
+        },
+    )
+    assert r.status_code in (200, 201), r.get_data(as_text=True)
+    tpl_id = (get_json(r).get("data") or get_json(r))["id"]
+
+    r = auth_client.post(
+        "/api/v2/certificates",
+        json={
+            "ca_id": ca["id"],
+            "cn": "digest.example.test",
+            "cert_type": "server",
+            "key_type": "rsa",
+            "key_size": 2048,
+            "validity_days": 30,
+            "template_id": tpl_id,
+        },
+    )
+    assert r.status_code in (200, 201), r.get_data(as_text=True)
+    body = get_json(r).get("data") or get_json(r)
+    cert_id = body.get("id") or body.get("certificate", {}).get("id")
+    assert cert_id
+
+    with app.app_context():
+        import base64
+        from cryptography import x509
+        from cryptography.hazmat.backends import default_backend
+        from models import Certificate, db
+
+        row = db.session.get(Certificate, cert_id)
+        assert row.template_id == tpl_id
+        pem = base64.b64decode(row.crt)
+        leaf = x509.load_pem_x509_certificate(pem, default_backend())
+        assert leaf.signature_hash_algorithm.name.lower() == "sha384"

--- a/backend/tests/test_template_usage_count.py
+++ b/backend/tests/test_template_usage_count.py
@@ -1,0 +1,38 @@
+"""Template usage_count must reflect live Certificate.template_id rows."""
+from tests.conftest import get_json
+
+
+def test_template_usage_count_live(app, auth_client, create_cert):
+    r = auth_client.post(
+        "/api/v2/templates",
+        json={
+            "name": "Usage Count Lab",
+            "description": "lab",
+            "template_type": "web_server",
+            "key_type": "RSA-2048",
+            "digest": "sha256",
+            "validity_days": 365,
+        },
+    )
+    assert r.status_code in (200, 201), r.get_data(as_text=True)
+    tpl = get_json(r).get("data") or get_json(r)
+    tpl_id = tpl["id"]
+
+    r = auth_client.get(f"/api/v2/templates/{tpl_id}")
+    assert r.status_code == 200
+    data = get_json(r).get("data") or get_json(r)
+    assert data.get("usage_count") == 0
+
+    # Attach a certificate to the template (issuance digest path is a separate PR)
+    with app.app_context():
+        from models import Certificate, db
+
+        cert = create_cert(cn="usage.example.test")
+        row = db.session.get(Certificate, cert["id"])
+        row.template_id = tpl_id
+        db.session.commit()
+
+    r = auth_client.get(f"/api/v2/templates/{tpl_id}")
+    assert r.status_code == 200
+    data = get_json(r).get("data") or get_json(r)
+    assert data.get("usage_count") == 1

--- a/frontend/src/pages/certificates/IssueCertificateForm.jsx
+++ b/frontend/src/pages/certificates/IssueCertificateForm.jsx
@@ -29,6 +29,7 @@ export function IssueCertificateForm({ cas, initialData, onSubmit, onCancel, t }
     key_size: '2048',
     validity_days: '365',
     expiry_date: '',
+    digest: 'sha256',
     ocsp_must_staple: false,
     extra_ekus: [],
   })
@@ -153,6 +154,7 @@ export function IssueCertificateForm({ cas, initialData, onSubmit, onCancel, t }
       }
     }
     if (tpl.validity_days) updates.validity_days = String(tpl.validity_days)
+    if (tpl.digest) updates.digest = String(tpl.digest).toLowerCase()
 
     // Map template_type to cert_type
     const typeMap = {
@@ -287,6 +289,7 @@ export function IssueCertificateForm({ cas, initialData, onSubmit, onCancel, t }
       ...(san_uri.length && { san_uri }),
       ...(san_upn.length && { san_upn }),
       ...(selectedTemplate && { template_id: parseInt(selectedTemplate) }),
+      ...(formData.digest && { digest: formData.digest }),
       ...(formData.ocsp_must_staple && { ocsp_must_staple: true }),
       ...(formData.extra_ekus?.length && { extra_ekus: formData.extra_ekus }),
     }


### PR DESCRIPTION
## Summary
Bug-fix only from discussion #207:

- `POST /api/v2/certificates` honors template (or request) **digest** (no longer always SHA-256)
- Persists **`template_id`** on the issued certificate
- Template API **`usage_count`** is a live count of `Certificate.template_id`

No friendly name, no CA validity changes, no protocol transport.

## Test plan
- [x] `pytest tests/test_template_digest_issuance.py`
- [x] `pytest tests/test_template_usage_count.py`
- [ ] Manual: issue with SHA-384 template → signature SHA-384; template usage_count increments