### PR TITLE
fix(ssh): honor the "24h/7d/365d" duration format the TTL placeholder promises

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Starting with v2.48, UCM uses Major.Build versioning (e.g., 2.48, 2.49). Earlier
 
 
 ### Fixed
+- **SSH CA TTL fields accept the duration format the UI advertises** — the create/edit placeholders say "e.g. 24h, 7d, 365d", but `default_ttl`/`max_ttl` were cast with a bare `int()`, so `365d` was rejected with `invalid literal for int()` (and the import path stored the raw string, crashing later at issuance). All three entry points (create, update, import) now normalize through `utils.duration.parse_duration_seconds()` — plain numbers stay valid as seconds, `s/m/h/d/w/y` suffixes are accepted, and malformed values fail with a clear 400 naming the accepted formats.
 - **Approved issuance (policy workflow) now honors the certificate template** — when a deferred certificate request finalized after approval, the legacy approval issuance path ignored the template's Key Usage / Extended Key Usage, used hardcoded cert-type profiles, always signed with SHA-256 (ignoring the template digest), fell back to its own request defaults instead of the template's key type/validity, stored the resulting private key unencrypted, dropped the `template_id` linkage, and skipped the CA-expiration sanity check. The approval path now applies the template's extensions template / digest / defaults like the direct issuance path (#226), encrypts the issued private key via `encrypt_private_key`, preserves the template link with `template_overrides` (#258), and refuses validity beyond the CA's own end-of-life.
 
 ### Added

--- a/backend/services/ssh_ca_service.py
+++ b/backend/services/ssh_ca_service.py
@@ -22,6 +22,7 @@ from cryptography.hazmat.primitives.serialization import ssh as ssh_serializatio
 from models import db
 from models.ssh import SSHCertificateAuthority
 from utils.datetime_utils import utc_now
+from utils.duration import parse_duration_seconds
 
 # Import key encryption (optional — fallback if not available)
 try:
@@ -138,8 +139,9 @@ class SSHCAService:
             ca_type: 'user' or 'host'
             key_type: Key algorithm (ed25519, rsa, ecdsa-p256/p384/p521)
             username: Who created it
-            default_ttl: Default certificate validity in seconds
-            max_ttl: Maximum allowed TTL (0 = unlimited)
+            default_ttl: Default certificate validity — seconds or a
+                duration string ("24h", "7d", "365d")
+            max_ttl: Maximum allowed TTL (0 = unlimited) — same formats
             default_extensions: List of default extensions for user certs
             allowed_principals: List of allowed principal patterns
             comment: Optional notes
@@ -155,6 +157,15 @@ class SSHCAService:
             raise ValueError(f"Invalid key type: {key_type}. "
                              f"Valid: {', '.join(KEY_TYPE_MAP.keys())}")
 
+        # Validate/normalize TTL before burning a keygen on an invalid request
+        if default_ttl is None:
+            default_ttl = DEFAULT_USER_TTL if ca_type == 'user' else DEFAULT_HOST_TTL
+        else:
+            default_ttl = parse_duration_seconds(default_ttl, field='default_ttl')
+
+        if max_ttl is not None:
+            max_ttl = parse_duration_seconds(max_ttl, field='max_ttl')
+
         # Generate key pair
         private_key = SSHCAService._generate_key(key_type)
         public_key = private_key.public_key()
@@ -163,15 +174,6 @@ class SSHCAService:
         pub_openssh = ssh_serialization.serialize_ssh_public_key(public_key).decode('utf-8')
         prv_stored = SSHCAService._serialize_private_key(private_key)
         fingerprint = SSHCAService._compute_fingerprint(public_key)
-
-        # Set default TTL based on type
-        if default_ttl is None:
-            default_ttl = DEFAULT_USER_TTL if ca_type == 'user' else DEFAULT_HOST_TTL
-        else:
-            default_ttl = int(default_ttl)
-
-        if max_ttl is not None:
-            max_ttl = int(max_ttl)
 
         # Default extensions for user CAs
         if default_extensions is None and ca_type == 'user':
@@ -216,8 +218,8 @@ class SSHCAService:
             ca_type: 'user' or 'host'
             private_key_pem: Private key in OpenSSH PEM format (bytes or str)
             username: Who imported it
