### PR TITLE
fix(crl): human-readable CDP Content-Disposition filename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ Starting with v2.48, UCM uses Major.Build versioning (e.g., 2.48, 2.49). Earlier
 
 ## [Unreleased]
 
+### Fixed
+- **CRL download filename** — CDP responses use a human-readable `Content-Disposition` attachment name (`{slug}-{refid8}.crl`); URL paths remain refid-based. (#207)
+
 ## [2.194] - 2026-07-17
 
 ### Fixed

--- a/backend/api/cdp_routes.py
+++ b/backend/api/cdp_routes.py
@@ -11,6 +11,7 @@ import logging
 from models import db, CA
 from services.crl_service import CRLService
 from utils.datetime_utils import utc_now
+from utils.sanitize import crl_download_filename
 
 logger = logging.getLogger(__name__)
 
@@ -134,7 +135,7 @@ def get_crl(ca_ref):
         status=200,
         mimetype='application/pkix-crl',
         headers={
-            'Content-Disposition': f'attachment; filename="{ca.refid}.crl"',
+            'Content-Disposition': f'attachment; filename="{crl_download_filename(ca)}"',
             'Cache-Control': 'public, max-age=3600, must-revalidate',
             'Last-Modified': crl_meta.this_update.strftime('%a, %d %b %Y %H:%M:%S GMT'),
         }
@@ -158,7 +159,7 @@ def get_delta_crl(ca_ref):
         status=200,
         mimetype='application/pkix-crl',
         headers={
-            'Content-Disposition': f'attachment; filename="{ca.refid}-delta.crl"',
+            'Content-Disposition': f'attachment; filename="{crl_download_filename(ca, delta=True)}"',
             'Cache-Control': 'public, max-age=900, must-revalidate',
             'Last-Modified': delta_crl.this_update.strftime('%a, %d %b %Y %H:%M:%S GMT'),
         }

--- a/backend/tests/test_crl_download_filename.py
+++ b/backend/tests/test_crl_download_filename.py
@@ -1,0 +1,50 @@
+"""Human-readable CRL Content-Disposition filename (#207)."""
+
+import json
+import os
+import sys
+from types import SimpleNamespace
+
+from tests.conftest import assert_success
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from utils.sanitize import crl_download_filename, slugify_filename_component
+
+CONTENT_JSON = 'application/json'
+
+
+def _post_json(client, url, data):
+    return client.post(url, data=json.dumps(data), content_type=CONTENT_JSON)
+
+
+class TestSanitizeCrlFilename:
+    def test_slugify_and_download_name(self):
+        assert slugify_filename_component('My Root CA!') == 'My-Root-CA'
+        ca = SimpleNamespace(descr='Corp Root CA', refid='abcdef12-9999')
+        assert crl_download_filename(ca) == 'Corp-Root-CA-abcdef12.crl'
+        assert (
+            crl_download_filename(ca, delta=True)
+            == 'Corp-Root-CA-abcdef12-delta.crl'
+        )
+
+
+class TestCrlDownloadFilenameHeader:
+    def test_cdp_content_disposition_uses_slug(self, app, auth_client, create_ca):
+        ca = create_ca(cn='Slug Filename CA')
+        with app.app_context():
+            from models import CA, db
+
+            row = db.session.get(CA, ca['id'])
+            row.descr = 'Slug Filename CA'
+            row.cdp_enabled = True
+            db.session.commit()
+            refid = row.refid
+
+        assert_success(auth_client.post(f'/api/v2/crl/{ca["id"]}/regenerate'))
+        r = auth_client.get(f'/cdp/{refid}.crl')
+        assert r.status_code == 200, r.data
+        cd = r.headers.get('Content-Disposition', '')
+        assert 'Slug-Filename-CA-' in cd
+        assert refid[:8] in cd
+        assert cd.endswith('.crl"') or '.crl"' in cd

--- a/backend/utils/sanitize.py
+++ b/backend/utils/sanitize.py
@@ -20,3 +20,21 @@ def sanitize_filename(name):
     # Limit length
     name = name[:200]
     return name or 'download'
+
+
+def slugify_filename_component(name: str, *, max_len: int = 48) -> str:
+    """Filesystem-/header-safe slug for human-readable CRL download names."""
+    if not name:
+        return 'ca'
+    slug = re.sub(r'[^A-Za-z0-9._-]+', '-', name.strip())
+    slug = re.sub(r'-{2,}', '-', slug).strip('-._')
+    slug = sanitize_filename(slug)[:max_len].rstrip('-._')
+    return slug or 'ca'
+
+
+def crl_download_filename(ca, *, delta: bool = False) -> str:
+    """Human-readable CRL attachment name: ``{slug}-{refid8}.crl``."""
+    slug = slugify_filename_component(getattr(ca, 'descr', None) or 'ca')
+    ref = (getattr(ca, 'refid', None) or 'unknown')[:8]
+    suffix = '-delta.crl' if delta else '.crl'
+    return f'{slug}-{ref}{suffix}'


### PR DESCRIPTION
## Summary
- CDP `Content-Disposition` uses `{slug}-{refid8}.crl` (and `-delta.crl`)
- URL paths stay refid-based (embedded in issued certificates unchanged)

Accepted enhancement from discussion #207.

## Test plan
- [x] `pytest tests/test_crl_download_filename.py`