### PR TITLE
fix(secrets): make silent encryption fallbacks loud and refusable

### DIFF
--- a/backend/security/encryption.py
+++ b/backend/security/encryption.py
@@ -70,6 +70,24 @@ class KeyEncryption:
                 logger.info("🔑 Encryption key loaded from KEY_ENCRYPTION_KEY env var")
         
         if not key:
+            # No key configured. encrypt() below then returns its input
+            # unchanged, so CA.prv / Certificate.prv — including CA *signing*
+            # keys — are stored as plaintext in the database. That used to
+            # happen silently; make it loud, and let deployments refuse to run
+            # rather than write crown-jewel keys in the clear.
+            if os.getenv('UCM_REQUIRE_KEY_ENCRYPTION', '').lower() == 'true':
+                raise RuntimeError(
+                    'Private-key encryption is required (UCM_REQUIRE_KEY_ENCRYPTION=true) '
+                    f'but no key is configured. Provide {MASTER_KEY_PATH} or set '
+                    'KEY_ENCRYPTION_KEY.'
+                )
+            logger.error(
+                "🔓 Private-key encryption is DISABLED — no %s and no "
+                "KEY_ENCRYPTION_KEY. CA and certificate private keys will be "
+                "stored UNENCRYPTED at rest. Configure a key, and set "
+                "UCM_REQUIRE_KEY_ENCRYPTION=true to refuse startup without one.",
+                MASTER_KEY_PATH,
+            )
             self._enabled = False
             self._key_source = None
             return

--- a/backend/utils/encryption.py
+++ b/backend/utils/encryption.py
@@ -6,8 +6,11 @@ Uses Fernet symmetric encryption with key from environment
 import os
 import base64
 import hashlib
+import logging
 from cryptography.fernet import Fernet
 from functools import lru_cache
+
+logger = logging.getLogger(__name__)
 
 
 def _get_encryption_key() -> bytes:
@@ -16,11 +19,36 @@ def _get_encryption_key() -> bytes:
     Key is derived from UCM_DB_ENCRYPTION_KEY or a default based on machine ID.
     """
     key = os.environ.get('UCM_DB_ENCRYPTION_KEY')
-    
+
     if key:
         # Use provided key (should be base64-encoded 32 bytes)
         return key.encode()
-    
+
+    # No explicit key. The fallback below derives one from the machine id with
+    # a salt that is a constant in this source file — so anyone holding a copy
+    # of the database AND /etc/machine-id (world-readable, and routinely
+    # captured in backups and VM images) can reconstruct the key and decrypt
+    # every integration secret: DNS-provider credentials, LDAP/ADCS/WinRM
+    # passwords, SMTP and OAuth secrets, SSO client secrets, webhook secrets,
+    # ACME EAB keys and HSM credentials.
+    #
+    # The derivation is kept for backward compatibility — changing it would
+    # make existing encrypted rows undecryptable — but it is now loud, and
+    # deployments can refuse to run without a real key.
+    if os.environ.get('UCM_REQUIRE_DB_ENCRYPTION_KEY', '').lower() == 'true':
+        raise RuntimeError(
+            'UCM_DB_ENCRYPTION_KEY is not set and UCM_REQUIRE_DB_ENCRYPTION_KEY=true. '
+            'Set UCM_DB_ENCRYPTION_KEY to a base64-encoded 32-byte Fernet key.'
+        )
+
+    logger.warning(
+        'UCM_DB_ENCRYPTION_KEY is not set — falling back to a key derived from '
+        'the machine id with a static, in-source salt. Anyone with a copy of '
+        'the database and /etc/machine-id can decrypt all stored integration '
+        'secrets. Set UCM_DB_ENCRYPTION_KEY (and UCM_REQUIRE_DB_ENCRYPTION_KEY=true '
+        'to enforce it).'
+    )
+
     # Generate deterministic key from machine-specific data
     # This ensures the same key is used across restarts
     machine_id_paths = [


### PR DESCRIPTION
utils/encryption.py: with UCM_DB_ENCRYPTION_KEY unset, the Fernet key is
derived from the machine id with a static in-source salt. /etc/machine-id is
world-readable and routinely captured in backups and VM images, so a stolen
database plus that file yields every integration secret -- DNS-provider
credentials, LDAP/ADCS/WinRM passwords, SMTP and OAuth secrets, SSO client
secrets, webhook secrets, ACME EAB keys, HSM credentials.

security/encryption.py: with no master.key or KEY_ENCRYPTION_KEY, encrypt()
returned its input unchanged, so CA.prv and Certificate.prv -- including CA
signing keys -- were stored as plaintext with no operator signal.

The derivation is kept (changing the salt would make existing rows
undecryptable) but now warns, and UCM_REQUIRE_DB_ENCRYPTION_KEY /
UCM_REQUIRE_KEY_ENCRYPTION let a deployment refuse to start instead.

(cherry picked from commit 8377e829f93019cde5bd7a1d5b9fab204a59c1ae)