-            default_ttl: Default TTL in seconds
-            max_ttl: Max TTL (0 = unlimited)
+            default_ttl: Default TTL — seconds or duration string ("24h", "7d")
+            max_ttl: Max TTL (0 = unlimited) — same formats
             comment: Optional notes
             owner_group_id: Optional group ownership
 
@@ -252,6 +254,10 @@ class SSHCAService:
 
         if default_ttl is None:
             default_ttl = DEFAULT_USER_TTL if ca_type == 'user' else DEFAULT_HOST_TTL
+        else:
+            default_ttl = parse_duration_seconds(default_ttl, field='default_ttl')
+        if max_ttl is not None:
+            max_ttl = parse_duration_seconds(max_ttl, field='max_ttl')
 
         default_extensions = list(SSHCertificateAuthority.STANDARD_EXTENSIONS) if ca_type == 'user' else None
 
@@ -296,9 +302,10 @@ class SSHCAService:
         allowed_fields = {'descr', 'default_ttl', 'max_ttl', 'comment', 'owner_group_id'}
         for field, value in kwargs.items():
             if field in allowed_fields:
-                # Cast TTL fields to int to prevent str/int comparison errors
+                # Normalize TTL fields (seconds or duration strings like
+                # "7d") to int seconds to prevent str/int comparison errors
                 if field in ('default_ttl', 'max_ttl') and value is not None:
-                    value = int(value)
+                    value = parse_duration_seconds(value, field=field)
                 setattr(ca, field, value)
 
         if 'default_extensions' in kwargs:

--- a/backend/tests/test_ssh.py
+++ b/backend/tests/test_ssh.py
@@ -297,6 +297,120 @@ class TestUpdateSSHCA:
 
 
 # ============================================================
