### PR TITLE
fix(issuance): enforce key strength, cap CSR EKUs, and gate sub-CA minting

### DIFF
--- a/backend/api/v2/csrs.py
+++ b/backend/api/v2/csrs.py
@@ -28,6 +28,10 @@ from utils.db_transaction import safe_commit
 bp = Blueprint('csrs_v2', __name__)
 logger = logging.getLogger(__name__)
 
+# Backend cert_type values that produce a CA record with signing authority.
+# Signing one of these is a CA-management action and requires 'write:cas'.
+_CA_CERT_TYPES = frozenset({'intermediate_ca'})
+
 @bp.route('/api/v2/csrs', methods=['GET'])
 @require_auth(['read:csrs'])
 def list_csrs():
@@ -646,7 +650,20 @@ def sign_csr(csr_id):
         'intermediate_ca': 'intermediate_ca'
     }
     backend_cert_type = cert_type_map.get(cert_type, 'server_cert')
-    
+
+    # Signing a CSR as an intermediate CA creates a real CA record with signing
+    # authority — that is a CA-management action, not a certificate-issuance
+    # one, and must require the same permission as POST /api/v2/cas. Without
+    # this a principal holding only write:csrs / write:certificates could mint
+    # an intermediate able to issue for arbitrary names.
+    if backend_cert_type in _CA_CERT_TYPES:
+        from auth.unified import has_permission
+        if not has_permission('write:cas', getattr(g, 'permissions', []) or []):
+            return error_response(
+                'Signing a CSR as an intermediate CA requires the write:cas permission',
+                403,
+            )
+
     if not ca_id:
         return error_response('CA ID required', 400)
     

--- a/backend/services/trust_store/csr_operations_mixin.py
+++ b/backend/services/trust_store/csr_operations_mixin.py
@@ -37,6 +37,114 @@ _LEAF_FORBIDDEN_EKU_OIDS = frozenset({
     x509.ExtendedKeyUsageOID.TIME_STAMPING,
 })
 
