### PR TITLE
feat(crl): decouple validity from publish interval and CRL digest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ Starting with v2.48, UCM uses Major.Build versioning (e.g., 2.48, 2.49). Earlier
 
 ## [Unreleased]
 
+### Added
+- **Full CRL validity/publish decoupling + configurable digest** — per-CA `crl_validity_days` (nextUpdate window), `crl_publish_interval_hours` (automatic republish cadence), and `crl_digest` (sha224/sha256/sha384/sha512). `CRLMetadata.next_publish` tracks the scheduler's next republish target independently of `next_update`; the CRL scheduler regenerates on `next_publish` when set, falling back to the existing 24h-before-expiry threshold. New `GET|POST /api/v2/crl/<ca_id>/config` endpoints and a "Full CRL schedule" panel on the CRL/OCSP page. (#207)
+
 ## [2.194] - 2026-07-17
 
 ### Fixed

--- a/backend/api/v2/crl.py
+++ b/backend/api/v2/crl.py
@@ -286,6 +286,86 @@ def configure_delta_crl(ca_id):
         return error_response("Failed to update delta CRL settings", 500)
 
 
+@bp.route('/api/v2/crl/<int:ca_id>/config', methods=['GET'])
+@require_auth(['read:crl'])
+def get_full_crl_config(ca_id):
+    """Get full CRL validity / publish / digest settings (discussion #207)."""
+    ca = db.session.get(CA, ca_id)
+    if not ca:
+        return error_response('CA not found', 404)
+
+    return success_response(data={
+        'crl_validity_days': ca.crl_validity_days if ca.crl_validity_days is not None else 7,
+        'crl_publish_interval_hours': (
+            ca.crl_publish_interval_hours if ca.crl_publish_interval_hours is not None else 168
+        ),
+        'crl_digest': ca.crl_digest or 'sha256',
+        'delta_crl_enabled': bool(ca.delta_crl_enabled),
+        'delta_crl_interval': ca.delta_crl_interval or 4,
+    })
+
+
+@bp.route('/api/v2/crl/<int:ca_id>/config', methods=['POST'])
+@require_auth(['write:crl'])
+def configure_full_crl(ca_id):
+    """Update full CRL validity / publish / digest settings (discussion #207)."""
+    ca = db.session.get(CA, ca_id)
+    if not ca:
+        return error_response('CA not found', 404)
+
+    data = request.get_json() or {}
+    allowed_digests = {'sha224', 'sha256', 'sha384', 'sha512'}
+
+    try:
+        if 'crl_validity_days' in data:
+            days = int(data['crl_validity_days'])
+            if days < 1 or days > 365:
+                return error_response('crl_validity_days must be between 1 and 365', 400)
+            ca.crl_validity_days = days
+        if 'crl_publish_interval_hours' in data:
+            hours = int(data['crl_publish_interval_hours'])
+            if hours < 1 or hours > 8760:
+                return error_response('crl_publish_interval_hours must be between 1 and 8760', 400)
+            ca.crl_publish_interval_hours = hours
+        if 'crl_digest' in data:
+            digest = str(data['crl_digest']).lower().strip()
+            if digest not in allowed_digests:
+                return error_response(f"crl_digest must be one of: {', '.join(sorted(allowed_digests))}", 400)
+            ca.crl_digest = digest
+
+        AuditService.log_action(
+            action='crl_config',
+            resource_type='ca',
+            resource_id=str(ca.id),
+            resource_name=ca.descr,
+            details=(
+                f"CRL config: validity={ca.crl_validity_days}d, "
+                f"publish={ca.crl_publish_interval_hours}h, digest={ca.crl_digest}"
+            ),
+            success=True
+        )
+
+        ok, err = safe_commit(logger, 'Failed to update CRL settings')
+        if not ok:
+            return err
+
+        return success_response(
+            data={
+                'crl_validity_days': ca.crl_validity_days,
+                'crl_publish_interval_hours': ca.crl_publish_interval_hours,
+                'crl_digest': ca.crl_digest or 'sha256',
+            },
+            message='CRL configuration updated'
+        )
+    except (TypeError, ValueError):
+        db.session.rollback()
+        return error_response('Invalid CRL configuration values', 400)
+    except Exception as e:
+        db.session.rollback()
+        logger.error(f'Failed to configure CRL: {e}')
+        return error_response("Failed to update CRL settings", 500)
+
+
 @bp.route('/api/v2/ocsp/status', methods=['GET'])
 @require_auth(['read:certificates'])
 def get_ocsp_status():

--- a/backend/app.py
+++ b/backend/app.py
@@ -1017,6 +1017,9 @@ def init_database(app):
                 ('serial_number', 'VARCHAR(64)', None),
                 ('delta_crl_enabled', 'BOOLEAN', '0'),
                 ('delta_crl_interval', 'INTEGER', '4'),