+# TTL duration strings — UI placeholder promises "24h, 7d, 365d"
+# ============================================================
+
+class TestSSHCaTtlDuration:
+    """TTL fields accept duration strings, normalized to int seconds."""
+
+    def test_create_accepts_day_suffix(self, auth_client):
+        payload = {**VALID_USER_CA, 'descr': 'Duration Days CA', 'default_ttl': '365d'}
+        r = post_json(auth_client, '/api/v2/ssh/cas', payload)
+        data = assert_success(r, status=201)
+        assert data['default_ttl'] == 365 * 86400
+
+    def test_create_accepts_hour_suffix_and_max_ttl(self, auth_client):
+        payload = {**VALID_USER_CA, 'descr': 'Duration Hours CA',
+                   'default_ttl': '24h', 'max_ttl': '7d'}
+        r = post_json(auth_client, '/api/v2/ssh/cas', payload)
+        data = assert_success(r, status=201)
+        assert data['default_ttl'] == 86400
+        assert data['max_ttl'] == 7 * 86400
+
+    def test_create_accepts_numeric_string(self, auth_client):
+        payload = {**VALID_USER_CA, 'descr': 'Numeric String TTL CA', 'default_ttl': '3600'}
+        r = post_json(auth_client, '/api/v2/ssh/cas', payload)
+        data = assert_success(r, status=201)
+        assert data['default_ttl'] == 3600
+
+    def test_create_rejects_unknown_unit(self, auth_client):
+        payload = {**VALID_USER_CA, 'descr': 'Bad Unit CA', 'default_ttl': '365x'}
+        r = post_json(auth_client, '/api/v2/ssh/cas', payload)
+        assert_error(r, 400)
+
+    def test_create_rejects_garbage(self, auth_client):
+        payload = {**VALID_USER_CA, 'descr': 'Garbage TTL CA', 'default_ttl': 'abc'}
+        r = post_json(auth_client, '/api/v2/ssh/cas', payload)
+        assert_error(r, 400)
+
+    def test_create_rejects_boolean(self, auth_client):
+        payload = {**VALID_USER_CA, 'descr': 'Boolean TTL CA', 'default_ttl': True}
+        r = post_json(auth_client, '/api/v2/ssh/cas', payload)
+        assert_error(r, 400)
+
+    def test_update_accepts_duration(self, auth_client):
+        ca = _create_ssh_ca(auth_client, descr='Duration Update CA')
+        r = put_json(auth_client, f'/api/v2/ssh/cas/{ca["id"]}', {'default_ttl': '30d'})
+        data = assert_success(r)
+        assert data['default_ttl'] == 30 * 86400
+
+    def test_update_rejects_invalid_duration(self, auth_client):
+        ca = _create_ssh_ca(auth_client, descr='Duration Reject CA')
+        r = put_json(auth_client, f'/api/v2/ssh/cas/{ca["id"]}', {'max_ttl': 'forever'})
+        assert_error(r, 400)
+
+    def test_import_accepts_duration(self, auth_client):
+        from cryptography.hazmat.primitives.asymmetric import ed25519
+        from cryptography.hazmat.primitives.serialization import (
+            Encoding, NoEncryption, PrivateFormat,
+        )
+        key = ed25519.Ed25519PrivateKey.generate()
+        pem = key.private_bytes(Encoding.PEM, PrivateFormat.OpenSSH, NoEncryption()).decode()
+        r = post_json(auth_client, '/api/v2/ssh/cas/import', {
+            'private_key': pem,
+            'descr': 'Duration Import CA',
+            'ca_type': 'user',
+            'default_ttl': '90d',
+            'max_ttl': '1y',
+        })
+        data = assert_success(r, status=201)
+        assert data['default_ttl'] == 90 * 86400
+        assert data['max_ttl'] == 365 * 86400
+
+    def test_duration_ca_signs_certificate(self, auth_client):
+        """The import path used to store raw strings — issuance then crashed
+        on int(ca.default_ttl). Duration-created CAs must sign fine."""
+        payload = {**VALID_USER_CA, 'descr': 'Duration Sign CA', 'default_ttl': '365d'}
+        r = post_json(auth_client, '/api/v2/ssh/cas', payload)
+        ca = assert_success(r, status=201)
+        r = post_json(auth_client, '/api/v2/ssh/certificates', {
+            'ca_id': ca['id'],
+            'public_key': _generate_test_ssh_key(),
+            'cert_type': 'user',
+            'principals': ['testuser'],
+        })
+        assert_success(r, status=201)
+
+
+class TestParseDurationSeconds:
+    """Unit coverage for utils.duration.parse_duration_seconds."""
+
+    def test_units(self):
+        from utils.duration import parse_duration_seconds as parse
+        assert parse('30s') == 30
+        assert parse('30m') == 1800
+        assert parse('24h') == 86400
+        assert parse('7d') == 604800
+        assert parse('2w') == 1209600
+        assert parse('1y') == 31536000
+        assert parse('7D') == 604800  # case-insensitive
+        assert parse(' 24h ') == 86400  # surrounding whitespace
+
+    def test_passthrough_scalars(self):
+        from utils.duration import parse_duration_seconds as parse
+        assert parse(3600) == 3600
+        assert parse('3600') == 3600
+        assert parse(0) == 0  # max_ttl=0 means unlimited
+
+    def test_rejects_invalid(self):
+        from utils.duration import parse_duration_seconds as parse
+        for bad in ('', 'd', '1.5h', '-7d', '365x', 'abc', True, None, [86400],
+                    1.5, float('inf'), float('nan'), 2**63, '99999999999999999999y'):
+            with pytest.raises(ValueError):
+                parse(bad)
+
+
+# ============================================================
 # Delete SSH CA
 # ============================================================
 

--- a/backend/utils/duration.py
+++ b/backend/utils/duration.py
@@ -1,0 +1,57 @@
+"""
+Human duration strings ("24h", "7d", "365d") → seconds.
+
+UI placeholders advertise duration suffixes for TTL fields, so the backend
+must accept them at the API boundary and normalize to integer seconds for
+storage. Bare numbers stay valid (seconds) for API compatibility.
+"""
+import math
+import re
+
+_DURATION_RE = re.compile(r'^(\d+)\s*([smhdwySMHDWY]?)$')
+
+_UNIT_SECONDS = {
+    '': 1,
+    's': 1,
+    'm': 60,
+    'h': 3600,
+    'd': 86400,
+    'w': 604800,
+    'y': 31536000,  # 365 days — civil-year convention, leap years ignored
+}
+
+_MAX_SECONDS = 2**63 - 1  # signed BIGINT range — larger values overflow the column at commit time
+
+
+def parse_duration_seconds(value, *, field='duration') -> int:
+    """
+    Parse a TTL/duration value to integer seconds.
+
+    Accepts int/float (already seconds), numeric strings ("86400"), and
+    unit-suffixed strings ("30m", "24h", "7d", "2w", "1y"; case-insensitive,
+    optional space before the unit).
+
+    Raises ValueError carrying the field name and the accepted formats on
+    anything else (unknown units, negatives, non-finite or fractional
+    floats, values beyond the BIGINT column range, empty, non-scalar
+    types), so API handlers surface a clean 400 instead of a bare int()
+    traceback or a 500 from the database.
+    """
+    hint = "use seconds or a duration like '24h', '7d', '365d' (s/m/h/d/w/y)"
+    seconds = None
+    if isinstance(value, bool):
+        # bool is an int subclass — a JSON true/false is never a TTL
+        pass
+    elif isinstance(value, float) and not math.isfinite(value):
+        pass
+    elif isinstance(value, (int, float)):
+        seconds = int(value)
+        if seconds != value:  # fractional float — not a whole-second TTL
+            seconds = None
+    elif isinstance(value, str):
+        match = _DURATION_RE.match(value.strip())
+        if match:
+            seconds = int(match.group(1)) * _UNIT_SECONDS[match.group(2).lower()]
+    if seconds is None or seconds < 0 or seconds > _MAX_SECONDS:
+        raise ValueError(f"Invalid {field}: {value!r} — {hint}")
+    return seconds


