### PR TITLE
fix(cert): backdate notBefore by 15 minutes for clock skew

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ Starting with v2.48, UCM uses Major.Build versioning (e.g., 2.48, 2.49). Earlier
 
 ## [Unreleased]
 
+### Fixed
+- **Certificate notBefore clock skew** — newly issued certificates backdate `notBefore` by 15 minutes so relying parties with slightly slow clocks accept fresh certs immediately (#207).
+
 ## [2.194] - 2026-07-17
 
 ### Fixed

--- a/backend/api/v2/certificates/cert_create.py
+++ b/backend/api/v2/certificates/cert_create.py
@@ -19,7 +19,7 @@ from cryptography.x509.oid import NameOID, ExtendedKeyUsageOID, ExtensionOID
 from services.audit_service import AuditService
 from services.notification_service import NotificationService
 from websocket.emitters import on_certificate_issued
-from utils.datetime_utils import utc_now, utc_isoformat
+from utils.datetime_utils import cert_not_before, utc_isoformat, utc_now
 from utils.db_transaction import safe_commit
 from . import bp
 
@@ -170,9 +170,8 @@ def create_certificate():
         if validity_days < 1 or validity_days > MAX_VALIDITY_DAYS:
             return error_response(
                 f"validity_days must be between 1 and {MAX_VALIDITY_DAYS}", 400)
-        now = utc_now()
-        not_before = now
-        not_after = now + timedelta(days=validity_days)
+        not_before = cert_not_before()
+        not_after = utc_now() + timedelta(days=validity_days)
 
         # Cert validity must not exceed CA cert validity
         ca_not_after = ca_cert.not_valid_after_utc.replace(tzinfo=None)

--- a/backend/api/v2/certificates/cert_renew.py
+++ b/backend/api/v2/certificates/cert_renew.py
@@ -14,7 +14,7 @@ from cryptography.hazmat.backends import default_backend
 from cryptography.x509.oid import ExtensionOID
 from services.audit_service import AuditService
 from websocket.emitters import on_certificate_renewed
-from utils.datetime_utils import utc_now
+from utils.datetime_utils import cert_not_before, utc_now
 from . import bp
 
 logger = logging.getLogger(__name__)
@@ -103,9 +103,8 @@ def renew_certificate(cert_id):
         if validity_days > 3650:
             validity_days = 3650
 
-        now = utc_now()
-        not_before = now
-        not_after = now + timedelta(days=validity_days)
+        not_before = cert_not_before()
+        not_after = utc_now() + timedelta(days=validity_days)
         # Don't exceed CA expiration
         ca_not_after = ca_cert.not_valid_after_utc.replace(tzinfo=None)
         if not_after > ca_not_after:

--- a/backend/services/scep/scep_service.py
+++ b/backend/services/scep/scep_service.py
@@ -21,7 +21,7 @@ from cryptography.x509.oid import ExtensionOID
 from config.settings import Config
 from models import CA, Certificate, SCEPRequest, db
 from utils.key_codec import load_pem_bytes
-from utils.datetime_utils import utc_now
+from utils.datetime_utils import cert_not_before, utc_now
 from utils.file_naming import cert_cert_path
 
 from services.scep.message_parser import (
@@ -637,8 +637,8 @@ class SCEPService:
         # Clamp validity to the CA's own expiry — issuing a leaf that outlives
         # its issuer is invalid per RFC 5280 §6.1 and breaks every chain
         # validator the moment the CA expires.
-        not_before = utc_now()
-        requested_not_after = not_before + timedelta(days=validity_days)
+        not_before = cert_not_before()
+        requested_not_after = utc_now() + timedelta(days=validity_days)
         # not_valid_after_utc is timezone-aware; utc_now() is naive-UTC (project
         # convention). Drop the tzinfo so the comparisons below stay naive-vs-naive
         # — mixing the two raises "can't compare offset-naive and offset-aware".

--- a/backend/services/trust_store/ca_certificate_creation_mixin.py
+++ b/backend/services/trust_store/ca_certificate_creation_mixin.py
@@ -9,7 +9,7 @@ from cryptography import x509
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.backends import default_backend
 
-from utils.datetime_utils import utc_now, to_naive_utc
+from utils.datetime_utils import cert_not_before, to_naive_utc, utc_now
 from utils.ca_profile import (
     build_extended_key_usage_extension,
     build_key_usage_extension,
@@ -73,7 +73,7 @@ class CACertificateCreationMixin:
         builder = builder.serial_number(
             serial if serial else x509.random_serial_number()
         )
-        builder = builder.not_valid_before(utc_now())
+        builder = builder.not_valid_before(cert_not_before())
         not_after = utc_now() + timedelta(days=validity_days)
         max_end = to_naive_utc(not_valid_after_max)
         if max_end is not None and not_after > max_end:

--- a/backend/services/trust_store/certificate_creation_mixin.py
+++ b/backend/services/trust_store/certificate_creation_mixin.py
@@ -10,7 +10,7 @@ from cryptography.x509.oid import NameOID
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.backends import default_backend
 
-from utils.datetime_utils import utc_now
+from utils.datetime_utils import cert_not_before, utc_now
 from .constants import HASH_ALGORITHMS
 from .constraints_mixin import ConstraintsMixin
 from .key_operations_mixin import KeyOperationsMixin
@@ -54,7 +54,7 @@ class CertificateCreationMixin:
         builder = builder.issuer_name(ca_cert.subject)
         builder = builder.public_key(private_key.public_key())
         builder = builder.serial_number(x509.random_serial_number())
-        builder = builder.not_valid_before(utc_now())
+        builder = builder.not_valid_before(cert_not_before())
         builder = builder.not_valid_after(
             utc_now() + timedelta(days=validity_days)
         )

--- a/backend/services/trust_store/csr_operations_mixin.py
+++ b/backend/services/trust_store/csr_operations_mixin.py
@@ -10,7 +10,7 @@ from cryptography.x509.oid import NameOID, ExtensionOID
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.backends import default_backend
 
-from utils.datetime_utils import utc_now
+from utils.datetime_utils import cert_not_before, utc_now
 from .constants import HASH_ALGORITHMS
 from .key_operations_mixin import KeyOperationsMixin
 from .constraints_mixin import ConstraintsMixin
@@ -130,7 +130,7 @@ class CSROperationsMixin:
         builder = builder.issuer_name(ca_cert.subject)
         builder = builder.public_key(csr.public_key())
         builder = builder.serial_number(x509.random_serial_number())
-        builder = builder.not_valid_before(utc_now())
+        builder = builder.not_valid_before(cert_not_before())
         builder = builder.not_valid_after(
             utc_now() + timedelta(days=validity_days)
         )

--- a/backend/tests/test_cert_notbefore_skew.py
+++ b/backend/tests/test_cert_notbefore_skew.py
@@ -1,0 +1,40 @@
+"""Regression: certificate notBefore backdated for clock skew (#207)."""
+from datetime import timedelta
+
+from cryptography import x509
+from cryptography.hazmat.backends import default_backend
+
+from utils.datetime_utils import (
+    DEFAULT_CERT_NOT_BEFORE_SKEW_MINUTES,
+    cert_not_before,
+    utc_now,
+)
+
+BASE = '/api/v2/certificates'
+
+
+class TestCertNotBeforeSkew:
+    def test_default_skew_is_fifteen_minutes(self):
+        now = utc_now()
+        nb = cert_not_before()
+        delta = now - nb
+        assert timedelta(minutes=14, seconds=50) <= delta <= timedelta(minutes=15, seconds=10)
+        assert DEFAULT_CERT_NOT_BEFORE_SKEW_MINUTES == 15
+
+    def test_custom_skew_clamped_to_non_negative(self):
+        now = utc_now()
+        assert cert_not_before(0) == now or abs((now - cert_not_before(0)).total_seconds()) < 2
+        assert utc_now() - cert_not_before(5) >= timedelta(minutes=4, seconds=50)
+
+    def test_issued_certificate_not_before_backdated(self, auth_client, create_cert):
+        cert = create_cert(cn='notbefore-skew.example.com')
+        cert_id = cert.get('id', cert.get('cert_id'))
+        r = auth_client.get(f'{BASE}/{cert_id}/export?format=pem')
+        assert r.status_code == 200
+        pem = r.data.decode('utf-8')
+        x509_cert = x509.load_pem_x509_certificate(pem.encode(), default_backend())
+        nb = x509_cert.not_valid_before_utc.replace(tzinfo=None)
+        now = utc_now()
+        assert nb < now
+        assert now - nb >= timedelta(minutes=14)
+        assert now - nb <= timedelta(minutes=16)

--- a/backend/utils/datetime_utils.py
+++ b/backend/utils/datetime_utils.py
@@ -5,7 +5,10 @@ in this codebase represent UTC. This module provides a utc_now()
 function that uses the non-deprecated datetime.now(timezone.utc) API
 but returns a naive datetime for DB compatibility.
 """
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
+
+# Default backdate for certificate notBefore (discussion #207 clock skew).
+DEFAULT_CERT_NOT_BEFORE_SKEW_MINUTES = 15
 
 
 def utc_now() -> datetime:
@@ -16,6 +19,20 @@ def utc_now() -> datetime:
     stored in SQLite via SQLAlchemy.
     """
     return datetime.now(timezone.utc).replace(tzinfo=None)
+
+
+def cert_not_before(skew_minutes: int | None = None) -> datetime:
+    """UTC ``notBefore`` for issued certificates, backdated for clock skew.
+
+    Relying parties with clocks slightly behind the CA otherwise reject
+    freshly issued certificates. Default skew is 15 minutes (#207).
+    """
+    minutes = (
+        DEFAULT_CERT_NOT_BEFORE_SKEW_MINUTES
+        if skew_minutes is None
+        else max(0, int(skew_minutes))
+    )
+    return utc_now() - timedelta(minutes=minutes)
 
 
 def to_naive_utc(dt: datetime | None) -> datetime | None:
@@ -37,5 +54,4 @@ def utc_isoformat(dt):
         return None
     if dt.tzinfo is None:
         return dt.isoformat() + 'Z'
-    from datetime import timezone
     return dt.astimezone(timezone.utc).isoformat().replace('+00:00', 'Z')


### PR DESCRIPTION
## Summary
- Fixed 15-minute `notBefore` backdate via `cert_not_before()` (no new setting)
- Applied on certificate create/renew, SCEP, and trust-store issuance paths

Accepted enhancement from discussion #207.

## Test plan
- [x] `pytest tests/test_cert_notbefore_skew.py`