+# anyExtendedKeyUsage defeats EKU chaining entirely: a leaf carrying it is
+# usable for every purpose, which makes any per-type EKU policy meaningless.
+# Never honour it from a CSR on a leaf, whatever the certificate type.
+_ANY_EKU_OID = x509.ObjectIdentifier('2.5.29.37.0')
+
+# Microsoft Smartcard Logon — grants Active Directory interactive logon when
+# paired with a UPN SAN. Never honoured from CSR-supplied EKU on a leaf; an
+# operator who genuinely wants it passes it explicitly via ``extra_ekus``.
+_SMARTCARD_LOGON_OID = x509.ObjectIdentifier('1.3.6.1.4.1.311.20.2.2')
+
+# Per-certificate-type EKU ceiling for CSR-supplied Extended Key Usage.
+#
+# Without this, whatever EKU a CSR carries is copied onto the leaf, so a client
+# that only proved DNS control (ACME finalize signs with cert_type
+# 'server_cert') could mint a codeSigning or emailProtection certificate. The
+# resolved certificate type — not the requester's CSR — decides what the leaf
+# may be used for. Operator-supplied ``extra_ekus`` are deliberate admin intent
+# and are merged in separately, so they are not capped here.
+_TLS_EKUS = frozenset({
+    x509.ExtendedKeyUsageOID.SERVER_AUTH,
+    x509.ExtendedKeyUsageOID.CLIENT_AUTH,
+})
+_CERT_TYPE_ALLOWED_EKUS = {
+    'server_cert': _TLS_EKUS,
+    'server': _TLS_EKUS,
+    'host': _TLS_EKUS,
+    'client_cert': _TLS_EKUS,
+    'usr_cert': _TLS_EKUS,
+    'user': _TLS_EKUS,
+    'combined_cert': _TLS_EKUS,
+    'combined_server_client': _TLS_EKUS,
+    'code_signing': frozenset({x509.ExtendedKeyUsageOID.CODE_SIGNING}),
+    'email_cert': frozenset({
+        x509.ExtendedKeyUsageOID.EMAIL_PROTECTION,
+        x509.ExtendedKeyUsageOID.CLIENT_AUTH,
+    }),
+}
+
+
+def _filter_csr_ekus(eku_oids, cert_type, allow_sensitive_ekus):
+    """Cap CSR-supplied EKUs for a leaf to what *cert_type* permits.
+
+    Returns (kept, dropped).
+
+    ``allow_sensitive_ekus`` marks the admin Sign-CSR path — an operator with
+    full CA control deliberately signing a CSR (e.g. a delegated OCSP responder
+    or TSA). That is explicit human intent, so no ceiling is applied and the
+    path behaves exactly as before. Every protocol path (ACME finalize, EST,
+    SCEP, auto-renewal) leaves it False and gets the full cap: an enrollee that
+    only proved domain control cannot widen its own leaf's key purposes.
+    """
+    if allow_sensitive_ekus:
+        return list(eku_oids), []
+
+    allowed = _CERT_TYPE_ALLOWED_EKUS.get(cert_type)
+    kept, dropped = [], []
+    for oid in eku_oids:
+        if oid in _LEAF_FORBIDDEN_EKU_OIDS or oid in (_ANY_EKU_OID, _SMARTCARD_LOGON_OID):
+            dropped.append(oid)
+            continue
+        # Unknown/custom certificate types keep their historical behaviour:
+        # no per-type ceiling, only the block-list above applies.
+        if allowed is not None and oid not in allowed:
+            dropped.append(oid)
+            continue
+        kept.append(oid)
+    return kept, dropped
+
+
+def _capped_basic_constraints(csr_constraints, ca_cert):
+    """Clamp a sub-CA's pathLenConstraint to what the parent CA permits.
+
+    RFC 5280 §4.2.1.9: a CA with pathLenConstraint N may be followed by at most
+    N further CAs in the chain, so a child issued by it may assert at most N-1;
+    a parent with pathLen 0 may not issue a sub-CA at all. The value otherwise
+    comes straight from the requester's CSR, so without this clamp a signed
+    intermediate could claim a deeper (or unlimited) path than its issuer.
+    """
+    requested = csr_constraints.path_length
+
+    try:
+        parent_bc = ca_cert.extensions.get_extension_for_oid(
+            ExtensionOID.BASIC_CONSTRAINTS
+        ).value
+        parent_limit = parent_bc.path_length
+    except x509.ExtensionNotFound:
+        parent_limit = None
+
+    if parent_limit is None:
+        # Unconstrained parent — the child's own request stands.
+        return csr_constraints
+
+    if parent_limit <= 0:
+        raise ValueError(
+            "Issuing CA has pathLenConstraint 0 and may not issue a subordinate CA"
+        )
+
+    max_allowed = parent_limit - 1
+    if requested is None or requested > max_allowed:
+        if requested is not None:
+            logger.warning(
+                "sign_csr: clamping requested sub-CA pathLenConstraint %s to %s "
+                "(issuing CA permits %s)", requested, max_allowed, parent_limit,
+            )
+        return x509.BasicConstraints(ca=True, path_length=max_allowed)
+
+    return csr_constraints
+
 
 def _key_usage_with_ca_signing(usage, enabled):
     """Return a KeyUsage with CA signing bits forced to the policy value."""
@@ -146,6 +254,14 @@ class CSROperationsMixin:
         if not csr.is_signature_valid:
             raise ValueError("CSR has invalid signature")
 
+        # Key-strength floor. Enforced here rather than at each caller so every
+        # issuance path (admin sign-CSR, ACME finalize, EST/SCEP, renewal)
+        # inherits it from the one place that actually applies a CA signature.
+        from utils.key_type import validate_enrollment_public_key
+        key_err = validate_enrollment_public_key(csr.public_key())
+        if key_err:
+            raise ValueError(f"CSR public key rejected: {key_err}")
+
         # NameConstraints enforcement
         csr_sans = None
         try:
@@ -210,11 +326,12 @@ class CSROperationsMixin:
             if not issuing_ca and extension.oid in _LEAF_CA_ONLY_EXTENSION_OIDS:
                 continue
             if extension.oid == ExtensionOID.BASIC_CONSTRAINTS:
-                constraints = (
-                    extension.value
-                    if issuing_ca
-                    else x509.BasicConstraints(ca=False, path_length=None)
-                )
+                if issuing_ca:
+                    constraints = _capped_basic_constraints(
+                        extension.value, ca_cert
+                    )
+                else:
+                    constraints = x509.BasicConstraints(ca=False, path_length=None)
                 builder = builder.add_extension(constraints, critical=True)
                 continue
             if extension.oid == ExtensionOID.KEY_USAGE:
