### PR TITLE
fix(acme): reject CSR SANs the order never validated

### DIFF
--- a/backend/services/acme/mixins/issuance.py
+++ b/backend/services/acme/mixins/issuance.py
@@ -92,7 +92,21 @@ class IssuanceMixin:
         order_ips_norm = {ip for ip in order_ips}
         if csr_ips_norm != order_ips_norm:
             return False, f"CSR IPs {sorted(csr_ips_norm)} don't match order IPs {sorted(order_ips_norm)}"
-        
+
+        # Reject any SAN entry that is not one of the validated identifiers.
+        # The per-type extractors above only look at DNSName/IPAddress, so an
+        # rfc822Name, otherName/UPN, URI or dirName would otherwise sail past
+        # validation and be copied verbatim into the signed certificate by
+        # sign_csr — letting a client that only proved control of a DNS name
+        # obtain a cert asserting an email address or a Windows UPN it never
+        # proved. ACME only ever proves DNS/IP control, so anything else is
+        # unauthorized by construction.
+        san_ok, san_err = self._validate_csr_san_types(
+            csr, order_domains_norm, order_ips_norm
+        )
+        if not san_ok:
+            return False, san_err
+
         # CAA record check (RFC 6844 + RFC 8555 §8.1) - only for DNS identifiers
         if order_domains:
             caa_enforce = False
@@ -245,6 +259,57 @@ class IssuanceMixin:
         except Exception as e:
             logger.warning(f"Auto-supersede check failed: {e}")
     