+                ('crl_validity_days', 'INTEGER', '7'),
+                ('crl_publish_interval_hours', 'INTEGER', '168'),
+                ('crl_digest', 'VARCHAR(20)', "'sha256'"),
             ],
             'groups': [
                 ('description', 'TEXT', None),
@@ -1047,6 +1050,7 @@ def init_database(app):
             'crl_metadata': [
                 ('is_delta', 'BOOLEAN', '0'),
                 ('base_crl_number', 'INTEGER', None),
+                ('next_publish', 'DATETIME', None),
             ],
             'approval_requests': [
                 ('request_data', 'TEXT', None),

--- a/backend/migrations/059_crl_validity_publish_digest.py
+++ b/backend/migrations/059_crl_validity_publish_digest.py
@@ -1,0 +1,104 @@
+"""Migration 059: per-CA CRL validity / publish / digest + next_publish metadata.
+
+Discussion #207 — decouple full-CRL nextUpdate (validity) from publish schedule,
+allow configurable CRL digest, and expose next_publish on CRLMetadata.
+"""
+
+import logging
+import sqlite3
+
+logger = logging.getLogger(__name__)
+pg_compatible = True
+
+_CA_COLS_SQLITE = [
+    ("crl_validity_days", "INTEGER DEFAULT 7"),
+    ("crl_publish_interval_hours", "INTEGER DEFAULT 168"),
+    ("crl_digest", "TEXT DEFAULT 'sha256'"),
+]
+_CA_COLS_PG = [
+    ("crl_validity_days", "INTEGER DEFAULT 7"),
+    ("crl_publish_interval_hours", "INTEGER DEFAULT 168"),
+    ("crl_digest", "VARCHAR(20) DEFAULT 'sha256'"),
+]
+
+
+def _upgrade_sqlite(conn):
+    cur = conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='certificate_authorities'"
+    )
+    if cur.fetchone():
+        existing = {
+            row[1] for row in conn.execute("PRAGMA table_info(certificate_authorities)")
+        }
+        for name, ddl in _CA_COLS_SQLITE:
+            if name in existing:
+                continue
+            conn.execute(f"ALTER TABLE certificate_authorities ADD COLUMN {name} {ddl}")
+            logger.info(f"[059] added certificate_authorities.{name} (SQLite)")
+
+    cur = conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='crl_metadata'"
+    )
+    if cur.fetchone():
+        existing = {row[1] for row in conn.execute("PRAGMA table_info(crl_metadata)")}
+        if "next_publish" not in existing:
+            conn.execute("ALTER TABLE crl_metadata ADD COLUMN next_publish DATETIME")
+            logger.info("[059] added crl_metadata.next_publish (SQLite)")
+
+    conn.commit()
+
+
+def _upgrade_pg(conn):
+    from sqlalchemy import inspect, text
+
+    insp = inspect(conn)
+    tables = set(insp.get_table_names())
+
+    if "certificate_authorities" in tables:
+        existing = {c["name"] for c in insp.get_columns("certificate_authorities")}
+        for name, ddl in _CA_COLS_PG:
+            if name in existing:
+                continue
+            conn.execute(
+                text(f"ALTER TABLE certificate_authorities ADD COLUMN {name} {ddl}")
+            )
+            logger.info(f"[059] added certificate_authorities.{name} (PostgreSQL)")
+
+    if "crl_metadata" in tables:
+        existing = {c["name"] for c in insp.get_columns("crl_metadata")}
+        if "next_publish" not in existing:
+            conn.execute(
+                text("ALTER TABLE crl_metadata ADD COLUMN next_publish TIMESTAMP")
+            )
+            logger.info("[059] added crl_metadata.next_publish (PostgreSQL)")
+
+
+def upgrade(conn):
+    if isinstance(conn, sqlite3.Connection):
+        _upgrade_sqlite(conn)
+    else:
+        _upgrade_pg(conn)
+
+
+def downgrade(conn):
+    cols_ca = ["crl_validity_days", "crl_publish_interval_hours", "crl_digest"]
+    if isinstance(conn, sqlite3.Connection):
+        for c in cols_ca + ["next_publish"]:
+            try:
+                if c == "next_publish":
+                    conn.execute(f"ALTER TABLE crl_metadata DROP COLUMN {c}")
+                else:
+                    conn.execute(f"ALTER TABLE certificate_authorities DROP COLUMN {c}")
+            except Exception:
+                pass
+        conn.commit()
+    else:
+        from sqlalchemy import text
+
+        for c in cols_ca:
+            conn.execute(
+                text(f"ALTER TABLE certificate_authorities DROP COLUMN IF EXISTS {c}")
+            )
+        conn.execute(
+            text("ALTER TABLE crl_metadata DROP COLUMN IF EXISTS next_publish")
+        )

--- a/backend/models/ca.py
+++ b/backend/models/ca.py
@@ -40,6 +40,10 @@ class CA(db.Model):
     cdp_url = db.Column(db.String(512))  # Ex: http://ucm.local:8443/cdp/{ca_refid}/crl.pem
     delta_crl_enabled = db.Column(db.Boolean, default=False)
     delta_crl_interval = db.Column(db.Integer, default=4)  # Hours between delta CRLs
+    # Full CRL: nextUpdate window (days) vs publish cadence (hours) — discussion #207
+    crl_validity_days = db.Column(db.Integer, default=7)
+    crl_publish_interval_hours = db.Column(db.Integer, default=168)
+    crl_digest = db.Column(db.String(20), default='sha256')
     
     # OCSP (Online Certificate Status Protocol)
     ocsp_enabled = db.Column(db.Boolean, default=False)
@@ -352,6 +356,13 @@ class CA(db.Model):
             "cdp_urls": self.get_cdp_urls(),
             "delta_crl_enabled": self.delta_crl_enabled,
             "delta_crl_interval": self.delta_crl_interval or 4,
+            "crl_validity_days": self.crl_validity_days if self.crl_validity_days is not None else 7,
+            "crl_publish_interval_hours": (
+                self.crl_publish_interval_hours
+                if self.crl_publish_interval_hours is not None
+                else 168
+            ),
+            "crl_digest": self.crl_digest or 'sha256',
             # OCSP configuration
             "ocsp_enabled": self.ocsp_enabled,
             "ocsp_url": self.get_primary_ocsp_url(),

--- a/backend/models/crl.py
+++ b/backend/models/crl.py
@@ -20,6 +20,8 @@ class CRLMetadata(db.Model):
     # Validity period (RFC 5280 - Section 5.1.2.4-5)
     this_update = db.Column(db.DateTime, nullable=False)
     next_update = db.Column(db.DateTime, nullable=False)
+    # Scheduler publish target (may be earlier than next_update) — discussion #207
+    next_publish = db.Column(db.DateTime, nullable=True)
     
     # CRL data in multiple formats
     crl_pem = db.Column(db.Text, nullable=False)  # PEM encoded CRL
@@ -66,6 +68,7 @@ class CRLMetadata(db.Model):
             "crl_number": self.crl_number,
             "this_update": utc_isoformat(self.this_update),
             "next_update": utc_isoformat(self.next_update),
+            "next_publish": utc_isoformat(self.next_publish),
             "revoked_count": self.revoked_count,
             "is_stale": self.is_stale,
             "days_until_expiry": self.days_until_expiry,

--- a/backend/services/crl/generation.py
+++ b/backend/services/crl/generation.py
@@ -10,6 +10,7 @@ from cryptography.hazmat.backends import default_backend
 
 from models import db, CA, Certificate
 from models.crl import CRLMetadata
+from services.trust_store.constants import HASH_ALGORITHMS
 from utils.datetime_utils import utc_now
 from utils.serial_format import serial_to_int
 from utils.x509_aki import authority_key_identifier_from_issuer
@@ -17,6 +18,34 @@ from ._constants import REASON_MAP
 from .query import CRLQueryMixin
 
 logger = logging.getLogger(__name__)
