### PR TITLE
fix(templates): report live usage_count from Certificate.template_id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Starting with v2.48, UCM uses Major.Build versioning (e.g., 2.48, 2.49). Earlier
 
 ## [Unreleased]
 
+### Fixed
+- **Template usage_count** — template API reports live count from `Certificate.template_id` instead of a stuck zero. (#207)
+
+
 ## [2.194] - 2026-07-17
 
 ### Fixed

--- a/backend/models/certificate_template.py
+++ b/backend/models/certificate_template.py
@@ -47,6 +47,12 @@ class CertificateTemplate(db.Model):
     def to_dict(self):
         """Convert to dictionary"""
         import json
+        from models.certificate import Certificate
+
+        usage_count = 0
+        if self.id is not None:
+            usage_count = Certificate.query.filter_by(template_id=self.id).count()
+
         return {
             "id": self.id,
             "name": self.name,
@@ -59,6 +65,7 @@ class CertificateTemplate(db.Model):
             "extensions_template": json.loads(self.extensions_template) if self.extensions_template else {},
             "is_system": self.is_system,
             "is_active": self.is_active,
+            "usage_count": usage_count,
             "created_at": utc_isoformat(self.created_at),
             "created_by": self.created_by,
             "updated_at": utc_isoformat(self.updated_at),

--- a/backend/tests/test_template_usage_count.py
+++ b/backend/tests/test_template_usage_count.py
@@ -1,0 +1,38 @@
+"""Template usage_count must reflect live Certificate.template_id rows."""
+from tests.conftest import get_json
+
+
+def test_template_usage_count_live(app, auth_client, create_cert):
+    r = auth_client.post(
+        "/api/v2/templates",
+        json={
+            "name": "Usage Count Lab",
+            "description": "lab",
+            "template_type": "web_server",
+            "key_type": "RSA-2048",
+            "digest": "sha256",
+            "validity_days": 365,
+        },
+    )
+    assert r.status_code in (200, 201), r.get_data(as_text=True)
+    tpl = get_json(r).get("data") or get_json(r)
+    tpl_id = tpl["id"]
+
+    r = auth_client.get(f"/api/v2/templates/{tpl_id}")
+    assert r.status_code == 200
+    data = get_json(r).get("data") or get_json(r)
+    assert data.get("usage_count") == 0
+
+    # Attach a certificate to the template (issuance digest path is a separate PR)
+    with app.app_context():
+        from models import Certificate, db
+
+        cert = create_cert(cn="usage.example.test")
+        row = db.session.get(Certificate, cert["id"])
+        row.template_id = tpl_id
+        db.session.commit()
+
+    r = auth_client.get(f"/api/v2/templates/{tpl_id}")
+    assert r.status_code == 200
+    data = get_json(r).get("data") or get_json(r)
+    assert data.get("usage_count") == 1


### PR DESCRIPTION
## Summary
- Template API `usage_count` is a live `Certificate.template_id` count (no longer stuck/missing)

Confirmed bug from discussion #207. Independent of issuance digest fix (pairs well with it).

## Test plan
- [x] `pytest tests/test_template_usage_count.py`