@@ -227,23 +344,16 @@ class CSROperationsMixin:
                 )
                 continue
             if extension.oid == ExtensionOID.EXTENDED_KEY_USAGE and not issuing_ca:
-                if allow_sensitive_ekus:
-                    safe_ekus = list(extension.value)
-                else:
-                    safe_ekus = [
-                        oid for oid in extension.value
-                        if oid not in _LEAF_FORBIDDEN_EKU_OIDS
-                    ]
-                    dropped = [
-                        oid.dotted_string for oid in extension.value
-                        if oid in _LEAF_FORBIDDEN_EKU_OIDS
-                    ]
-                    if dropped:
-                        logger.warning(
-                            "sign_csr: dropped sensitive EKU(s) %s from CSR "
-                            "(protocol enrollees may not request delegated "
-                            "OCSP/timestamping authority)", dropped,
-                        )
+                safe_ekus, dropped_oids = _filter_csr_ekus(
+                    extension.value, cert_type, allow_sensitive_ekus
+                )
+                if dropped_oids:
+                    logger.warning(
+                        "sign_csr: dropped EKU(s) %s from CSR — not permitted "
+                        "for certificate type %r (the resolved certificate "
+                        "type, not the CSR, decides leaf key purposes)",
+                        [oid.dotted_string for oid in dropped_oids], cert_type,
+                    )
                 if safe_ekus:
                     builder = builder.add_extension(
                         x509.ExtendedKeyUsage(safe_ekus), extension.critical
@@ -352,12 +462,9 @@ class CSROperationsMixin:
         elif extra_oids:
             # Re-merging the CSR's original EKUs must not resurrect the
             # sensitive ones the copy loop above just dropped
-            csr_ekus = list(existing_eku.value)
-            if not allow_sensitive_ekus:
-                csr_ekus = [
-                    oid for oid in csr_ekus
-                    if oid not in _LEAF_FORBIDDEN_EKU_OIDS
-                ]
+            csr_ekus, _dropped = _filter_csr_ekus(
+                existing_eku.value, cert_type, allow_sensitive_ekus
+            )
             merged = merge_eku_lists(csr_ekus, extra_oids)
             new_builder = x509.CertificateBuilder()
             new_builder = new_builder.subject_name(builder._subject_name)

--- a/backend/tests/test_csr_eku_profile_cap.py
+++ b/backend/tests/test_csr_eku_profile_cap.py
@@ -1,0 +1,196 @@
+"""Regression tests: CSR EKU pass-through cap (security audit v2.203, item #3).
+
+For a leaf, whatever EKU the CSR carried was copied onto the certificate minus
+only OCSPSigning/timeStamping. ``codeSigning``, ``emailProtection``,
+``anyExtendedKeyUsage``, Microsoft Smartcard Logon and arbitrary custom OIDs all
+passed through, and ``cert_type`` only ever *added* an EKU when the CSR omitted
+one — it never constrained a CSR-supplied EKU. Combined with the ACME SAN issue
+(#1), an ACME enrollee that proved only domain control could mint a code-signing
+certificate.
+
+The fix caps CSR-supplied EKUs to what the resolved certificate type permits.
+The admin Sign-CSR path (allow_sensitive_ekus=True) is explicit operator intent
+and keeps its historical behaviour; every protocol path is capped.
+"""
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.x509.oid import ExtendedKeyUsageOID, ExtensionOID, NameOID
+
+from services.trust_store.trust_store_service import TrustStoreService
+
+CODE_SIGNING = ExtendedKeyUsageOID.CODE_SIGNING
+EMAIL_PROTECTION = ExtendedKeyUsageOID.EMAIL_PROTECTION
+SERVER_AUTH = ExtendedKeyUsageOID.SERVER_AUTH
+CLIENT_AUTH = ExtendedKeyUsageOID.CLIENT_AUTH
+ANY_EKU = x509.ObjectIdentifier('2.5.29.37.0')
+SMARTCARD_LOGON = x509.ObjectIdentifier('1.3.6.1.4.1.311.20.2.2')
+
+
+@pytest.fixture(scope='module')
+def ca():
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, 'EKU Cap CA')])
+    cert = (x509.CertificateBuilder()
+            .subject_name(name).issuer_name(name)
+            .public_key(key.public_key())
+            .serial_number(x509.random_serial_number())
+            .not_valid_before(datetime.now(timezone.utc) - timedelta(days=1))
+            .not_valid_after(datetime.now(timezone.utc) + timedelta(days=365))
+            .add_extension(x509.BasicConstraints(ca=True, path_length=None),
+                           critical=True)
+            .sign(key, hashes.SHA256()))
+    return cert, key
+
+
+@pytest.fixture(scope='module')
+def leaf_key():
+    return rsa.generate_private_key(public_exponent=65537, key_size=2048)
+
+
+def _csr(leaf_key, ekus):
+    builder = x509.CertificateSigningRequestBuilder().subject_name(
+        x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, 'leaf.example.com')])
+    )
+    if ekus:
+        builder = builder.add_extension(
+            x509.ExtendedKeyUsage(ekus), critical=False
+        )
+    return builder.sign(leaf_key, hashes.SHA256())
+
+
+def _sign_and_get_ekus(ca, csr, **kwargs):
+    ca_cert, ca_key = ca
+    pem = TrustStoreService.sign_csr(
+        csr_pem=csr.public_bytes(serialization.Encoding.PEM),
+        ca_cert=ca_cert,
+        ca_private_key=ca_key,
+        validity_days=30,
+        **kwargs,
+    )
+    cert = x509.load_pem_x509_certificate(pem)
+    try:
+        ext = cert.extensions.get_extension_for_oid(
+            ExtensionOID.EXTENDED_KEY_USAGE
+        )
+    except x509.ExtensionNotFound:
+        return set()
+    return set(ext.value)
+
+
+# --- the vulnerability: protocol paths must not widen their own EKU ---------
+
+def test_code_signing_stripped_from_server_cert(ca, leaf_key):
+    """The ACME path signs with cert_type='server_cert'."""
+    ekus = _sign_and_get_ekus(
+        ca, _csr(leaf_key, [SERVER_AUTH, CODE_SIGNING]),
+        cert_type='server_cert',
+    )
+    assert CODE_SIGNING not in ekus
+    assert SERVER_AUTH in ekus
+
+
+def test_email_protection_stripped_from_server_cert(ca, leaf_key):
+    ekus = _sign_and_get_ekus(
+        ca, _csr(leaf_key, [SERVER_AUTH, EMAIL_PROTECTION]),
+        cert_type='server_cert',
+    )
+    assert EMAIL_PROTECTION not in ekus
+
+
+def test_any_eku_stripped_from_server_cert(ca, leaf_key):
+    """anyExtendedKeyUsage would make every EKU policy meaningless."""
+    ekus = _sign_and_get_ekus(
+        ca, _csr(leaf_key, [SERVER_AUTH, ANY_EKU]), cert_type='server_cert',
+    )
+    assert ANY_EKU not in ekus
+
+
+def test_smartcard_logon_stripped_from_server_cert(ca, leaf_key):
+    """Smartcard logon + a UPN SAN is the AD-logon vector."""
+    ekus = _sign_and_get_ekus(
+        ca, _csr(leaf_key, [SERVER_AUTH, SMARTCARD_LOGON]),
+        cert_type='server_cert',
+    )
+    assert SMARTCARD_LOGON not in ekus
+
+
+def test_custom_oid_stripped_from_server_cert(ca, leaf_key):
+    custom = x509.ObjectIdentifier('1.3.6.1.4.1.99999.1.1')
+    ekus = _sign_and_get_ekus(
+        ca, _csr(leaf_key, [SERVER_AUTH, custom]), cert_type='server_cert',
+    )
+    assert custom not in ekus
+
+
+def test_code_signing_stripped_from_client_cert(ca, leaf_key):
+    ekus = _sign_and_get_ekus(
+        ca, _csr(leaf_key, [CLIENT_AUTH, CODE_SIGNING]),
+        cert_type='usr_cert',
+    )
+    assert CODE_SIGNING not in ekus
+    assert CLIENT_AUTH in ekus
+
+
+# --- legitimate uses keep working ------------------------------------------
+
+def test_tls_pair_survives_on_server_cert(ca, leaf_key):
+    """serverAuth+clientAuth is a normal mTLS-capable service certificate."""
+    ekus = _sign_and_get_ekus(
+        ca, _csr(leaf_key, [SERVER_AUTH, CLIENT_AUTH]),
+        cert_type='server_cert',
+    )
+    assert ekus == {SERVER_AUTH, CLIENT_AUTH}
+
+
+def test_code_signing_kept_when_cert_type_is_code_signing(ca, leaf_key):
+    """The resolved type — not the CSR — decides; asking properly works."""
+    ekus = _sign_and_get_ekus(
+        ca, _csr(leaf_key, [CODE_SIGNING]), cert_type='code_signing',
+    )
+    assert CODE_SIGNING in ekus
+
+
+def test_email_protection_kept_when_cert_type_is_email(ca, leaf_key):
+    ekus = _sign_and_get_ekus(
+        ca, _csr(leaf_key, [EMAIL_PROTECTION]), cert_type='email_cert',
+    )
+    assert EMAIL_PROTECTION in ekus
+
+
+def test_admin_sensitive_path_is_uncapped(ca, leaf_key):
+    """allow_sensitive_ekus = deliberate operator action; behaviour unchanged."""
+    ekus = _sign_and_get_ekus(
+        ca, _csr(leaf_key, [SERVER_AUTH, CODE_SIGNING]),
+        cert_type='server_cert', allow_sensitive_ekus=True,
+    )
+    assert CODE_SIGNING in ekus
+
+
+def test_operator_supplied_extra_ekus_are_not_capped(ca, leaf_key):
+    """extra_ekus is explicit admin intent and merges in regardless."""
+    ekus = _sign_and_get_ekus(
+        ca, _csr(leaf_key, [SERVER_AUTH]),
+        cert_type='server_cert',
+        extra_ekus=[CODE_SIGNING.dotted_string],
+    )
+    assert CODE_SIGNING in ekus
+
+
+def test_extra_eku_remerge_does_not_resurrect_capped_eku(ca, leaf_key):
+    """The extra_ekus re-merge path must apply the same cap to CSR EKUs.
+
+    Regression guard: the re-merge branch rebuilds the EKU extension from the
+    CSR's original list, so it must filter too, or requesting any extra EKU
+    would restore the ones the copy loop just dropped.
+    """
+    ekus = _sign_and_get_ekus(
+        ca, _csr(leaf_key, [SERVER_AUTH, CODE_SIGNING]),
+        cert_type='server_cert',
+        extra_ekus=[CLIENT_AUTH.dotted_string],
+    )
+    assert CODE_SIGNING not in ekus
+    assert CLIENT_AUTH in ekus

