### PR TITLE
fix(est,tsa): log configuration-driven request refusals

### DIFF
--- a/backend/api/est_protocol.py
+++ b/backend/api/est_protocol.py
@@ -287,12 +287,18 @@ def _resolve_est_ca(label=None):
     The two failure modes are distinct and must not be conflated: an unknown
     **label** is a wrong address (404 Not Found), whereas a missing default CA
     means the operator never configured EST (503, the historical response).
+
+    Both used to return silently, so a client that reached this endpoint and
+    was turned away left no trace — the same "did it even arrive" ambiguity
+    SCEP had before its configuration-driven refusals were logged.
     """
     ca = _get_est_ca(label)
     if ca:
         return ca, None
     if label is not None:
+        logger.warning("EST request refused: unknown label %r", label)
         return None, Response('Unknown EST label', status=404)
+    logger.warning("EST request refused: EST not configured")
     return None, Response('EST not configured', status=503)
 
 

--- a/backend/api/tsa_protocol.py
+++ b/backend/api/tsa_protocol.py
@@ -56,6 +56,7 @@ def timestamp_request():
 
         enabled_config = SystemConfig.query.filter_by(key='tsa_enabled').first()
         if not enabled_config or str(enabled_config.value).lower() != 'true':
+            logger.warning("TSA request refused: TSA is disabled")
             response = make_response('TSA temporarily unavailable', 503)
             response.headers['Content-Type'] = 'text/plain'
             return response
@@ -67,12 +68,17 @@ def timestamp_request():
         tsa_ca_config = SystemConfig.query.filter_by(key='tsa_ca_refid').first()
         tsa_ca_refid = tsa_ca_config.value if tsa_ca_config else ''
         if not tsa_ca_refid:
+            logger.warning("TSA request refused: no CA configured for TSA")
             response = make_response('TSA not configured', 503)
             response.headers['Content-Type'] = 'text/plain'
             return response
         ca = CA.query.filter_by(refid=tsa_ca_refid).first()
 
         if not ca or not ca.crt or not ca.prv:
+            logger.warning(
+                "TSA request refused: configured CA %r not found or missing cert/key",
+                tsa_ca_refid,
+            )
             response = make_response('TSA not configured', 503)
             response.headers['Content-Type'] = 'text/plain'
             return response


### PR DESCRIPTION
## Summary

Same class of gap as the SCEP fix in d5fdb96c (discussion #216): several config-driven refusals in EST and TSA returned an error response to the client without writing anything to the log, so it was impossible to tell whether a request had arrived and been silently turned away versus never reaching the server at all.

- `est_protocol.py`: `_resolve_est_ca()` now logs an unknown EST label or a missing default CA. Used by `cacerts`/`simpleenroll`/`simplereenroll`/`serverkeygen`. Rest of the file was already well-instrumented; this was the one silent function.
- `tsa_protocol.py`: `timestamp_request()` now logs TSA disabled, no CA assigned, and CA not found/missing cert or key. Consistent with the existing "CA is offline" warning a few lines below, which already logged.

Checked OCSP and ACME proxy for the same pattern too. Left those alone: OCSP's silent path is "no CA matches this issuer hash," which is normal expected behavior, not a misconfiguration. ACME proxy's `proxy_error()` doesn't log either, but its callers are mostly per-request client errors (order/account/cert not found), not operator misconfiguration, so I didn't want to add log noise there without a clearer case for it.

No response bodies or status codes changed, only added logging.

## Test plan

- [ ] `python -m py_compile` on both files (done locally)
- [ ] Existing test suite passes (no test asserts on the unchanged response strings)
- [ ] Manual: hit `/.well-known/est/cacerts` with an unknown label and confirm a warning is logged
- [ ] Manual: disable TSA / unassign its CA and confirm a warning is logged on a timestamp request