+
+DEFAULT_CRL_VALIDITY_DAYS = 7
+DEFAULT_CRL_PUBLISH_INTERVAL_HOURS = 168
+
+
+def _crl_hash_algorithm(ca: CA):
+    digest = (getattr(ca, 'crl_digest', None) or 'sha256').lower().strip()
+    return HASH_ALGORITHMS.get(digest, hashes.SHA256())
+
+
+def _resolve_full_crl_validity_days(ca: CA, validity_days: Optional[int]) -> int:
+    if validity_days is not None:
+        days = int(validity_days)
+    else:
+        days = int(getattr(ca, 'crl_validity_days', None) or DEFAULT_CRL_VALIDITY_DAYS)
+    if days < 1 or days > 365:
+        raise ValueError('validity_days must be between 1 and 365')
+    return days
+
+
+def _next_publish_at(ca: CA, now):
+    hours = getattr(ca, 'crl_publish_interval_hours', None)
+    if hours is None:
+        hours = DEFAULT_CRL_PUBLISH_INTERVAL_HOURS
+    hours = int(hours)
+    if hours < 1:
+        return None
+    return now + timedelta(hours=hours)
 
 
 def _authority_key_identifier_for_crl(ca_cert: x509.Certificate) -> x509.AuthorityKeyIdentifier:
@@ -125,12 +154,12 @@ def _parse_revoked_serial(cert: Certificate, *, context: str) -> Optional[int]:
 
 class CRLGenerationMixin:
 
-    DEFAULT_VALIDITY_DAYS = 7
+    DEFAULT_VALIDITY_DAYS = DEFAULT_CRL_VALIDITY_DAYS
 
     @staticmethod
     def generate_crl(
         ca_id: int,
-        validity_days: int = 7,
+        validity_days: Optional[int] = None,
         username: str = 'system'
     ) -> CRLMetadata:
         ca = db.session.get(CA, ca_id)
@@ -139,6 +168,8 @@ class CRLGenerationMixin:
 
         if not ca.has_private_key:
             raise ValueError(f"CA {ca.descr} does not have a private key - cannot sign CRL")
+
+        validity_days = _resolve_full_crl_validity_days(ca, validity_days)
 
         ca_cert_pem = base64.b64decode(ca.crt).decode('utf-8')
         ca_cert = x509.load_pem_x509_certificate(ca_cert_pem.encode(), default_backend())
@@ -154,10 +185,12 @@ class CRLGenerationMixin:
         crl_number = 1 if not last_crl else last_crl.crl_number + 1
 
         now = utc_now()
+        next_update = now + timedelta(days=validity_days)
+        next_publish = _next_publish_at(ca, now)
         builder = x509.CertificateRevocationListBuilder()
         builder = builder.issuer_name(ca_cert.subject)
         builder = builder.last_update(now)
-        builder = builder.next_update(now + timedelta(days=validity_days))
+        builder = builder.next_update(next_update)
 
         entries = 0
         for cert in revoked_certs:
@@ -183,7 +216,7 @@ class CRLGenerationMixin:
         # UCM issues unpartitioned CRLs — omit IDP on both full and delta.
         builder = _add_freshest_crl(builder, ca)
 
-        crl = builder.sign(ca_private_key, hashes.SHA256(), default_backend())
+        crl = builder.sign(ca_private_key, _crl_hash_algorithm(ca), default_backend())
 
         crl_pem = crl.public_bytes(serialization.Encoding.PEM).decode('utf-8')
         crl_der = crl.public_bytes(serialization.Encoding.DER)
@@ -192,7 +225,8 @@ class CRLGenerationMixin:
             ca_id=ca_id,
             crl_number=crl_number,
             this_update=now,
-            next_update=now + timedelta(days=validity_days),
+            next_update=next_update,
+            next_publish=next_publish,
             crl_pem=crl_pem,
             crl_der=crl_der,
             revoked_count=entries,
@@ -296,7 +330,7 @@ class CRLGenerationMixin:
             _authority_key_identifier_for_crl(ca_cert), critical=False
         )
 
-        crl = builder.sign(ca_private_key, hashes.SHA256(), default_backend())
+        crl = builder.sign(ca_private_key, _crl_hash_algorithm(ca), default_backend())
 
         crl_pem = crl.public_bytes(serialization.Encoding.PEM).decode('utf-8')
         crl_der = crl.public_bytes(serialization.Encoding.DER)
@@ -307,6 +341,7 @@ class CRLGenerationMixin:
                 crl_number=crl_number,
                 this_update=now,
                 next_update=now + timedelta(hours=validity_hours),
+                next_publish=None,
                 crl_pem=crl_pem,
                 crl_der=crl_der,
                 revoked_count=entries,

--- a/backend/services/crl_scheduler_task.py
+++ b/backend/services/crl_scheduler_task.py
@@ -1,40 +1,36 @@
 """
 CRL Scheduler Task - Automatic CRL Regeneration
-Monitors CRL expiration and regenerates when needed
+Monitors CRL expiration / publish schedule and regenerates when needed
 """
 import logging
-from datetime import datetime, timedelta
 from typing import Optional
 
 from models import db, CA
 from models.crl import CRLMetadata
 from services.crl_service import CRLService
+from utils.datetime_utils import utc_now
 
 logger = logging.getLogger(__name__)
 
 
 class CRLSchedulerTask:
     """
-    Handles automatic CRL regeneration based on expiration
-    
+    Handles automatic CRL regeneration based on publish schedule and expiration.
+
     Strategy:
-    - Check all CAs with private keys
-    - For each CA, get latest CRL
-    - If CRL is within threshold of expiration (or missing), regenerate
-    - Default threshold: regenerate when 24 hours before expiration
+    - Prefer ``next_publish`` when set (decoupled from nextUpdate validity)
+    - Else regenerate when within threshold of next_update (default 24h)
+    - Always regenerate if no base CRL or next_update has passed
     """
-    
-    # Regenerate CRL when this many hours before expiration
+
+    # Fallback when next_publish is unset: regenerate this many hours before next_update
     REGENERATION_THRESHOLD_HOURS = 24
-    
+
     @staticmethod
     def should_regenerate_crl(ca_id: int) -> tuple[bool, Optional[str]]:
         """
-        Check if a CA's CRL should be regenerated
-        
-        Args:
-            ca_id: CA database ID
-            
+        Check if a CA's full CRL should be regenerated.
+
         Returns:
             Tuple of (should_regenerate: bool, reason: str or None)
         """
@@ -42,102 +38,95 @@ class CRLSchedulerTask:
             ca = db.session.get(CA, ca_id)
             if not ca:
                 return False, f"CA {ca_id} not found"
-            
-            # Skip if no private key (can't sign CRL)
+
             if not ca.has_private_key:
                 return False, f"CA '{ca.descr}' has no private key"
