### PR TITLE
fix(ui): settings save buttons only submit their own section's fields

### DIFF
--- a/frontend/src/pages/SettingsPage.jsx
+++ b/frontend/src/pages/SettingsPage.jsx
@@ -90,6 +90,21 @@ const SSO_PROVIDER_ICONS = {
   saml: Shield,
 }
 
+// Fields each "Save Changes" button owns -- lets handleSave() send only its
+// own card's fields instead of the whole settings object.
+const SECTION_FIELDS = {
+  generalSite: ['system_name', 'base_url', 'protocol_base_url', 'http_protocol_port', 'acme_public_vhost', 'acme_public_port', 'acme_public_tls_cert_id'],
+  generalSession: ['session_timeout', 'max_login_attempts', 'lockout_duration', 'timezone', 'date_format', 'show_time'],
+  security2fa: ['enforce_2fa'],
+  securityHsts: ['hsts_enabled', 'hsts_include_subdomains', 'hsts_max_age', 'ocsp_response_validity_hours'],
+  securityKeyRecovery: ['key_recovery_dual_control'],
+  securityPassword: ['min_password_length', 'password_require_uppercase', 'password_require_numbers', 'password_require_special'],
+  securitySession: ['session_max_lifetime', 'api_rate_limit'],
+  backupAuto: ['auto_backup_enabled', 'backup_frequency', 'backup_password'],
+  backupRetention: ['backup_retention_days'],
+  audit: ['audit_enabled', 'audit_retention_days'],
+}
+
 export default function SettingsPage() {
   const { t } = useTranslation()
   const { showSuccess, showError, showConfirm, showPrompt, showWarning } = useNotification()
@@ -977,7 +992,11 @@ export default function SettingsPage() {
           smtp_oauth_redirect_uri: settings.smtp_oauth_redirect_uri,
         })
       } else {
-        await settingsService.updateBulk(settings)
+        const fields = SECTION_FIELDS[section]
+        const payload = fields
+          ? Object.fromEntries(fields.map((key) => [key, settings[key]]))
+          : settings
+        await settingsService.updateBulk(payload)
       }
       showSuccess(t('messages.success.update.settings'))
       if (section === 'email') setOauthDirty(false)