+    def _validate_csr_san_types(
+        self, csr, allowed_domains: set, allowed_ips: set
+    ) -> Tuple[bool, Optional[str]]:
+        """Reject SAN entries the ACME order never authorized.
+
+        ``allowed_domains`` / ``allowed_ips`` are the already-validated,
+        normalized order identifiers. Every general name in the CSR's SAN must
+        be a DNSName or IPAddress drawn from those sets; any other general-name
+        type (rfc822Name, otherName/UPN, URI, dirName, registeredID, ...) is
+        rejected outright because no ACME challenge can prove control of it.
+
+        Returns (True, None) when the SAN is acceptable, else (False, reason).
+        """
+        from cryptography import x509
+
+        try:
+            san_ext = csr.extensions.get_extension_for_oid(
+                x509.oid.ExtensionOID.SUBJECT_ALTERNATIVE_NAME
+            )
+        except x509.ExtensionNotFound:
+            return True, None
+        except Exception as exc:
+            return False, f"Unable to parse CSR SubjectAlternativeName: {exc}"
+
+        for name in san_ext.value:
+            if isinstance(name, x509.DNSName):
+                if name.value.lower().rstrip('.') not in allowed_domains:
+                    return False, (
+                        f"CSR SAN dNSName {name.value!r} is not an authorized "
+                        "order identifier"
+                    )
+            elif isinstance(name, x509.IPAddress):
+                if str(name.value) not in allowed_ips:
+                    return False, (
+                        f"CSR SAN iPAddress {name.value} is not an authorized "
+                        "order identifier"
+                    )
+            else:
+                # otherName (incl. UPN), rfc822Name, URI, dirName, ...
+                type_name = type(name).__name__
+                detail = ''
+                if isinstance(name, x509.OtherName):
+                    detail = f" (type-id {name.type_id.dotted_string})"
+                return False, (
+                    f"CSR SAN contains unauthorized general name type "
+                    f"{type_name}{detail}; ACME may only certify the DNS and IP "
+                    "identifiers validated by the order"
+                )
+
+        return True, None
+
     def _extract_ips_from_csr(self, csr) -> List[str]:
         """Extract IP addresses from CSR Subject Alternative Names (RFC 8738)
         

--- a/backend/tests/test_acme_san_type_injection.py
+++ b/backend/tests/test_acme_san_type_injection.py
@@ -1,0 +1,261 @@
+"""Regression tests: ACME SAN-type injection (security audit v2.203, item #1).
+
+ACME finalize validated the CSR by extracting only dNSName and iPAddress SANs
+and comparing those to the order identifiers. Every other general-name type was
+neither inspected nor rejected, and sign_csr copies the CSR's SAN extension
+verbatim onto the leaf. A client that legitimately passed http-01 for a domain
+it controlled could therefore attach:
+
+    SAN: email:ceo@victim.com
+    SAN: otherName/UPN: Administrator@corp.local
+
+to the finalize CSR and receive a CA-signed certificate asserting an email
+address and a Windows UPN it never proved control of — enabling S/MIME
+impersonation and, against a CA trusted for smartcard logon, AD authentication
+as another user.
+
+These tests exercise the validator directly (no DB/order needed): the fix is
+that _validate_csr_san_types rejects any SAN general name outside the set of
+identifiers the order actually validated.
+"""
+import ipaddress
+
+import pytest
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.x509.oid import NameOID
+
+from services.acme.acme_service import AcmeService
+from utils.upn_san import build_upn_other_name
+
+
+@pytest.fixture(scope='module')
+def signing_key():
+    return rsa.generate_private_key(public_exponent=65537, key_size=2048)
+
+
+def _csr_with_san(signing_key, san_entries, cn='web.example.com'):
+    builder = x509.CertificateSigningRequestBuilder().subject_name(
+        x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, cn)])
+    )
+    if san_entries:
+        builder = builder.add_extension(
+            x509.SubjectAlternativeName(san_entries), critical=False
+        )
+    return builder.sign(signing_key, hashes.SHA256())
+
+
+def _validate(csr, domains=frozenset({'web.example.com'}), ips=frozenset()):
+    """Call the SAN-type validator the way finalize_order does."""
+    return AcmeService._validate_csr_san_types(
+        AcmeService, csr, set(domains), set(ips)
+    )
+
+
+# --- the authorized case still works ---------------------------------------
+
+def test_dns_san_matching_order_is_accepted(signing_key):
+    csr = _csr_with_san(signing_key, [x509.DNSName('web.example.com')])
+    ok, err = _validate(csr)
+    assert ok, err
+
+
+def test_dns_san_is_case_and_trailing_dot_insensitive(signing_key):
+    csr = _csr_with_san(signing_key, [x509.DNSName('WEB.Example.COM.')])
+    ok, err = _validate(csr)
+    assert ok, err
+
+
+def test_ip_san_matching_order_is_accepted(signing_key):
+    csr = _csr_with_san(
+        signing_key, [x509.IPAddress(ipaddress.ip_address('203.0.113.10'))]
+    )
+    ok, err = _validate(csr, domains=frozenset(), ips=frozenset({'203.0.113.10'}))
+    assert ok, err
+
+
+def test_csr_without_san_extension_is_accepted(signing_key):
+    csr = _csr_with_san(signing_key, None)
+    ok, err = _validate(csr)
+    assert ok, err
+
+
+# --- the vulnerability ------------------------------------------------------
+
+def test_email_san_alongside_authorized_dns_is_rejected(signing_key):
+    """The core exploit: a valid DNS SAN carrying a smuggled rfc822Name."""
+    csr = _csr_with_san(signing_key, [
+        x509.DNSName('web.example.com'),          # matches the order
+        x509.RFC822Name('ceo@victim.com'),        # never proved
+    ])
+    ok, err = _validate(csr)
+    assert not ok
+    assert 'RFC822Name' in err
+
+
+def test_upn_othername_san_is_rejected(signing_key):
+    """UPN otherName — the AD-logon impersonation vector."""
+    csr = _csr_with_san(signing_key, [
+        x509.DNSName('web.example.com'),
+        build_upn_other_name('Administrator@corp.local'),
+    ])
+    ok, err = _validate(csr)
+    assert not ok
+    assert 'OtherName' in err
+    # The offending type-id is named so operators can see what was attempted.
+    assert '1.3.6.1.4.1.311.20.2.3' in err
+
+
+def test_uri_san_is_rejected(signing_key):
+    csr = _csr_with_san(signing_key, [
+        x509.DNSName('web.example.com'),
+        x509.UniformResourceIdentifier('spiffe://cluster/ns/default/sa/admin'),
+    ])
+    ok, err = _validate(csr)
+    assert not ok
+    assert 'UniformResourceIdentifier' in err
+
+
+def test_directory_name_san_is_rejected(signing_key):
+    csr = _csr_with_san(signing_key, [
+        x509.DNSName('web.example.com'),
+        x509.DirectoryName(
+            x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, 'Domain Admins')])
+        ),
+    ])
+    ok, err = _validate(csr)
+    assert not ok
+    assert 'DirectoryName' in err
+
+
+def test_unauthorized_extra_dns_san_is_rejected(signing_key):
+    """A second dNSName outside the order must not ride along either."""
+    csr = _csr_with_san(signing_key, [
+        x509.DNSName('web.example.com'),
+        x509.DNSName('mail.victim.com'),
+    ])
+    ok, err = _validate(csr)
+    assert not ok
+    assert 'mail.victim.com' in err
+
+
+def test_unauthorized_ip_san_is_rejected(signing_key):
+    csr = _csr_with_san(signing_key, [
+        x509.DNSName('web.example.com'),
+        x509.IPAddress(ipaddress.ip_address('10.0.0.1')),
+    ])
+    ok, err = _validate(csr)
+    assert not ok
+    assert '10.0.0.1' in err
+
+
+def test_email_san_rejected_even_as_sole_entry(signing_key):
+    """No DNS SAN at all — the type check must not depend on ordering."""
+    csr = _csr_with_san(signing_key, [x509.RFC822Name('ceo@victim.com')])
+    ok, err = _validate(csr)
+    assert not ok
+
+
+# --- end-to-end: the smuggled SAN must stop finalize before signing ---------
+
+class TestFinalizeOrderRejectsSmuggledSan:
+    """Drive the real finalize_order path.
+
+    ``_sign_certificate_with_ca`` is stubbed to record whether issuance was
+    reached at all. Before the fix, a CSR carrying an unproven UPN/email SAN
+    sailed through validation and the stub was invoked (i.e. a real deployment
+    would have signed the certificate); after the fix, finalize fails during
+    identifier validation and signing is never reached.
+    """
+
+    def _order(self, app, identifiers):
+        import json as _json
+        import uuid as _uuid
+        from models import db
+        from models.acme_models import AcmeAccount, AcmeOrder
+
+        # jwk_thumbprint is UNIQUE — keep each test's account distinct.
+        acct = AcmeAccount(
+            jwk='{}',
+            jwk_thumbprint=_uuid.uuid4().hex + _uuid.uuid4().hex[:11],
+            status='valid',
+        )
+        db.session.add(acct)
+        db.session.flush()
+        order = AcmeOrder(
+            account_id=acct.account_id,
+            status='ready',
+            identifiers=_json.dumps(identifiers),
+        )
+        db.session.add(order)
+        db.session.commit()
+        return order
+
+    def _run_finalize(self, app, monkeypatch, san_entries):
+        from cryptography.hazmat.primitives import serialization
+
+        with app.app_context():
+            order = self._order(
+                app, [{'type': 'dns', 'value': 'web.example.com'}]
+            )
+            service = AcmeService(base_url='http://localhost')
+
+            from utils import caa_checker
+            monkeypatch.setattr(
+                caa_checker, 'check_caa_for_domains',
+                lambda *a, **k: (True, 'allowed'),
+            )
+            monkeypatch.setattr(
+                service, '_resolve_ca_for_domains', lambda _d: 'test-ca'
+            )
+            reached = {'signing': False}
+
+            def _stub_sign(**_kwargs):
+                reached['signing'] = True
+                return False, None, 'signing failed'
+
+            monkeypatch.setattr(service, '_sign_certificate_with_ca', _stub_sign)
+
+            key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+            csr = _csr_with_san(key, san_entries)
+            csr_pem = csr.public_bytes(serialization.Encoding.PEM).decode()
+
+            service.begin_order_processing(order)
+            service._finalizing_order_id = order.order_id
+            success, error = service.finalize_order(order.order_id, csr_pem)
+            service._finalizing_order_id = None
+            return success, error, reached['signing']
+
+    def test_clean_csr_reaches_signing(self, app, monkeypatch):
+        """Control: an honest CSR still gets through to issuance."""
+        success, error, reached_signing = self._run_finalize(
+            app, monkeypatch, [x509.DNSName('web.example.com')]
+        )
+        assert reached_signing, 'validation wrongly blocked a legitimate CSR'
+        assert error == 'signing failed'
+
+    def test_smuggled_upn_never_reaches_signing(self, app, monkeypatch):
+        success, error, reached_signing = self._run_finalize(
+            app, monkeypatch, [
+                x509.DNSName('web.example.com'),
+                build_upn_other_name('Administrator@corp.local'),
+            ],
+        )
+        assert not success
+        assert not reached_signing, (
+            'CSR with an unproven UPN SAN reached the signer — a real '
+            'deployment would have issued the certificate'
+        )
+        assert 'unauthorized general name type' in error
+
+    def test_smuggled_email_never_reaches_signing(self, app, monkeypatch):
+        success, error, reached_signing = self._run_finalize(
+            app, monkeypatch, [
+                x509.DNSName('web.example.com'),
+                x509.RFC822Name('ceo@victim.com'),
+            ],
+        )
+        assert not success
+        assert not reached_signing
+        assert 'unauthorized general name type' in error


### PR DESCRIPTION
finalize_order extracted only dNSName and iPAddress SANs and compared those
to the order identifiers. Every other general-name type was neither inspected
nor rejected, and sign_csr copies the CSR's SAN extension verbatim onto the
leaf. A client that legitimately passed http-01 for a domain it controlled
could attach an rfc822Name or an otherName/UPN and receive a CA-signed
certificate asserting an email address and a Windows UPN it never proved --
S/MIME impersonation, and AD logon as another user against a CA trusted for
smartcard logon.

Reject any SAN general name outside the validated identifier set rather than
relying on per-type extractors. Only mitigated before this by Name Constraints
covering email/UPN, which most CAs do not set.

Evidence: driving finalize_order with the signer stubbed, a CSR carrying an
unproven UPN SAN reached the signer on v2.203 (8e51e76).

(cherry picked from commit 16871d88beca8412864fc1fa067bbb3b020cdef0)