--- a/backend/tests/test_sign_csr_key_strength.py
+++ b/backend/tests/test_sign_csr_key_strength.py
@@ -1,0 +1,115 @@
+"""Regression tests: key-strength floor on every issuance path
+(security audit v2.203, item #2).
+
+``validate_enrollment_public_key`` (RSA >= 2048, NIST P-256/384/521, Ed25519/
+Ed448) existed and was called from SCEP and EST only. Its docstring claimed
+parity with UI/API issuance, but ``TrustStoreService.sign_csr`` — the choke
+point every other path goes through, including the admin sign-CSR endpoint and
+ACME finalize — never called it. A CSR built on a 1024-bit RSA key or a weak
+curve was signed without complaint.
+
+The fix moves the check into sign_csr so all paths inherit the floor.
+"""
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec, ed25519, rsa
+from cryptography.x509.oid import NameOID
+
+from services.trust_store.trust_store_service import TrustStoreService
+
+
+@pytest.fixture(scope='module')
+def ca():
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, 'Key Floor CA')])
+    cert = (x509.CertificateBuilder()
+            .subject_name(name).issuer_name(name)
+            .public_key(key.public_key())
+            .serial_number(x509.random_serial_number())
+            .not_valid_before(datetime.now(timezone.utc) - timedelta(days=1))
+            .not_valid_after(datetime.now(timezone.utc) + timedelta(days=365))
+            .add_extension(x509.BasicConstraints(ca=True, path_length=None),
+                           critical=True)
+            .sign(key, hashes.SHA256()))
+    return cert, key
+
+
+def _csr(private_key, hash_alg=hashes.SHA256()):
+    builder = x509.CertificateSigningRequestBuilder().subject_name(
+        x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, 'weak.example.com')])
+    )
+    # Ed25519/Ed448 self-sign with algorithm=None
+    if isinstance(private_key, ed25519.Ed25519PrivateKey):
+        return builder.sign(private_key, None)
+    return builder.sign(private_key, hash_alg)
+
+
+def _sign(ca, csr, **kwargs):
+    ca_cert, ca_key = ca
+    return TrustStoreService.sign_csr(
+        csr_pem=csr.public_bytes(serialization.Encoding.PEM),
+        ca_cert=ca_cert,
+        ca_private_key=ca_key,
+        validity_days=30,
+        **kwargs,
+    )
+
+
+# --- strong keys still sign ------------------------------------------------
+
+def test_rsa_2048_is_accepted(ca):
+    assert _sign(ca, _csr(rsa.generate_private_key(65537, 2048)))
+
+
+def test_p256_is_accepted(ca):
+    assert _sign(ca, _csr(ec.generate_private_key(ec.SECP256R1())))
+
+
+def test_p384_is_accepted(ca):
+    assert _sign(ca, _csr(ec.generate_private_key(ec.SECP384R1())))
+
+
+def test_ed25519_is_accepted(ca):
+    assert _sign(ca, _csr(ed25519.Ed25519PrivateKey.generate()))
+
+
+# --- weak keys are refused --------------------------------------------------
+
+def test_rsa_1024_is_rejected(ca):
+    """Below the 2048-bit floor — previously signed without complaint."""
+    csr = _csr(rsa.generate_private_key(65537, 1024), hashes.SHA256())
+    with pytest.raises(ValueError, match='RSA key too small'):
+        _sign(ca, csr)
+
+
+def test_weak_curve_secp192r1_is_rejected(ca):
+    csr = _csr(ec.generate_private_key(ec.SECP192R1()))
+    with pytest.raises(ValueError, match='Unsupported EC curve'):
+        _sign(ca, csr)
+
+
+def test_brainpool_curve_is_rejected(ca):
+    """Non-NIST curve outside the allow-list."""
+    try:
+        key = ec.generate_private_key(ec.BrainpoolP256R1())
+    except Exception:
+        pytest.skip('BrainpoolP256R1 unavailable in this OpenSSL build')
+    with pytest.raises(ValueError, match='Unsupported EC curve'):
+        _sign(ca, _csr(key))
+
+
+def test_weak_key_rejected_for_intermediate_ca_too(ca):
+    """The floor is not bypassable by asking for a CA certificate."""
+    csr = _csr(rsa.generate_private_key(65537, 1024))
+    with pytest.raises(ValueError, match='RSA key too small'):
+        _sign(ca, csr, cert_type='intermediate_ca')
+
+
+def test_weak_key_rejected_even_on_admin_sensitive_eku_path(ca):
+    """allow_sensitive_ekus relaxes EKU policy, never key strength."""
+    csr = _csr(rsa.generate_private_key(65537, 1024))
+    with pytest.raises(ValueError, match='RSA key too small'):
+        _sign(ca, csr, allow_sensitive_ekus=True)