-            
-            # Get latest CRL
+
             latest_crl = CRLMetadata.query.filter_by(
-                ca_id=ca_id
-            ).order_by(CRLMetadata.created_at.desc()).first()
-            
+                ca_id=ca_id, is_delta=False
+            ).order_by(CRLMetadata.crl_number.desc()).first()
+
             if not latest_crl:
                 return True, f"No CRL exists for CA '{ca.descr}' - needs generation"
-            
-            # Check if CRL is stale (past next_update)
+
+            now = utc_now()
+
             if latest_crl.is_stale:
                 return True, f"CRL is stale for CA '{ca.descr}' - needs regeneration"
-            
-            # Check if approaching expiration
-            hours_until_expiry = latest_crl.days_until_expiry * 24
+
+            if latest_crl.next_publish is not None and now >= latest_crl.next_publish:
+                return (
+                    True,
+                    f"CRL publish due for CA '{ca.descr}' "
+                    f"(next_publish={latest_crl.next_publish.isoformat()})"
+                )
+
+            hours_until_expiry = (latest_crl.next_update - now).total_seconds() / 3600
             if hours_until_expiry <= CRLSchedulerTask.REGENERATION_THRESHOLD_HOURS:
                 return (
                     True,
                     f"CRL expires in {hours_until_expiry:.1f}h for CA '{ca.descr}' "
                     f"(threshold: {CRLSchedulerTask.REGENERATION_THRESHOLD_HOURS}h)"
                 )
-            
+
             return False, None
-        
+
         except Exception as e:
             logger.error(f"Error checking CRL regeneration for CA {ca_id}: {e}", exc_info=True)
             return False, f"Error: {str(e)}"
-    
+
     @staticmethod
     def regenerate_crl(ca_id: int, username: str = "scheduler") -> bool:
-        """
-        Regenerate CRL for a specific CA
-        
-        Args:
-            ca_id: CA database ID
-            username: Username to record in audit log
-            
-        Returns:
-            True if successful, False if failed
-        """
+        """Regenerate full CRL for a specific CA."""
         try:
             ca = db.session.get(CA, ca_id)
             if not ca:
                 logger.error(f"Cannot regenerate CRL: CA {ca_id} not found")
                 return False
-            
+
             logger.info(f"Regenerating CRL for CA '{ca.descr}' (ID: {ca_id})")
-            
-            # Generate new CRL using CRLService
+
             crl_metadata = CRLService.generate_crl(
                 ca_id=ca_id,
                 username=username
             )
-            
+
             logger.info(
                 f"Successfully generated CRL for CA '{ca.descr}' "
-                f"(#{ crl_metadata.crl_number}, {crl_metadata.revoked_count} revoked certs)"
+                f"(#{crl_metadata.crl_number}, {crl_metadata.revoked_count} revoked certs)"
             )
             return True
-        
+
         except Exception as e:
             logger.error(
                 f"Error regenerating CRL for CA {ca_id}: {e}",
                 exc_info=True
             )
             return False
-    
+
     @staticmethod
     def execute() -> None:
         """
-        Main task to check all CAs and regenerate CRLs as needed
-        Called by scheduler every N seconds
+        Main task to check all CAs and regenerate CRLs as needed.
+        Called by scheduler every N seconds.
         """
         try:
             logger.debug("Starting CRL regeneration check")
-            
-            # Get all CAs with CDP enabled (auto-regen)
-            # NOTE: has_private_key is a @property, NOT a DB column — cannot use filter_by
+
             cas_with_cdp = CA.query.filter_by(cdp_enabled=True).all()
             cas_with_keys = [ca for ca in cas_with_cdp if ca.has_private_key]
-            
+
             if not cas_with_keys:
                 logger.debug("No CAs with CDP enabled and private key found")
                 return
-            
+
             regenerated_count = 0
             skipped_count = 0
             error_count = 0
-            
+
             for ca in cas_with_keys:
                 should_regen, reason = CRLSchedulerTask.should_regenerate_crl(ca.id)
-                
+
                 if should_regen:
                     logger.info(f"Regenerating CRL: {reason}")
                     success = CRLSchedulerTask.regenerate_crl(ca.id)
@@ -149,42 +138,39 @@ class CRLSchedulerTask:
                     if reason:
                         logger.debug(f"Skipping CRL regeneration: {reason}")
                     skipped_count += 1
-            
+
             logger.info(
                 f"CRL regeneration check complete: "
                 f"regenerated={regenerated_count}, "
                 f"skipped={skipped_count}, "
                 f"errors={error_count}"
             )
-            
+
             # Check delta CRLs for CAs with delta enabled
             # NOTE: has_private_key is a @property — filter in Python
             delta_cas = [
                 ca for ca in CA.query.filter_by(cdp_enabled=True, delta_crl_enabled=True).all()
                 if ca.has_private_key
             ]
-            
+
             delta_count = 0
             for ca in delta_cas:
                 try:
-                    # Check if delta CRL needs regeneration
                     latest_delta = CRLService.get_latest_delta_crl(ca.id)
                     interval_hours = ca.delta_crl_interval or 4
-                    
+
                     need_delta = False
                     if not latest_delta:
-                        # Only generate delta if a base CRL exists
                         base = CRLService.get_latest_base_crl(ca.id)
                         if base:
                             need_delta = True
                     elif latest_delta.is_stale:
                         need_delta = True
                     else:
-                        from utils.datetime_utils import utc_now as _utc_now
-                        age_hours = (_utc_now() - latest_delta.this_update).total_seconds() / 3600
+                        age_hours = (utc_now() - latest_delta.this_update).total_seconds() / 3600
                         if age_hours >= interval_hours:
                             need_delta = True