--- a/frontend/src/pages/settings/BackupSection.jsx
+++ b/frontend/src/pages/settings/BackupSection.jsx
@@ -69,7 +69,7 @@ export default function BackupSection({
 
           {isAdmin && (
             <div className="flex gap-2">
-              <Button type="button" onClick={() => handleSave('backup')} disabled={saving}>
+              <Button type="button" onClick={() => handleSave('backupAuto')} disabled={saving}>
                 <FloppyDisk size={16} />
                 {t('settings.saveSettings')}
               </Button>
@@ -96,7 +96,7 @@ export default function BackupSection({
           />
           {isAdmin && (
             <div className="flex gap-2">
-              <Button type="button" onClick={() => handleSave('backup')} disabled={saving}>
+              <Button type="button" onClick={() => handleSave('backupRetention')} disabled={saving}>
                 <FloppyDisk size={16} />
                 {t('settings.saveSettings')}
               </Button>

--- a/frontend/src/pages/settings/GeneralSection.jsx
+++ b/frontend/src/pages/settings/GeneralSection.jsx
@@ -141,7 +141,7 @@ export default function GeneralSection({ settings, updateSetting, handleSave, sa
               <Button
                 type="button"
                 onClick={async () => {
-                  await handleSave('general')
+                  await handleSave('generalSite')
                   setEndpointsRefresh((k) => k + 1)
                 }}
                 disabled={saving}
@@ -243,7 +243,7 @@ export default function GeneralSection({ settings, updateSetting, handleSave, sa
           </label>
           {canWrite('settings') && (
             <div className="pt-2">
-              <Button type="button" onClick={() => handleSave('general')} disabled={saving}>
+              <Button type="button" onClick={() => handleSave('generalSession')} disabled={saving}>
                 <FloppyDisk size={16} />
                 {t('common.saveChanges')}
               </Button>

--- a/frontend/src/pages/settings/SecuritySection.jsx
+++ b/frontend/src/pages/settings/SecuritySection.jsx
@@ -78,12 +78,20 @@ export default function SecuritySection({ settings, updateSetting, handleSave, s
         )}
       </DetailSection>
       <DetailSection title={t('common.twoFactorAuth')} icon={ShieldCheck} iconClass="icon-bg-emerald">
-        <ToggleSwitch
-          checked={settings.enforce_2fa || false}
-          onChange={(val) => updateSetting('enforce_2fa', val)}
-          label={t('settings.enforce2fa')}
-          description={t('settings.enforce2faDesc')}
-        />
+        <div className="space-y-4">
+          <ToggleSwitch
+            checked={settings.enforce_2fa || false}
+            onChange={(val) => updateSetting('enforce_2fa', val)}
+            label={t('settings.enforce2fa')}
+            description={t('settings.enforce2faDesc')}
+          />
+          {hasPermission('admin:system') && (
+            <Button type="button" onClick={() => handleSave('security2fa')} disabled={saving}>
+              <FloppyDisk size={16} />
+              {t('common.saveChanges')}
+            </Button>
+          )}
+        </div>
       </DetailSection>
       <DetailSection title={t('settings.hstsTitle')} icon={Globe} iconClass="icon-bg-sky">
         <div className="space-y-4">
@@ -137,7 +145,7 @@ export default function SecuritySection({ settings, updateSetting, handleSave, s
             helperText={t('settings.ocspResponseValidityDesc')}
           />
           {hasPermission('admin:system') && (
-            <Button type="button" onClick={() => handleSave('security')} disabled={saving}>
+            <Button type="button" onClick={() => handleSave('securityHsts')} disabled={saving}>
               <FloppyDisk size={16} />
               {t('common.saveChanges')}
             </Button>
@@ -160,7 +168,7 @@ export default function SecuritySection({ settings, updateSetting, handleSave, s
             </div>
           )}
           {hasPermission('admin:system') && !settings.key_recovery_dual_control_locked && (
-            <Button type="button" onClick={() => handleSave('security')} disabled={saving}>
+            <Button type="button" onClick={() => handleSave('securityKeyRecovery')} disabled={saving}>
               <FloppyDisk size={16} />
               {t('common.saveChanges')}
             </Button>
@@ -197,6 +205,12 @@ export default function SecuritySection({ settings, updateSetting, handleSave, s
               size="sm"
             />
           </div>
+          {hasPermission('admin:system') && (
+            <Button type="button" onClick={() => handleSave('securityPassword')} disabled={saving}>
+              <FloppyDisk size={16} />
+              {t('common.saveChanges')}
+            </Button>
+          )}
         </div>
       </DetailSection>
       <DetailSection title={t('settings.anomalyDetection')} icon={Warning} iconClass="icon-bg-orange"
@@ -275,7 +289,7 @@ export default function SecuritySection({ settings, updateSetting, handleSave, s
         </DetailGrid>
         {hasPermission('admin:system') && (
           <div className="pt-4">
-            <Button type="button" onClick={() => handleSave('security')} disabled={saving}>
+            <Button type="button" onClick={() => handleSave('securitySession')} disabled={saving}>
               <FloppyDisk size={16} />
               {t('common.saveChanges')}
             </Button>


### PR DESCRIPTION
## Summary
- Every "Save Changes" button on the General, Security, Backup, and Audit settings tabs called the same `handleSave(section)`, which always sent the entire shared settings object regardless of which card's button was clicked
- An invalid/unset field in one card (e.g. an empty `base_url`) could silently block saving an unrelated card (e.g. changing the timezone), even though each card visually looks independent with its own button
- Added a `SECTION_FIELDS` map so each button now sends only the fields it actually owns
- Password Policy and 2FA (Security tab) previously had no Save button of their own at all and only persisted as a side effect of clicking a neighboring card's button; they now have their own scoped Save button too

## Test plan
- [x] `npm run build` clean
- [x] Manually verified against a live instance: changing only the timezone (with `base_url` left empty) now saves successfully instead of being blocked
- [x] Verified Password Policy and 2FA save independently via their new buttons