### PR TITLE
docs(protocol): port 80 via env, capability, or reverse proxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Starting with v2.48, UCM uses Major.Build versioning (e.g., 2.48, 2.49). Earlier
 
 ## [Unreleased]
 
+### Changed
+- **Docs: protocol port 80** — document `HTTP_PROTOCOL_PORT=80` with `CAP_NET_BIND_SERVICE` or reverse proxy; no Settings API validator change (UCM stays unprivileged). (#207)
+
+
 ## [2.194] - 2026-07-17
 
 ### Fixed

--- a/docs/ADMIN_GUIDE.md
+++ b/docs/ADMIN_GUIDE.md
@@ -365,6 +365,15 @@ http://your-server:8080/cdp/<ca_refid>-delta.crl   # when delta CRL is enabled
 
 Management UI: **CA → CRL / CDP** tab (enable CDP, optional delta, regeneration interval).
 
+### Publishing on TCP port 80
+
+UCM is unprivileged. Prefer one of:
+
+- **`HTTP_PROTOCOL_PORT=80`** in `/etc/ucm/ucm.env` **plus** `CAP_NET_BIND_SERVICE` on the service unit, **or**
+- Keep UCM on **8080** and put a reverse proxy on **:80** (recommended).
+
+Settings → HTTP protocol port in the GUI only allows **0** or **1024–65535**; use the environment for privileged 80. Details: [PUBLIC-ENDPOINTS.md](./testing/PUBLIC-ENDPOINTS.md) (Privileged protocol port 80).
+
 **Regenerate via API** (requires `write:crl`):
 
 ```bash

--- a/docs/testing/PUBLIC-ENDPOINTS.md
+++ b/docs/testing/PUBLIC-ENDPOINTS.md
@@ -63,6 +63,31 @@ wildcard rejected for `acme_public_vhost` (TLS SAN only).
 
 Fallback for corporate DNS preflight: SystemConfig `acme.dns01_nameservers` (same format).
 
+### Privileged protocol port 80 (ops)
+
+UCM runs **unprivileged**. The Settings API only accepts protocol ports **0** (disabled) or **1024–65535**, so **port 80 is not set through the GUI/API validator**.
+
+To publish CDP/OCSP on **:80**:
+
+1. **Environment** — set in `/etc/ucm/ucm.env` (or equivalent), then restart UCM:
+   ```bash
+   HTTP_PROTOCOL_PORT=80
+   ```
+   Keep `protocol_base_url` as plain `http://…` (no TLS) to avoid CRL/OCSP verification loops.
+
+2. **Bind capability** (direct listen on 80) — grant the service binary capability, e.g. systemd:
+   ```ini
+   # /etc/systemd/system/ucm.service.d/override.conf
+   [Service]
+   AmbientCapabilities=CAP_NET_BIND_SERVICE
+   CapabilityBoundingSet=CAP_NET_BIND_SERVICE
+   ```
+   Then `systemctl daemon-reload && systemctl restart ucm`.
+
+3. **Reverse proxy** (recommended) — leave UCM on **8080** and terminate :80 on nginx/Caddy/Traefik, forwarding to `127.0.0.1:8080`. Set `protocol_base_url` / public URLs to `http://pki.example.com` (port 80 omitted) so embedded CDP/OCSP URIs match what clients fetch.
+
+Do **not** point CDP/OCSP at the admin HTTPS port unless you have a clear TLS trust story for relying parties.
+
 Example `/etc/ucm/ucm.env` snippet:
 
 ```bash


### PR DESCRIPTION
## Summary
Documentation only for discussion #207 port 80:

- `HTTP_PROTOCOL_PORT=80` + `CAP_NET_BIND_SERVICE`, or reverse proxy `:80` → UCM `:8080`
- Notes that Settings API still allows only **0** or **1024–65535** (no validator change)

No code/API changes.

## Test plan
- [ ] Read `docs/testing/PUBLIC-ENDPOINTS.md` § Privileged protocol port 80
- [ ] Read `docs/ADMIN_GUIDE.md` § Publishing on TCP port 80