### PR TITLE
fix(ui): add missing icon to Microsoft CA connection Save button

### DIFF
--- a/frontend/src/pages/settings/MscaConnectionForm.jsx
+++ b/frontend/src/pages/settings/MscaConnectionForm.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
-import { TestTube } from '@phosphor-icons/react'
+import { TestTube, FloppyDisk } from '@phosphor-icons/react'
 import { Button, Input, Select, Textarea } from '../../components'
 import CertificateInput from '../../components/CertificateInput'
 import { mscaService } from '../../services'
@@ -371,6 +371,7 @@ export default function MscaConnectionForm({ connection, onSave, onCancel }) {
             {t('common.cancel')}
           </Button>
           <Button type="submit">
+            <FloppyDisk size={16} />
             {connection ? t('common.save') : t('common.create')}
           </Button>
         </div>


### PR DESCRIPTION
## Summary
- The Test Connection and Test Admin Channel buttons in the Microsoft CA connection form both carry a TestTube icon, but the Save/Create submit button next to them had none, breaking the icon+label pattern within the same button row

## Test plan
- [x] `npm run build` clean