### PR DESCRIPTION
While creating an SSH CA through the UI I filled the Default TTL field with `365d` — exactly what the placeholder suggests (`e.g. 24h, 7d, 365d`, in all nine locales) — and got back `invalid literal for int() with base 10: '365d'`. The placeholder promises a duration format the backend never accepted.

## 1. Root cause — and it's three paths, not one

`default_ttl`/`max_ttl` handling in `services/ssh_ca_service.py` diverged per entry point:

- **create** (`create_ca`) and **update** (`update_ca`) cast with a bare `int()`, so any duration suffix is rejected with a raw `int()` error message (400 via the route's `except ValueError`).
- **import** (`import_ca`) skipped the cast *entirely* — the raw string was stored as-is. On SQLite that silently writes TEXT into the INTEGER column and the CA looks fine until the first issuance, where `int(ca.default_ttl)` in `services/ssh_cert/signing.py` blows up; on PostgreSQL the import itself errors. The worst of the three: a latent crash planted at creation time.

There was no shared duration parser anywhere in the backend, so the UI promise had nothing backing it.

## 2. The fix

New `utils/duration.py` with `parse_duration_seconds()`, used by all three entry points (stored value is still integer seconds, so signing and every existing consumer is untouched):

- Accepts: plain ints/floats and numeric strings (unchanged, backwards compatible), plus case-insensitive `s/m/h/d/w/y` suffixes (`24h`, `7d`, `365d`, `2w`, `1y`, optional space before the unit).
- Rejects with a 400 naming the accepted formats: unknown units, garbage, negatives, fractional floats, `bool`, non-finite floats (`Infinity`/`NaN` — `int(float('inf'))` raises `OverflowError`, which would otherwise fall through to a 500), and values beyond the signed BIGINT range (previously a DB overflow at commit).
- Composite durations like `1h30m` are deliberately *not* supported — single-unit only, matching the placeholder examples; the error message says exactly what is accepted.

Two small behavior changes, both in the hardening direction: negative integers are now refused (they used to be stored and would produce certs with `valid_before > valid_after`), and TTL parsing in `create_ca` moved ahead of key generation so a malformed TTL no longer burns an RSA-4096 keygen before failing.

The frontend needs no change — the placeholder was already the contract; the backend now honors it. Note the cert *issuance* endpoint (`validity_seconds`) intentionally stays integer-seconds: its UI copy says "custom seconds", so there's no mismatch there.

## Tests

New coverage in `backend/tests/test_ssh.py` (14 tests):

- API level: create with `365d`/`24h`+`7d`/numeric string → 201 with the normalized seconds asserted; unknown unit, garbage and `true` → 400; update accepts `30d` and rejects `forever`; import with `90d`+`1y` stores seconds.
- End-to-end: a CA created with `default_ttl: '365d'` signs a certificate successfully — the exact path the import bug would have crashed.
- Parser units: every suffix, case-insensitivity, whitespace, scalar pass-through, and 14 invalid inputs including `inf`/`nan`/`2**63`.

Fail-before/pass-after: every API-level test fails against `upstream/dev` (create/update rejected, import stored the string). Full backend suite: **3220 passed** (2 truststore export failures reproduce identically on unmodified upstream — environment, no regression). `ruff check` clean on all touched files.