--- a/backend/tests/test_subca_permission_and_pathlen.py
+++ b/backend/tests/test_subca_permission_and_pathlen.py
@@ -1,0 +1,232 @@
+"""Regression tests: sub-CA minting via the CSR-sign endpoint
+(security audit v2.203, item #4).
+
+``POST /api/v2/csrs/<id>/sign`` is guarded by ['write:csrs',
+'write:certificates'] but accepted cert_type='intermediate_ca', which creates a
+full CA row with a signing key. Creating a CA normally requires 'write:cas', so
+a principal holding only certificate/CSR scopes (e.g. a scoped API key) could
+escalate to minting an intermediate able to issue for arbitrary names.
+
+Separately, the child's pathLenConstraint was copied straight from the
+requester's CSR BasicConstraints with no cap against the parent, so a signed
+intermediate could claim a deeper — or unlimited — path than its issuer
+(RFC 5280 §4.2.1.9).
+"""
+import json
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.x509.oid import ExtensionOID, NameOID
+
+from services.trust_store.trust_store_service import TrustStoreService
+
+
+def _ca(path_length):
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, 'Pathlen CA')])
+    cert = (x509.CertificateBuilder()
+            .subject_name(name).issuer_name(name)
+            .public_key(key.public_key())
+            .serial_number(x509.random_serial_number())
+            .not_valid_before(datetime.now(timezone.utc) - timedelta(days=1))
+            .not_valid_after(datetime.now(timezone.utc) + timedelta(days=365))
+            .add_extension(
+                x509.BasicConstraints(ca=True, path_length=path_length),
+                critical=True)
+            .sign(key, hashes.SHA256()))
+    return cert, key
+
+
+def _subca_csr(path_length):
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    return (x509.CertificateSigningRequestBuilder()
+            .subject_name(x509.Name(
+                [x509.NameAttribute(NameOID.COMMON_NAME, 'sub.example.com')]))
+            .add_extension(
+                x509.BasicConstraints(ca=True, path_length=path_length),
+                critical=True)
+            .sign(key, hashes.SHA256()))
+
+
+def _sign_subca(ca, csr):
+    ca_cert, ca_key = ca
+    pem = TrustStoreService.sign_csr(
+        csr_pem=csr.public_bytes(serialization.Encoding.PEM),
+        ca_cert=ca_cert,
+        ca_private_key=ca_key,
+        validity_days=30,
+        cert_type='intermediate_ca',
+    )
+    return x509.load_pem_x509_certificate(pem)
+
+
+def _path_length(cert):
+    return cert.extensions.get_extension_for_oid(
+        ExtensionOID.BASIC_CONSTRAINTS
+    ).value.path_length
+
+
+class TestSubCaPathLenCap:
+    """RFC 5280 §4.2.1.9 — a child may assert at most parent_pathlen - 1."""
+
+    def test_unlimited_request_is_clamped_to_parent(self):
+        """CSR asks for an unconstrained path under a pathlen-2 parent."""
+        cert = _sign_subca(_ca(path_length=2), _subca_csr(path_length=None))
+        assert _path_length(cert) == 1
+
+    def test_deeper_request_is_clamped_to_parent(self):
+        cert = _sign_subca(_ca(path_length=2), _subca_csr(path_length=9))
+        assert _path_length(cert) == 1
+
+    def test_within_budget_request_is_honoured(self):
+        cert = _sign_subca(_ca(path_length=3), _subca_csr(path_length=0))
+        assert _path_length(cert) == 0
+
+    def test_pathlen_zero_parent_cannot_issue_a_subca(self):
+        """A parent with pathLen 0 may not be followed by another CA at all."""
+        with pytest.raises(ValueError, match='pathLenConstraint 0'):
+            _sign_subca(_ca(path_length=0), _subca_csr(path_length=None))
+
+    def test_unconstrained_parent_honours_request(self):
+        """No parent constraint — the child's own request stands."""
+        cert = _sign_subca(_ca(path_length=None), _subca_csr(path_length=1))
+        assert _path_length(cert) == 1
+
+
+class TestSubCaRequiresWriteCas:
+    """The CSR-sign endpoint must not be a back door around 'write:cas'."""
+
+    _counter = 0
+
+    def _make_csr_record(self, auth_client):
+        """Create a pending CSR record (the API generates the key + CSR)."""
+        TestSubCaRequiresWriteCas._counter += 1
+        r = auth_client.post(
+            '/api/v2/csrs',
+            data=json.dumps({
+                'cn': f'escalate{self._counter}.example.com',
+                'organization': 'Test Org',
+                'country': 'US',
+                'key_type': 'RSA 2048',
+            }),
+            content_type='application/json',
+        )
+        assert r.status_code in (200, 201), r.data
+        body = json.loads(r.data)
+        return (body.get('data') or body).get('id')
+
+    def _scoped_key(self, app, permissions, name):
+        """Create an API key held by a dedicated operator user.
+
+        The row is written directly rather than via POST
+        /api/v2/account/apikeys: that endpoint enforces a
+        10-active-keys-per-user cap that other tests consume in a full-suite
+        run, and this test is about authorisation at the sign endpoint, not
+        about key minting.
+
+        The owner is an *operator* — who legitimately holds write:cas — while
+        the key is scoped to certificate/CSR permissions only. That is exactly
+        the escalation shape: a principal whose key omits write:cas must not be
+        able to mint a CA.
+        """
+        import hashlib
+        import secrets
+
+        from models import User, db
+        from models.api_key import APIKey
+
+        username = f'subca_probe_{name}'
+        with app.app_context():
+            user = User.query.filter_by(username=username).first()
+            if not user:
+                user = User(
+                    username=username,
+                    email=f'{username}@test.local',
+                    password_hash='!',           # unused: key auth only
+                    role='operator',
+                    active=True,
+                )
+                db.session.add(user)
+                db.session.commit()
+
+            raw_key = f'ucm_ak_{secrets.token_urlsafe(32)}'
+            db.session.add(APIKey(
+                user_id=user.id,
+                key_hash=hashlib.sha256(raw_key.encode()).hexdigest(),
+                key_prefix=raw_key[:12],
+                name=name,
+                permissions=json.dumps(permissions),
+            ))
+            db.session.commit()
+        return raw_key
+
+    def test_cert_scoped_key_cannot_mint_an_intermediate_ca(
+        self, app, auth_client, create_ca
+    ):
+        """The escalation: CSR/cert scopes only, asking for intermediate_ca."""
+        ca = create_ca(cn='Escalation Parent CA')
+        csr_id = self._make_csr_record(auth_client)
+        api_key = self._scoped_key(
+            app,
+            ['read:csrs', 'write:csrs', 'read:certificates', 'write:certificates'],
+            'subca-escalation-probe',
+        )
+
+        client = app.test_client()
+        r = client.post(
+            f'/api/v2/csrs/{csr_id}/sign',
+            data=json.dumps({
+                'ca_id': ca['id'],
+                'cert_type': 'intermediate_ca',
+                'validity_days': 365,
+            }),
+            content_type='application/json',
+            headers={'X-API-Key': api_key},
+        )
+        assert r.status_code == 403, (
+            f'expected 403, got {r.status_code}: {r.data!r} — a key without '
+            'write:cas minted an intermediate CA'
+        )
+
+    def test_cert_scoped_key_can_still_sign_a_leaf(
+        self, app, auth_client, create_ca
+    ):
+        """Control: the gate must not break ordinary certificate signing."""
+        ca = create_ca(cn='Leaf Signing Parent CA')
+        csr_id = self._make_csr_record(auth_client)
+        api_key = self._scoped_key(
+            app,
+            ['read:csrs', 'write:csrs', 'read:certificates', 'write:certificates'],
+            'leaf-signing-probe',
+        )
+
+        client = app.test_client()
+        r = client.post(
+            f'/api/v2/csrs/{csr_id}/sign',
+            data=json.dumps({
+                'ca_id': ca['id'],
+                'cert_type': 'server',
+                'validity_days': 365,
+            }),
+            content_type='application/json',
+            headers={'X-API-Key': api_key},
+        )
+        assert r.status_code in (200, 201), r.data
+
+    def test_admin_can_still_mint_an_intermediate_ca(self, auth_client, create_ca):
+        """Control: admin holds '*', so the CA path stays open to operators."""
+        ca = create_ca(cn='Admin Subca Parent CA')
+        csr_id = self._make_csr_record(auth_client)
+        r = auth_client.post(
+            f'/api/v2/csrs/{csr_id}/sign',
+            data=json.dumps({
+                'ca_id': ca['id'],
+                'cert_type': 'intermediate_ca',
+                'validity_days': 365,
+            }),
+            content_type='application/json',
+        )
+        assert r.status_code in (200, 201), r.data