-                    
+
                     if need_delta:
                         CRLService.generate_delta_crl(
                             ca.id,
@@ -194,10 +180,10 @@ class CRLSchedulerTask:
                         delta_count += 1
                 except Exception as e:
                     logger.error(f"Error generating delta CRL for CA {ca.id}: {e}")
-            
+
             if delta_count > 0:
                 logger.info(f"Generated {delta_count} delta CRL(s)")
-        
+
         except Exception as e:
             logger.error(f"Error in CRL regeneration task: {e}", exc_info=True)
 

--- a/backend/tests/test_crl_validity_publish_digest.py
+++ b/backend/tests/test_crl_validity_publish_digest.py
@@ -1,0 +1,125 @@
+"""
+CRL validity / publish / digest (discussion #207).
+
+- Full CRL validity vs publish schedule + next_publish
+- Configurable CRL signature digest
+- Scheduler prefers next_publish when set
+- Auth gates for the /config endpoints
+"""
+
+import json
+import os
+import sys
+from datetime import timedelta
+
+from cryptography import x509
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives import hashes
+from tests.conftest import assert_success
+from utils.datetime_utils import utc_now
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+CONTENT_JSON = "application/json"
+
+
+def _post_json(client, url, data):
+    return client.post(url, data=json.dumps(data), content_type=CONTENT_JSON)
+
+
+class TestCrlValidityPublishDigest:
+    def test_config_and_next_publish(self, app, auth_client, create_ca):
+        ca = create_ca(cn="CRL Config CA")
+        ca_id = ca["id"]
+
+        r = auth_client.get(f"/api/v2/crl/{ca_id}/config")
+        cfg = assert_success(r)
+        assert cfg["crl_validity_days"] == 7
+        assert cfg["crl_publish_interval_hours"] == 168
+        assert cfg["crl_digest"] == "sha256"
+
+        r = _post_json(
+            auth_client,
+            f"/api/v2/crl/{ca_id}/config",
+            {
+                "crl_validity_days": 14,
+                "crl_publish_interval_hours": 24,
+                "crl_digest": "sha384",
+            },
+        )
+        updated = assert_success(r)
+        assert updated["crl_validity_days"] == 14
+        assert updated["crl_publish_interval_hours"] == 24
+        assert updated["crl_digest"] == "sha384"
+
+        with app.app_context():
+            from models import CA, db
+
+            row = db.session.get(CA, ca_id)
+            row.cdp_enabled = True
+            db.session.commit()
+
+        r = auth_client.post(f"/api/v2/crl/{ca_id}/regenerate")
+        meta = assert_success(r)
+        assert meta.get("next_publish")
+        assert meta.get("next_update")
+
+        this_update = meta["this_update"].replace("Z", "")
+        next_update = meta["next_update"].replace("Z", "")
+        next_publish = meta["next_publish"].replace("Z", "")
+        from datetime import datetime
+
+        tu = datetime.fromisoformat(this_update)
+        nu = datetime.fromisoformat(next_update)
+        np = datetime.fromisoformat(next_publish)
+        assert abs((nu - tu).days - 14) <= 1
+        assert abs((np - tu).total_seconds() / 3600 - 24) < 1
+
+        r = auth_client.get(f"/api/v2/crl/{ca_id}")
+        data = assert_success(r)
+        crl = x509.load_pem_x509_crl(data["crl_pem"].encode(), default_backend())
+        assert isinstance(crl.signature_hash_algorithm, hashes.SHA384)
+
+    def test_scheduler_uses_next_publish(self, app, auth_client, create_ca):
+        ca = create_ca(cn="CRL Publish Due CA")
+        ca_id = ca["id"]
+        with app.app_context():
+            from models import CA, db
+
+            row = db.session.get(CA, ca_id)
+            row.cdp_enabled = True
+            row.crl_validity_days = 30
+            row.crl_publish_interval_hours = 1
+            db.session.commit()
+
+        assert_success(auth_client.post(f"/api/v2/crl/{ca_id}/regenerate"))
+
+        with app.app_context():
+            from models.crl import CRLMetadata
+            from services.crl_scheduler_task import CRLSchedulerTask
+
+            latest = (
+                CRLMetadata.query.filter_by(ca_id=ca_id, is_delta=False)
+                .order_by(CRLMetadata.crl_number.desc())
+                .first()
+            )
+            latest.next_publish = utc_now() - timedelta(minutes=1)
+            from models import db
+
+            db.session.commit()
+            should, reason = CRLSchedulerTask.should_regenerate_crl(ca_id)
+            assert should is True
+            assert "publish due" in (reason or "").lower()
+
+
+class TestCrlConfigAuthGates:
+    def test_config_requires_auth(self, client, create_ca, auth_client):
+        ca = create_ca(cn="CRL Config Auth CA")
+        r = client.get(f"/api/v2/crl/{ca['id']}/config")
+        assert r.status_code == 401
+        r = client.post(
+            f"/api/v2/crl/{ca['id']}/config",
+            data=json.dumps({"crl_digest": "sha256"}),
+            content_type=CONTENT_JSON,
+        )
+        assert r.status_code == 401

--- a/docs/ADMIN_GUIDE.md
+++ b/docs/ADMIN_GUIDE.md
@@ -365,6 +365,22 @@ http://your-server:8080/cdp/<ca_refid>-delta.crl   # when delta CRL is enabled
 
 Management UI: **CA → CRL / CDP** tab (enable CDP, optional delta, regeneration interval).
 
+**Full CRL schedule** (validity vs publish — discussion #207):
+
+| Setting | Default | Meaning |
+|---------|---------|---------|
+| `crl_validity_days` | 7 | `nextUpdate` window on the full CRL |
+| `crl_publish_interval_hours` | 168 | Scheduler republish target (`next_publish` in metadata) |
+| `crl_digest` | `sha256` | CRL signature hash (`sha224`/`sha256`/`sha384`/`sha512`) |
+
+```bash
+curl -k -H "Authorization: Bearer $TOKEN" \
+  https://your-server:8443/api/v2/crl/<ca_id>/config
+curl -k -X POST -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  -d '{"crl_validity_days":14,"crl_publish_interval_hours":24,"crl_digest":"sha384"}' \
+  https://your-server:8443/api/v2/crl/<ca_id>/config
+```
+
 **Regenerate via API** (requires `write:crl`):
 
 ```bash

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -1316,7 +1316,15 @@ GET /api/v2/crl/{ca_id}
 POST /api/v2/crl/{ca_id}/regenerate
 ```
 
-Requires `write:crl`. Offline CAs return `400`. Response metadata omits PEM by default; fetch PEM with `GET /api/v2/crl/{ca_id}`.
+Requires `write:crl`. Offline CAs return `400`. Response metadata omits PEM by default; fetch PEM with `GET /api/v2/crl/{ca_id}`. Metadata includes `next_publish` when a publish interval is configured.
+
+### Full CRL configuration
+```http
+GET /api/v2/crl/{ca_id}/config
+POST /api/v2/crl/{ca_id}/config
+```
+
+Requires `read:crl` / `write:crl`. Body fields: `crl_validity_days` (1–365), `crl_publish_interval_hours` (1–8760), `crl_digest` (`sha224`|`sha256`|`sha384`|`sha512`). Decouples CRL `nextUpdate` from the auto-publish cadence.
 
 Generated CRLs include **Authority Key Identifier** = issuing CA **Subject Key Identifier** (RFC 5280 §5.2.1).
 

--- a/frontend/src/i18n/__tests__/discussion207CrlI18n.test.js
+++ b/frontend/src/i18n/__tests__/discussion207CrlI18n.test.js
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+
+const dir = dirname(fileURLToPath(import.meta.url))
+const localesDir = join(dir, '..', 'locales')
+const LOCALE_CODES = ['de', 'en', 'es', 'fr', 'it', 'ja', 'pt', 'uk', 'zh']
+
+const CRL_KEYS = [
+  'nextPublish',
+  'fullCrlScheduleTitle',
+  'fullCrlScheduleHelp',
+  'crlValidityDays',
+  'crlValidityDaysOption',
+  'crlPublishInterval',
+  'crlPublishIntervalOption',
+  'crlDigest',
+  'fullCrlConfigUpdated',
+  'fullCrlConfigFailed',
+]
+
+function loadLocale(code) {
+  return JSON.parse(readFileSync(join(localesDir, `${code}.json`), 'utf8'))
+}
+
+describe('discussion #207 CRL schedule i18n (9 locales)', () => {
+  for (const code of LOCALE_CODES) {
+    it(`${code}: crlOcsp schedule keys are defined`, () => {
+      const bundle = loadLocale(code)
+      for (const key of CRL_KEYS) {
+        const value = bundle.crlOcsp?.[key]
+        expect(value, `missing crlOcsp.${key} in ${code}`).toBeTruthy()
+        expect(String(value).trim().length).toBeGreaterThan(2)
+      }
+    })
+  }
+})

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -1678,7 +1678,17 @@
     "selectResponder": "Responder-Zertifikat auswählen",
     "noEligibleResponders": "Keine berechtigten Zertifikate gefunden. Ein Zertifikat benötigt OCSPSigning-EKU und einen privaten Schlüssel.",
     "removeResponder": "Responder entfernen",
-    "assignResponder": "Responder zuweisen"
+    "assignResponder": "Responder zuweisen",
+    "nextPublish": "Nächste Veröffentlichung",
+    "fullCrlScheduleTitle": "Vollständige CRL-Zeitplanung",
+    "fullCrlScheduleHelp": "Gültigkeit setzt nextUpdate auf der CRL. Das Veröffentlichungsintervall steuert die automatische Neuveröffentlichung (next_publish). Digest gilt bei der nächsten Regenerierung.",
+    "crlValidityDays": "CRL-Gültigkeit",
+    "crlValidityDaysOption": "{{count}} Tage",
+    "crlPublishInterval": "Veröffentlichungsintervall",
+    "crlPublishIntervalOption": "{{count}} Stunden",
+    "crlDigest": "CRL-Signatur-Digest",
+    "fullCrlConfigUpdated": "Vollständige CRL-Zeitplanung aktualisiert",
+    "fullCrlConfigFailed": "Aktualisierung der CRL-Zeitplanung fehlgeschlagen"
   },
   "trustStore": {
     "caTrust": "CA-Vertrauen",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1678,7 +1678,17 @@
     "selectResponder": "Select Responder Certificate",
     "noEligibleResponders": "No eligible certificates found. A certificate needs OCSPSigning EKU and private key.",
     "removeResponder": "Remove Responder",
-    "assignResponder": "Assign Responder"
+    "assignResponder": "Assign Responder",
+    "nextPublish": "Next Publish",
+    "fullCrlScheduleTitle": "Full CRL schedule",
+    "fullCrlScheduleHelp": "Validity sets nextUpdate on the CRL. Publish interval drives automatic republishing (next_publish). Digest applies on the next regeneration.",
+    "crlValidityDays": "CRL validity",
+    "crlValidityDaysOption": "{{count}} days",
+    "crlPublishInterval": "Publish interval",
+    "crlPublishIntervalOption": "{{count}} hours",
+    "crlDigest": "CRL signature digest",
+    "fullCrlConfigUpdated": "Full CRL schedule updated",
+    "fullCrlConfigFailed": "Failed to update full CRL schedule"
   },
   "trustStore": {
     "caTrust": "CA Trust",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -1678,7 +1678,17 @@
     "selectResponder": "Seleccionar certificado respondedor",
     "noEligibleResponders": "No se encontraron certificados elegibles. Un certificado necesita EKU OCSPSigning y clave privada.",
     "removeResponder": "Eliminar respondedor",
-    "assignResponder": "Asignar respondedor"
+    "assignResponder": "Asignar respondedor",
+    "nextPublish": "Próxima publicación",
+    "fullCrlScheduleTitle": "Programación de CRL completa",
+    "fullCrlScheduleHelp": "La validez define nextUpdate en la CRL. El intervalo de publicación controla la republicación automática (next_publish). El digest se aplica en la siguiente regeneración.",
+    "crlValidityDays": "Validez de la CRL",
+    "crlValidityDaysOption": "{{count}} días",
+    "crlPublishInterval": "Intervalo de publicación",
+    "crlPublishIntervalOption": "{{count}} horas",
+    "crlDigest": "Digest de firma de la CRL",
+    "fullCrlConfigUpdated": "Programación de CRL completa actualizada",
+    "fullCrlConfigFailed": "Error al actualizar la programación de CRL"
   },
   "trustStore": {
     "caTrust": "Confianza de CA",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -1419,7 +1419,17 @@
     "selectResponder": "Sélectionner le certificat répondeur",
     "noEligibleResponders": "Aucun certificat éligible trouvé. Un certificat nécessite l'EKU OCSPSigning et une clé privée.",
     "removeResponder": "Supprimer le répondeur",
-    "assignResponder": "Assigner le répondeur"
+    "assignResponder": "Assigner le répondeur",
+    "nextPublish": "Prochaine publication",
+    "fullCrlScheduleTitle": "Planning CRL complète",
+    "fullCrlScheduleHelp": "La validité définit nextUpdate sur la CRL. L’intervalle de publication pilote la republication automatique (next_publish). Le digest s’applique à la prochaine régénération.",
+    "crlValidityDays": "Validité CRL",
+    "crlValidityDaysOption": "{{count}} jours",
+    "crlPublishInterval": "Intervalle de publication",
+    "crlPublishIntervalOption": "{{count}} heures",
+    "crlDigest": "Digest de signature CRL",
+    "fullCrlConfigUpdated": "Planning CRL complète mis à jour",
+    "fullCrlConfigFailed": "Échec de la mise à jour du planning CRL"
   },
   "csrs": {
     "uploadCSR": "Téléverser une CSR",

--- a/frontend/src/i18n/locales/it.json
+++ b/frontend/src/i18n/locales/it.json
@@ -1678,7 +1678,17 @@
     "selectResponder": "Seleziona certificato responder",
     "noEligibleResponders": "Nessun certificato idoneo trovato. Un certificato necessita di EKU OCSPSigning e chiave privata.",
     "removeResponder": "Rimuovi responder",
-    "assignResponder": "Assegna responder"
+    "assignResponder": "Assegna responder",
+    "nextPublish": "Prossima pubblicazione",
+    "fullCrlScheduleTitle": "Pianificazione CRL completa",
+    "fullCrlScheduleHelp": "La validità imposta nextUpdate sulla CRL. L’intervallo di pubblicazione guida la ripubblicazione automatica (next_publish). Il digest si applica alla prossima rigenerazione.",
+    "crlValidityDays": "Validità CRL",
+    "crlValidityDaysOption": "{{count}} giorni",
+    "crlPublishInterval": "Intervallo di pubblicazione",
+    "crlPublishIntervalOption": "{{count}} ore",
+    "crlDigest": "Digest firma CRL",
+    "fullCrlConfigUpdated": "Pianificazione CRL completa aggiornata",
+    "fullCrlConfigFailed": "Aggiornamento pianificazione CRL non riuscito"
   },
   "trustStore": {
     "caTrust": "Fiducia CA",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -1678,7 +1678,17 @@
     "selectResponder": "レスポンダー証明書を選択",
     "noEligibleResponders": "対象の証明書が見つかりません。証明書にはOCSPSigning EKUと秘密鍵が必要です。",
     "removeResponder": "レスポンダーを削除",
-    "assignResponder": "レスポンダーを割り当て"
+    "assignResponder": "レスポンダーを割り当て",
+    "nextPublish": "次回公開",
+    "fullCrlScheduleTitle": "完全CRLスケジュール",
+    "fullCrlScheduleHelp": "有効期間はCRLのnextUpdateを設定します。公開間隔は自動再公開（next_publish）を制御します。ダイジェストは次回再生成時に適用されます。",
+    "crlValidityDays": "CRL有効期間",
+    "crlValidityDaysOption": "{{count}}日",
+    "crlPublishInterval": "公開間隔",
+    "crlPublishIntervalOption": "{{count}}時間",
+    "crlDigest": "CRL署名ダイジェスト",
+    "fullCrlConfigUpdated": "完全CRLスケジュールを更新しました",
+    "fullCrlConfigFailed": "完全CRLスケジュールの更新に失敗しました"
   },
   "trustStore": {
     "caTrust": "CAトラスト",

--- a/frontend/src/i18n/locales/pt.json
+++ b/frontend/src/i18n/locales/pt.json
@@ -1678,7 +1678,17 @@
     "selectResponder": "Selecionar certificado respondedor",
     "noEligibleResponders": "Nenhum certificado elegível encontrado. Um certificado precisa de EKU OCSPSigning e chave privada.",
     "removeResponder": "Remover respondedor",
-    "assignResponder": "Atribuir respondedor"
+    "assignResponder": "Atribuir respondedor",
+    "nextPublish": "Próxima publicação",
+    "fullCrlScheduleTitle": "Agendamento da CRL completa",
+    "fullCrlScheduleHelp": "A validade define nextUpdate na CRL. O intervalo de publicação controla a republicação automática (next_publish). O digest aplica-se na próxima regeneração.",
+    "crlValidityDays": "Validade da CRL",
+    "crlValidityDaysOption": "{{count}} dias",
+    "crlPublishInterval": "Intervalo de publicação",
+    "crlPublishIntervalOption": "{{count}} horas",
+    "crlDigest": "Digest de assinatura da CRL",
+    "fullCrlConfigUpdated": "Agendamento da CRL completa atualizado",
+    "fullCrlConfigFailed": "Falha ao atualizar o agendamento da CRL"
   },
   "trustStore": {
     "caTrust": "AC Trust",

--- a/frontend/src/i18n/locales/uk.json
+++ b/frontend/src/i18n/locales/uk.json
@@ -1678,7 +1678,17 @@
     "selectResponder": "Обрати сертифікат відповідача",
     "noEligibleResponders": "Придатних сертифікатів не знайдено. Сертифікат потребує EKU OCSPSigning та закритий ключ.",
     "removeResponder": "Видалити відповідач",
-    "assignResponder": "Призначити відповідач"
+    "assignResponder": "Призначити відповідач",
+    "nextPublish": "Наступна публікація",
+    "fullCrlScheduleTitle": "Розклад повної CRL",
+    "fullCrlScheduleHelp": "Термін дії задає nextUpdate у CRL. Інтервал публікації керує автоматичною републікацією (next_publish). Digest застосовується під час наступної регенерації.",
+    "crlValidityDays": "Термін дії CRL",
+    "crlValidityDaysOption": "{{count}} днів",
+    "crlPublishInterval": "Інтервал публікації",
+    "crlPublishIntervalOption": "{{count}} годин",
+    "crlDigest": "Digest підпису CRL",
+    "fullCrlConfigUpdated": "Розклад повної CRL оновлено",
+    "fullCrlConfigFailed": "Не вдалося оновити розклад CRL"
   },
   "trustStore": {
     "caTrust": "Довіра CA",

--- a/frontend/src/i18n/locales/zh.json
+++ b/frontend/src/i18n/locales/zh.json
@@ -1678,7 +1678,17 @@
     "selectResponder": "选择响应者证书",
     "noEligibleResponders": "未找到符合条件的证书。证书需要OCSPSigning EKU和私钥。",
     "removeResponder": "移除响应者",
-    "assignResponder": "分配响应者"
+    "assignResponder": "分配响应者",
+    "nextPublish": "下次发布",
+    "fullCrlScheduleTitle": "完整CRL计划",
+    "fullCrlScheduleHelp": "有效期设置CRL的nextUpdate。发布间隔控制自动重新发布（next_publish）。摘要算法在下次重新生成时生效。",
+    "crlValidityDays": "CRL有效期",
+    "crlValidityDaysOption": "{{count}}天",
+    "crlPublishInterval": "发布间隔",
+    "crlPublishIntervalOption": "{{count}}小时",
+    "crlDigest": "CRL签名摘要",
+    "fullCrlConfigUpdated": "完整CRL计划已更新",
+    "fullCrlConfigFailed": "更新完整CRL计划失败"
   },
   "trustStore": {
     "caTrust": "CA 信任",

--- a/frontend/src/pages/CRLOCSPPage.jsx
+++ b/frontend/src/pages/CRLOCSPPage.jsx
@@ -209,6 +209,21 @@ export default function CRLOCSPPage() {
     }
   }
 
+  const handleFullCrlConfigChange = async (ca, patch) => {
+    if (!canWrite('crl')) return
+    try {
+      const result = await crlService.updateConfig(ca.id, patch)
+      const updated = result.data || result
+      showSuccess(t('crlOcsp.fullCrlConfigUpdated'))
+      setCas(prev => prev.map(c => c.id === ca.id ? { ...c, ...updated } : c))
+      if (selectedCA?.id === ca.id) {
+        setSelectedCA(prev => ({ ...prev, ...updated }))
+      }
+    } catch (error) {
+      showError(error.message || t('crlOcsp.fullCrlConfigFailed'))
+    }
+  }
+
   const handleToggleOcsp = async (ca) => {
     if (!canWrite('crl')) return
     try {
@@ -662,8 +677,62 @@ export default function CRLOCSPPage() {
           <CompactField autoIcon="revokedCount" label={t('crlOcsp.revokedCount')} value={selectedCRL?.revoked_count || 0} />
           <CompactField autoIcon="lastUpdate" label={t('common.lastUpdate')} value={selectedCRL?.updated_at ? formatDate(selectedCRL.updated_at) : '-'} />
           <CompactField autoIcon="nextUpdate" label={t('crlOcsp.nextUpdate')} value={selectedCRL?.next_update ? formatDate(selectedCRL.next_update) : '-'} />
+          <CompactField autoIcon="nextUpdate" label={t('crlOcsp.nextPublish')} value={selectedCRL?.next_publish ? formatDate(selectedCRL.next_publish) : '-'} />
         </CompactGrid>
       </CompactSection>
+
+      {/* Full CRL validity / publish / digest (#207) */}
+      {selectedCA?.has_private_key !== false && (
+        <div className="space-y-3 border-t border-border pt-4">
+          <h4 className="text-sm font-medium text-text-primary">{t('crlOcsp.fullCrlScheduleTitle')}</h4>
+          <p className="text-xs text-text-tertiary">{t('crlOcsp.fullCrlScheduleHelp')}</p>
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+            <div className="flex flex-col gap-1">
+              <label htmlFor="crl-validity-days" className="text-xs text-text-secondary">{t('crlOcsp.crlValidityDays')}</label>
+              <select
+                id="crl-validity-days"
+                className="text-xs bg-bg-tertiary border border-border rounded px-2 py-1.5 text-text-primary"
+                value={selectedCA?.crl_validity_days ?? 7}
+                disabled={!canWrite('crl')}
+                onChange={(e) => handleFullCrlConfigChange(selectedCA, { crl_validity_days: parseInt(e.target.value, 10) })}
+              >
+                {Array.from(new Set([1, 3, 7, 14, 30, 90, selectedCA?.crl_validity_days ?? 7])).sort((a, b) => a - b).map((d) => (
+                  <option key={d} value={d}>{t('crlOcsp.crlValidityDaysOption', { count: d })}</option>
+                ))}
+              </select>
+            </div>
+            <div className="flex flex-col gap-1">
+              <label htmlFor="crl-publish-hours" className="text-xs text-text-secondary">{t('crlOcsp.crlPublishInterval')}</label>
+              <select
+                id="crl-publish-hours"
+                className="text-xs bg-bg-tertiary border border-border rounded px-2 py-1.5 text-text-primary"
+                value={selectedCA?.crl_publish_interval_hours ?? 168}
+                disabled={!canWrite('crl')}
+                onChange={(e) => handleFullCrlConfigChange(selectedCA, { crl_publish_interval_hours: parseInt(e.target.value, 10) })}
+              >
+                {Array.from(new Set([1, 4, 12, 24, 48, 168, 336, selectedCA?.crl_publish_interval_hours ?? 168])).sort((a, b) => a - b).map((h) => (
+                  <option key={h} value={h}>{t('crlOcsp.crlPublishIntervalOption', { count: h })}</option>
+                ))}
+              </select>
+            </div>
+            <div className="flex flex-col gap-1">
+              <label htmlFor="crl-digest" className="text-xs text-text-secondary">{t('crlOcsp.crlDigest')}</label>
+              <select
+                id="crl-digest"
+                className="text-xs bg-bg-tertiary border border-border rounded px-2 py-1.5 text-text-primary"
+                value={selectedCA?.crl_digest || 'sha256'}
+                disabled={!canWrite('crl')}
+                onChange={(e) => handleFullCrlConfigChange(selectedCA, { crl_digest: e.target.value })}
+              >
+                <option value="sha256">SHA-256</option>
+                <option value="sha384">SHA-384</option>
+                <option value="sha512">SHA-512</option>
+                <option value="sha224">SHA-224</option>
+              </select>
+            </div>
+          </div>
+        </div>
+      )}
 
       {/* OCSP Configuration */}
       <CompactSection title={t('crlOcsp.ocspConfig')} icon={Pulse}>

--- a/frontend/src/services/crl.service.js
+++ b/frontend/src/services/crl.service.js
@@ -46,6 +46,14 @@ export const crlService = {
     return apiClient.post(`/crl/${caId}/delta-config`, config)
   },
 
+  async getConfig(caId) {
+    return apiClient.get(`/crl/${caId}/config`)
+  },
+
+  async updateConfig(caId, config) {
+    return apiClient.post(`/crl/${caId}/config`, config)
+  },
+
   async getOcspStatus() {
     return apiClient.get('/ocsp/status')
   },


### PR DESCRIPTION
## Summary
- Per-CA `crl_validity_days` (CRL `nextUpdate`) vs `crl_publish_interval_hours` (`next_publish`)
- Configurable `crl_digest`; migration **059**
- API `GET|POST /api/v2/crl/<id>/config`; CRL/OCSP UI Full CRL schedule
- Scheduler prefers `next_publish`

Accepted enhancement from discussion #207. Does **not** include port 80, long-lived CAs, friendly name, or per-CA protocol transport.

## Test plan
- [x] `pytest tests/test_crl_validity_publish_digest.py`
- [x] vitest `discussion207CrlI18n.test.js` (9 locales)
- [ ] Manual: CRL & OCSP → Full CRL schedule; regenerate; check `next_publish`