### PR TITLE
chore(hardening): fix deployment and CI defaults flagged by the audit

### DIFF
--- a/.env.docker.example
+++ b/.env.docker.example
@@ -40,7 +40,10 @@ POSTGRES_DB=ucm
 POSTGRES_USER=ucm
 
 # PostgreSQL password (CHANGE THIS IN PRODUCTION!)
-POSTGRES_PASSWORD=changeme123
+# Generate a real value, e.g.: openssl rand -base64 32
+# Left deliberately non-working so a copied example file fails loudly instead
+# of silently standing up a database with a publicly known password.
+POSTGRES_PASSWORD=REPLACE_WITH_A_STRONG_RANDOM_PASSWORD
 
 
 # =============================================================================

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -70,7 +70,9 @@ jobs:
         continue-on-error: true
       
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@master
+        # Pinned to a release SHA: @master is a mutable ref, so a compromise of
+        # the action's repo would execute attacker code in this workflow.
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25  # v0.36.0
         with:
           scan-type: 'fs'
           scan-ref: '.'

--- a/backend/api/est_protocol.py
+++ b/backend/api/est_protocol.py
@@ -410,8 +410,15 @@ def _trusted_client_cert():
         or request.headers.get('X-SSL-Client-Verify')
         or ''
     ).upper()
-    if verify and verify != 'SUCCESS':
-        logger.warning("EST: SSL_CLIENT_VERIFY=%s — refusing client cert", verify)
+    # Fail closed: a missing SSL_CLIENT_VERIFY is not evidence of a verified
+    # peer. Treating absent-as-OK meant a trusted proxy that forwarded the
+    # certificate but not the verify result would have its client certs
+    # accepted unvalidated.
+    if verify != 'SUCCESS':
+        logger.warning(
+            "EST: SSL_CLIENT_VERIFY=%r — refusing client cert",
+            verify or '<missing>',
+        )
         return None
 
     return (

--- a/backend/api/v2/import_opnsense.py
+++ b/backend/api/v2/import_opnsense.py
@@ -138,7 +138,7 @@ def test_connection():
         "port": 443,
         "api_key": "xxx",
         "api_secret": "xxx",
-        "verify_ssl": false
+        "verify_ssl": true
     }
     
     Returns: {
@@ -168,7 +168,7 @@ def test_connection():
     port = data.get('port', 443)
     api_key = _clean(data.get('api_key'))
     api_secret = _clean(data.get('api_secret'))
-    verify_ssl = data.get('verify_ssl', False)
+    verify_ssl = data.get('verify_ssl', True)
     
     logger.info(f"OpnSense test connection: host={host}, port={port}, verify_ssl={verify_ssl}")
     
@@ -259,7 +259,7 @@ def import_items():
         "port": 443,
         "api_key": "xxx",
         "api_secret": "xxx",
-        "verify_ssl": false,
+        "verify_ssl": true,
         "items": ["uuid1", "uuid2", ...]
     }
     
@@ -280,7 +280,7 @@ def import_items():
     port = data.get('port', 443)
     api_key = _clean(data.get('api_key'))
     api_secret = _clean(data.get('api_secret'))
-    verify_ssl = data.get('verify_ssl', False)
+    verify_ssl = data.get('verify_ssl', True)
     items = data.get('items', [])
     
     logger.info(f"OpnSense import: host={host}, port={port}, items_count={len(items)}")

--- a/backend/init_db.py
+++ b/backend/init_db.py
@@ -37,7 +37,11 @@ def init_database():
                 email='admin@ucm.local',
                 password_hash=hashed_password.decode('utf-8'),
                 role='admin',
-                is_active=True
+                is_active=True,
+                # Match app.py / database_health.py: the seeded password is
+                # public knowledge, so it must be rotated at first login rather
+                # than silently remaining valid.
+                force_password_change=True
             )
             db.session.add(admin)
             db.session.commit()

--- a/backend/services/opnsense/__init__.py
+++ b/backend/services/opnsense/__init__.py
@@ -11,7 +11,7 @@ class OPNsenseImportService(ConnectionMixin, ParserMixin, ImportMixin):
 
     def __init__(self, base_url: str, username: str = None, password: str = None,
                  api_key: str = None, api_secret: str = None,
-                 verify_ssl: bool = False):
+                 verify_ssl: bool = True):
         """
         Initialize OPNsense import service.
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -2,9 +2,18 @@
 # UCM - Docker Compose Development Configuration
 # ============================================================================
 # Development setup with hot-reload, debugging, and verbose logging
-# 
+#
 # Usage:
 #   docker-compose -f docker-compose.yml -f docker-compose.dev.yml up
+#
+# ############################################################################
+# # NEVER EXPOSE THIS CONFIGURATION TO AN UNTRUSTED NETWORK.               ##
+# # FLASK_DEBUG=true enables the Werkzeug interactive debugger, which is    ##
+# # remote code execution for anyone who can reach it, and the debugpy      ##
+# # port below is an unauthenticated Python debugger. Both are bound to     ##
+# # 127.0.0.1 so they stay on the developer's machine — do not change that  ##
+# # to 0.0.0.0, and never use this file in production.                      ##
+# ############################################################################
 # ============================================================================
 
 
@@ -55,7 +64,9 @@ services:
     ports:
       - "${UCM_HTTPS_PORT:-8443}:8443"
       - "${UCM_HTTP_PORT:-8080}:8080"
-      - "5678:5678"  # Python debugger (debugpy)
+      # Loopback-bound: an unauthenticated Python debugger must never be
+      # reachable off-host.
+      - "127.0.0.1:5678:5678"  # Python debugger (debugpy)
     
     # Relaxed resource limits for development
     deploy:


### PR DESCRIPTION
- init_db.py seeded admin/changeme123 without force_password_change, unlike
  the app.py and database_health.py paths; match them.
- .env.docker.example shipped a working POSTGRES_PASSWORD; use a non-working
  placeholder so a copied file fails loudly.
- docker-compose.dev.yml exposed debugpy on 0.0.0.0 alongside FLASK_DEBUG
  (Werkzeug console = RCE); bind to loopback and add a do-not-expose banner.
- trivy-action was pinned to @master, a mutable ref; pin to a release SHA.
- OPNsense import defaulted verify_ssl=False, allowing MITM on that outbound
  channel; default to True.
- EST treated a missing SSL_CLIENT_VERIFY as success when the peer was a
  trusted proxy; require SUCCESS explicitly.

(cherry picked from commit bf14819429efb08559ac1e4693cdc682628e60a3)