### PR DESCRIPTION
Three defects sharing the sign_csr choke point.

Key strength: validate_enrollment_public_key enforced RSA>=2048 / P-256+ but
was called only from SCEP and EST, despite a docstring claiming parity with
UI/API issuance. A 1024-bit RSA or secp192r1 CSR was signed without complaint
via the admin sign endpoint and ACME finalize. Moved into sign_csr so every
path inherits it.

EKU pass-through: whatever EKU a CSR carried was copied onto the leaf minus
only OCSPSigning/timeStamping; cert_type only ever added an EKU, never
constrained one. An ACME enrollee (cert_type 'server_cert') could mint a
codeSigning certificate. Cap CSR-supplied EKUs to what the resolved type
permits, and never honour anyExtendedKeyUsage or MS Smartcard Logon from a
CSR. allow_sensitive_ekus (admin sign-CSR) stays uncapped -- explicit operator
intent, behaviour unchanged.

Sub-CA minting: POST /csrs/<id>/sign accepted cert_type='intermediate_ca',
creating a CA row with a signing key, while guarded only by write:csrs /
write:certificates. Require write:cas for CA types. The child's
pathLenConstraint was also copied from the requester's CSR uncapped; clamp it
to parent-1 and refuse a sub-CA under a pathLen 0 parent (RFC 5280 4.2.1.9).

Evidence: all three verified against v2.203 (8e51e76); the new tests fail on
that tree and pass here.

(cherry picked from commit 700c9597318e5fe3f2a54fafdcf969d5540723aa)
