### PR TITLE
fix(api): recognize application/problem+json error bodies in apiClient

### DIFF
--- a/frontend/src/services/apiClient.js
+++ b/frontend/src/services/apiClient.js
@@ -118,10 +118,12 @@ class APIClient {
       const response = await fetch(url, config)
       
       // Handle different response types
+      // Error bodies may be `application/problem+json` (RFC 7807) rather than
+      // plain `application/json` -- both must be parsed as JSON.
       const contentType = response.headers.get('content-type')
       let data
-      
-      if (contentType && contentType.includes('application/json')) {
+
+      if (contentType && /application\/(problem\+)?json/.test(contentType)) {
         data = await response.json()
       } else if (options.responseType === 'blob') {
         data = await response.blob()


### PR DESCRIPTION
## Summary
- `apiClient.js`'s content-type check only matched the exact string `application/json`, so RFC 7807 error bodies (`application/problem+json`, added for problem-details support) were read as plain text instead of parsed JSON
- The real backend error message was then discarded and the UI fell back to a generic per-status string for any failed request, not just password policy errors

Reported in #234, where a password-policy violation at user creation showed a generic error instead of the specific one the backend already returns.

## Test plan
- [x] `npm run build` clean
- [x] Manually verified against a live instance: backend error messages (LDAP bind failures, invalid credentials) now surface correctly in the UI instead of falling back to generic text