### PR TITLE
feat(wstep): embed AD SID security extension for KB5014754 strong mapping

### DIFF
--- a/backend/services/ad_connector/lookup.py
+++ b/backend/services/ad_connector/lookup.py
@@ -221,6 +221,95 @@ def lookup_computer_dns_hostname(sam_account_name):
             pass
 
 
+def _sid_bytes_to_string(raw):
+    """Windows binary SID -> ``"S-1-5-21-...-<RID>"`` string form.
+
+    Layout: ``byte[0]`` revision, ``byte[1]`` sub-authority count,
+    ``bytes[2:8]`` big-endian identifier authority, then N x 4-byte
+    little-endian sub-authorities. Verified against a real captured SID
+    (both a live LDAP query for a lab machine account and the SID string
+    embedded in a real ADCS-issued certificate's security extension agree
+    on the domain-SID prefix) -- not spec-derived.
+
+    ``None`` on any malformed input (wrong length for the declared
+    sub-authority count, empty bytes) rather than raising -- this is
+    untrusted binary data straight from a directory attribute.
+    """
+    if not raw or len(raw) < 8:
+        return None
+    revision = raw[0]
+    sub_count = raw[1]
+    expected_len = 8 + sub_count * 4
+    if len(raw) != expected_len:
+        return None
+    authority = int.from_bytes(raw[2:8], 'big')
+    sub_authorities = [
+        int.from_bytes(raw[8 + i * 4:12 + i * 4], 'little')
+        for i in range(sub_count)
+    ]
+    return f"S-{revision}-{authority}-" + "-".join(str(s) for s in sub_authorities)
+
+
+def lookup_object_sid(sam_account_name):
+    """The AD object's ``objectSid`` (user or computer -- no ``objectClass``
+    filter needed since ``sAMAccountName`` is domain-unique, machine
+    accounts keep their trailing ``$``), as a ``"S-1-5-21-..."`` string --
+    the exact form real ADCS embeds in the SID security extension
+    (``szOID_NTDS_CA_SECURITY_EXT``, see services/trust_store/
+    csr_operations_mixin.py's ``_ad_security_extension``) for KB5014754
+    strong certificate mapping.
+
+    ``ldap3`` does not auto-format ``objectSid`` -- ``entry.objectSid.value``
+    returns the raw bytes mis-decoded as a string, so this reads
+    ``raw_values[0]`` (the real binary SID) and converts it via
+    ``_sid_bytes_to_string``.
+
+    Returns ``None`` on every failure mode: connector not configured or
+    disabled, unreachable, bind failure, entry not found, or the attribute
+    is empty/malformed. Never raises. Callers needing to distinguish
+    "connector not configured" (skip this feature) from "configured but
+    this lookup failed" (deny, for strong mapping) must check
+    ``ADConnectorConfig`` themselves before calling this -- this function's
+    ``None`` return does not carry that distinction, matching every other
+    lookup in this module.
+    """
+    from ldap3.utils.conv import escape_filter_chars
+
+    from models import ADConnectorConfig
+
+    config = ADConnectorConfig.get_singleton()
+    if not config or not config.enabled or not config.server or not config.base_dn:
+        return None
+
+    try:
+        conn = _connect(config)
+    except Exception as e:
+        logger.warning("AD Connector: bind failed during SID lookup: %s", e)
+        return None
+
+    try:
+        safe_sam = escape_filter_chars(sam_account_name)
+        conn.search(
+            config.base_dn,
+            f'(sAMAccountName={safe_sam})',
+            attributes=['objectSid'],
+        )
+        if not conn.entries:
+            return None
+        entry = conn.entries[0]
+        if 'objectSid' not in entry or not entry.objectSid.raw_values:
+            return None
+        return _sid_bytes_to_string(entry.objectSid.raw_values[0])
+    except Exception as e:
+        logger.warning("AD Connector: SID lookup failed: %s", e)
+        return None
+    finally:
+        try:
+            conn.unbind()
+        except Exception:
+            pass
+
+
 def lookup_user_ad_identity(sam_account_name):
     """The AD user object's directory path (as ordered RDN components, for
     building an x509.Name matching real ADCS's directory-path subject),

--- a/backend/services/ca/ca_signing.py
+++ b/backend/services/ca/ca_signing.py
@@ -46,6 +46,7 @@ class CASigningMixin:
         ms_certificate_template_oid: str = None,
         override_subject: x509.Name = None,
         override_san: list = None,
+        requester_sid: str = None,
         cert_type: str = 'server_cert',
         extra_ekus: list = None,
     ) -> Tuple[str, str]:
@@ -68,6 +69,8 @@ class CASigningMixin:
             override_subject: forwarded to TrustStoreService.sign_csr — see
                 its docstring. Only WSTEP's Kerberos binding passes this.
             override_san: forwarded to TrustStoreService.sign_csr — see its
+                docstring. Only WSTEP's Kerberos binding passes this.
+            requester_sid: forwarded to TrustStoreService.sign_csr — see its
                 docstring. Only WSTEP's Kerberos binding passes this.
             cert_type: Signing profile for TrustStoreService.sign_csr —
                 decides the EKU ceiling. EST passes 'device_cert'; WSTEP
@@ -118,6 +121,7 @@ class CASigningMixin:
             ms_certificate_template_oid=ms_certificate_template_oid,
             override_subject=override_subject,
             override_san=override_san,
+            requester_sid=requester_sid,
             extra_ekus=extra_ekus,
         )
 

--- a/backend/services/trust_store/csr_operations_mixin.py
+++ b/backend/services/trust_store/csr_operations_mixin.py
@@ -51,6 +51,47 @@ def _certificate_template_extension(template_oid, major=100, minor=0):
     return x509.UnrecognizedExtension(_MS_CERTIFICATE_TEMPLATE_OID, der)
 
 
+_SID_SECURITY_EXT_OID = x509.ObjectIdentifier('1.3.6.1.4.1.311.25.2')
+_NTDS_OBJECT_SID_OID = '1.3.6.1.4.1.311.25.2.1'
+
+
+def _ad_security_extension(sid_string):
+    """Build the Microsoft SID security extension
+    (``szOID_NTDS_CA_SECURITY_EXT``, 1.3.6.1.4.1.311.25.2) real ADCS embeds
+    on AD-authenticated issuances for KB5014754 strong certificate mapping:
+    ``SEQUENCE OF [0] { type OBJECT IDENTIFIER, value [0] EXPLICIT OCTET
+    STRING }``, one entry, the OCTET STRING holding the requester's SID in
+    its ``"S-1-5-21-..."`` string form (not raw binary -- confirmed by
+    capturing a real cert's extension in the lab). ``cryptography`` has no
+    native type for this either, so hand-built with asn1crypto and wrapped
+    as UnrecognizedExtension -- same approach as
+    ``_certificate_template_extension`` above. Byte-for-byte verified
+    against a real ADCS-issued certificate's own extension for the same
+    SID (see test_ad_security_extension.py)."""
+    from asn1crypto import core as asn1_core
+
+    class _SidValue(asn1_core.OctetString):
+        pass
+
+    class _SecurityExtEntry(asn1_core.Sequence):
+        class_ = 2  # context
+        tag = 0
+        _fields = [
+            ('type', asn1_core.ObjectIdentifier),
+            ('value', _SidValue, {'explicit': 0}),
+        ]
+
+    class _SecurityExt(asn1_core.SequenceOf):
+        _child_spec = _SecurityExtEntry
+
+    entry = _SecurityExtEntry({
+        'type': _NTDS_OBJECT_SID_OID,
+        'value': sid_string.encode('ascii'),
+    })
+    der = _SecurityExt([entry]).dump()
+    return x509.UnrecognizedExtension(_SID_SECURITY_EXT_OID, der)
+
+
 _LEAF_CA_ONLY_EXTENSION_OIDS = frozenset({
     ExtensionOID.NAME_CONSTRAINTS,
     ExtensionOID.POLICY_CONSTRAINTS,
@@ -416,6 +457,7 @@ class CSROperationsMixin:
         ms_certificate_template_oid: Optional[str] = None,
         override_subject: Optional[x509.Name] = None,
         override_san: Optional[List[x509.GeneralName]] = None,
+        requester_sid: Optional[str] = None,
     ) -> bytes:
         """Sign a CSR with a CA. ``renewal_of``: existing certificate this
         signing renews — its names are graced by NameConstraints validation.
@@ -447,7 +489,13 @@ class CSROperationsMixin:
         DNS name or email address, so synthesis would build a nonsensical
         DNSName SAN entry — real ADCS instead puts the user's UPN in SAN as
         a Microsoft OtherName, which the caller (wstep_service) builds and
-        passes here directly."""
+        passes here directly.
+        ``requester_sid``: the authenticated requester's AD SID (
+        ``"S-1-5-21-..."`` string form), embedded as the SID security
+        extension (KB5014754 strong certificate mapping) — only WSTEP's
+        Kerberos binding passes this, independent of ``override_subject``
+        (applies to naked and normal CSRs alike, since it identifies who
+        authenticated, not what subject was requested)."""
         from utils.eku_validation import normalize_extra_ekus, to_object_identifiers, merge_eku_lists
 
         # Load CSR
@@ -799,6 +847,18 @@ class CSROperationsMixin:
         if ms_certificate_template_oid:
             builder = builder.add_extension(
                 _certificate_template_extension(ms_certificate_template_oid),
+                critical=False,
+            )
+
+        # Microsoft SID security extension (szOID_NTDS_CA_SECURITY_EXT,
+        # 1.3.6.1.4.1.311.25.2) for KB5014754 strong certificate mapping —
+        # only WSTEP's Kerberos binding passes this, with the requester's
+        # own AD SID once resolved via the AD Connector. Non-critical,
+        # matching real ADCS's own issuance (confirmed against a captured
+        # real cert — see _ad_security_extension's docstring).
+        if requester_sid:
+            builder = builder.add_extension(
+                _ad_security_extension(requester_sid),
                 critical=False,
             )
 

--- a/backend/services/wstep/wstep_service.py
+++ b/backend/services/wstep/wstep_service.py
@@ -487,6 +487,20 @@ def issue(ca, csr_der, validity_days, source='wstep', require_pop=True, kerberos
     UsernamePassword-bound calls (``kerberos_principal=None``) are never
     gated, since that path authenticates a single shared SystemConfig
     credential with no per-request principal to check membership for.
+
+    Strong certificate mapping (KB5014754): whenever ``kerberos_principal``
+    resolves to a sam_account_name AND the AD Connector is configured and
+    enabled, the requester's own AD SID is embedded as the SID security
+    extension (see ``services/trust_store/csr_operations_mixin.py``'s
+    ``_ad_security_extension``) -- matching real ADCS's own automatic
+    behavior, unlike every other AD Connector feature here, this is
+    unconditional rather than a per-template opt-in, and independent of
+    whether the CSR is naked. If the AD Connector isn't configured/enabled
+    at all, this simply doesn't apply (no error) -- but if it IS enabled
+    and the SID lookup for this specific request fails for any reason,
+    issuance is refused rather than silently issuing a weaker-mapped cert.
+    UsernamePassword-bound calls never get this either, same reason as
+    Enroll ACL: no per-request principal to resolve a SID for.
     """
     csr, err = _load_csr(csr_der)
     if err:
@@ -515,6 +529,34 @@ def issue(ca, csr_der, validity_days, source='wstep', require_pop=True, kerberos
             parsed = None
         if parsed:
             kerberos_sam_account_name = parsed[0]
+
+    # Strong certificate mapping (KB5014754): embed the authenticated
+    # requester's AD SID as the SID security extension, matching real
+    # ADCS's own automatic behavior since a 2021-era hotfix -- unlike
+    # every other WSTEP AD Connector feature here, this is unconditional,
+    # not a per-template opt-in, and independent of _is_naked_csr below:
+    # the SID identifies who authenticated, not what subject was
+    # requested, so it applies to naked AND manually-typed Kerberos-bound
+    # CSRs alike. "AD Connector not configured at all" and "configured but
+    # this lookup failed" are deliberately different outcomes -- the
+    # former means the feature doesn't apply (checked directly against
+    # ADConnectorConfig, since lookup.py's functions collapse both cases
+    # to the same None), the latter refuses issuance rather than silently
+    # issuing a weaker-mapped cert.
+    requester_sid = None
+    if kerberos_sam_account_name:
+        from models import ADConnectorConfig
+
+        ad_config = ADConnectorConfig.get_singleton()
+        if ad_config and ad_config.enabled:
+            requester_sid = lookup.lookup_object_sid(kerberos_sam_account_name)
+            if requester_sid is None:
+                logger.warning(
+                    "WSTEP: could not resolve requester SID for %r via AD "
+                    "Connector -- refusing issuance (strong certificate mapping)",
+                    kerberos_sam_account_name,
+                )
+                return None, 'Could not resolve requester identity for strong certificate mapping'
 
     if kerberos_sam_account_name and _is_naked_csr(csr):
         if lookup.is_machine_principal(kerberos_principal):
@@ -594,6 +636,7 @@ def issue(ca, csr_der, validity_days, source='wstep', require_pop=True, kerberos
             ms_certificate_template_oid=template_oid,
             override_subject=override_subject,
             override_san=override_san,
+            requester_sid=requester_sid,
             # Upstream's CSR-EKU cap (see _template_extra_ekus) never
             # honours Microsoft Smartcard Logon from a CSR's own EKU
             # extension, whatever cert_type is — extra_ekus is the only

--- a/backend/tests/test_ad_connector_lookup.py
+++ b/backend/tests/test_ad_connector_lookup.py
@@ -7,6 +7,9 @@ Tests for services/ad_connector/lookup.py:
   failure, not found, empty attribute) must return None, never raise --
   the WSTEP naked-CSR fallback depends on that to fail safely closed
   (falling back to the existing rejection, never issuing something wrong).
+- _sid_bytes_to_string / lookup_object_sid: same fail-closed shape, for
+  KB5014754 strong certificate mapping. The golden case uses a REAL SID
+  captured this session from the lab, not a synthetic example.
 """
 import pytest
 
@@ -105,8 +108,9 @@ class TestRealmMatchesConnector:
 
 
 class _FakeAttr:
-    def __init__(self, value):
+    def __init__(self, value, raw_values=None):
         self.value = value
+        self.raw_values = raw_values if raw_values is not None else ([value] if value else [])
 
 
 class _FakeEntry:
@@ -198,6 +202,106 @@ class TestLookupComputerDnsHostname:
         monkeypatch.setattr(lookup, '_connect', lambda config: _FakeConnection(entries=[entry]))
         with app.app_context():
             assert lookup.lookup_computer_dns_hostname('WIN11$') == 'win11.hagland.domain'
+
+
+class TestSidBytesToString:
+    """Pure-function coverage of _sid_bytes_to_string -- no DB/Flask app
+    needed. The golden case is a REAL SID captured this session via a live
+    LDAP query against the lab's WIN11$ machine account (raw_values), not
+    a synthetic example -- cross-validated against a real ADCS-issued
+    certificate's own SID security extension sharing the same domain-SID
+    prefix (see test_ad_security_extension.py)."""
+
+    _WIN11_RAW_SID = bytes([
+        0x01, 0x05, 0x00, 0x00, 0x00, 0x00, 0x00, 0x05,
+        0x15, 0x00, 0x00, 0x00,
+        0xd1, 0xba, 0xd9, 0x5f,
+        0x3d, 0xff, 0x98, 0x25,
+        0x71, 0x1a, 0xd2, 0x57,
+        0x51, 0x04, 0x00, 0x00,
+    ])
+
+    def test_real_captured_sid(self):
+        assert lookup._sid_bytes_to_string(self._WIN11_RAW_SID) == \
+            'S-1-5-21-1608104657-630783805-1473387121-1105'
+
+    def test_empty_bytes_returns_none(self):
+        assert lookup._sid_bytes_to_string(b'') is None
+
+    def test_none_returns_none(self):
+        assert lookup._sid_bytes_to_string(None) is None
+
+    def test_too_short_returns_none(self):
+        assert lookup._sid_bytes_to_string(b'short') is None
+
+    def test_length_mismatch_for_declared_sub_authority_count_returns_none(self):
+        """byte[1] claims 5 sub-authorities but only 4 are present --
+        malformed/truncated directory data must fail closed, not parse
+        partial garbage."""
+        truncated = self._WIN11_RAW_SID[:-4]
+        assert lookup._sid_bytes_to_string(truncated) is None
+
+
+class TestLookupObjectSid:
+    """Mirrors TestLookupComputerDnsHostname's exact fail-closed shape --
+    every failure mode returns None, never raises."""
+
+    def test_not_configured_returns_none(self, app):
+        with app.app_context():
+            ADConnectorConfig.query.delete()
+            db.session.commit()
+            assert lookup.lookup_object_sid('WIN11$') is None
+
+    def test_disabled_returns_none(self, app):
+        _configure(None, app, enabled=False)
+        with app.app_context():
+            assert lookup.lookup_object_sid('WIN11$') is None
+
+    def test_bind_failure_returns_none(self, app, monkeypatch):
+        _configure(None, app, enabled=True)
+        monkeypatch.setattr(lookup, '_connect', lambda config: (_ for _ in ()).throw(RuntimeError('bind failed')))
+        with app.app_context():
+            assert lookup.lookup_object_sid('WIN11$') is None
+
+    def test_not_found_returns_none(self, app, monkeypatch):
+        _configure(None, app, enabled=True)
+        monkeypatch.setattr(lookup, '_connect', lambda config: _FakeConnection(entries=[]))
+        with app.app_context():
+            assert lookup.lookup_object_sid('WIN11$') is None
+
+    def test_missing_attribute_returns_none(self, app, monkeypatch):
+        _configure(None, app, enabled=True)
+        entry = _FakeEntry({})
+        monkeypatch.setattr(lookup, '_connect', lambda config: _FakeConnection(entries=[entry]))
+        with app.app_context():
+            assert lookup.lookup_object_sid('WIN11$') is None
+
+    def test_empty_raw_values_returns_none(self, app, monkeypatch):
+        _configure(None, app, enabled=True)
+        entry = _FakeEntry({'objectSid': _FakeAttr('', raw_values=[])})
+        monkeypatch.setattr(lookup, '_connect', lambda config: _FakeConnection(entries=[entry]))
+        with app.app_context():
+            assert lookup.lookup_object_sid('WIN11$') is None
+
+    def test_search_exception_returns_none(self, app, monkeypatch):
+        _configure(None, app, enabled=True)
+        monkeypatch.setattr(
+            lookup, '_connect',
+            lambda config: _FakeConnection(search_raises=RuntimeError('search failed')),
+        )
+        with app.app_context():
+            assert lookup.lookup_object_sid('WIN11$') is None
+
+    def test_success_returns_sid_string(self, app, monkeypatch):
+        """Reads raw_values (the real binary SID), not .value -- ldap3
+        does not auto-format objectSid (confirmed empirically against the
+        lab), so .value would give mangled bytes-as-string garbage."""
+        _configure(None, app, enabled=True)
+        raw_sid = TestSidBytesToString._WIN11_RAW_SID
+        entry = _FakeEntry({'objectSid': _FakeAttr('garbage-if-used', raw_values=[raw_sid])})
+        monkeypatch.setattr(lookup, '_connect', lambda config: _FakeConnection(entries=[entry]))
+        with app.app_context():
+            assert lookup.lookup_object_sid('WIN11$') == 'S-1-5-21-1608104657-630783805-1473387121-1105'
 
 
 class _FakeSequentialConnection:

--- a/backend/tests/test_ad_connector_lookup.py
+++ b/backend/tests/test_ad_connector_lookup.py
@@ -277,8 +277,13 @@ class TestLookupObjectSid:
             assert lookup.lookup_object_sid('WIN11$') is None
 
     def test_empty_raw_values_returns_none(self, app, monkeypatch):
+        # _FakeEntry wraps every dict value in _FakeAttr itself (see its
+        # __init__) -- passing b'' here (not an already-built _FakeAttr)
+        # lets _FakeAttr's own default (raw_values=[value] if value else
+        # []) produce a genuinely empty raw_values list, matching what a
+        # real empty/missing objectSid attribute would look like.
         _configure(None, app, enabled=True)
-        entry = _FakeEntry({'objectSid': _FakeAttr('', raw_values=[])})
+        entry = _FakeEntry({'objectSid': b''})
         monkeypatch.setattr(lookup, '_connect', lambda config: _FakeConnection(entries=[entry]))
         with app.app_context():
             assert lookup.lookup_object_sid('WIN11$') is None
@@ -298,7 +303,10 @@ class TestLookupObjectSid:
         lab), so .value would give mangled bytes-as-string garbage."""
         _configure(None, app, enabled=True)
         raw_sid = TestSidBytesToString._WIN11_RAW_SID
-        entry = _FakeEntry({'objectSid': _FakeAttr('garbage-if-used', raw_values=[raw_sid])})
+        # Passing the raw bytes directly (not a pre-built _FakeAttr) --
+        # _FakeEntry wraps it in _FakeAttr(raw_sid) itself, whose default
+        # raw_values=[raw_sid] matches what ldap3's real raw_values gives.
+        entry = _FakeEntry({'objectSid': raw_sid})
         monkeypatch.setattr(lookup, '_connect', lambda config: _FakeConnection(entries=[entry]))
         with app.app_context():
             assert lookup.lookup_object_sid('WIN11$') == 'S-1-5-21-1608104657-630783805-1473387121-1105'

--- a/backend/tests/test_ad_security_extension.py
+++ b/backend/tests/test_ad_security_extension.py
@@ -1,0 +1,112 @@
+"""Tests for the SID security extension (szOID_NTDS_CA_SECURITY_EXT,
+1.3.6.1.4.1.311.25.2) used for KB5014754 strong certificate mapping -- see
+services/trust_store/csr_operations_mixin.py's _ad_security_extension and
+services/wstep/wstep_service.py's issue().
+
+The golden case is not spec-derived: it's the exact byte sequence captured
+this session from a real certificate issued by dc1.hagland.domain's own
+Enterprise CA (a genuine Windows Server AD CS install), for a real AD
+object's SID. Reproducing those bytes exactly is the strongest available
+verification -- this codebase's established practice (PKCS#7 PoP, the
+CertificateTemplateOID extension, the naked-CSR msPKI-Certificate-Name-Flag
+value) has repeatedly found that Microsoft-proprietary wire formats diverge
+from published spec text in ways only caught by testing against a real
+ADCS install.
+"""
+import pytest
+from cryptography import x509
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.x509.oid import NameOID
+from datetime import datetime, timedelta, timezone
+
+from services.trust_store.csr_operations_mixin import (
+    _SID_SECURITY_EXT_OID,
+    _ad_security_extension,
+)
+from services.trust_store.trust_store_service import TrustStoreService
+
+# Captured from dc1.hagland.domain's real Kerberos Authentication
+# certificate (issued by the lab's real "Hagland Domain Root CA" Enterprise
+# CA), via PowerShell: $c.Extensions | Where-Object Oid -eq
+# '1.3.6.1.4.1.311.25.2'. Confirmed non-critical.
+_REAL_CAPTURED_EXTENSION_HEX = (
+    '303fa03d060a2b060104018237190201a02f042d532d312d352d32312d31363038'
+    '3130343635372d3633303738333830352d313437333338373132312d31303030'
+)
+_REAL_CAPTURED_SID = 'S-1-5-21-1608104657-630783805-1473387121-1000'
+
+
+class TestAdSecurityExtension:
+    def test_matches_real_captured_bytes_exactly(self):
+        ext = _ad_security_extension(_REAL_CAPTURED_SID)
+        assert ext.value.hex() == _REAL_CAPTURED_EXTENSION_HEX
+
+    def test_oid(self):
+        ext = _ad_security_extension(_REAL_CAPTURED_SID)
+        assert ext.oid == _SID_SECURITY_EXT_OID
+        assert ext.oid.dotted_string == '1.3.6.1.4.1.311.25.2'
+
+    def test_different_sid_produces_different_bytes(self):
+        """Not just a hardcoded return value -- the SID string is actually
+        encoded into the structure."""
+        ext_a = _ad_security_extension('S-1-5-21-1-2-3-1000')
+        ext_b = _ad_security_extension('S-1-5-21-1-2-3-1001')
+        assert ext_a.value != ext_b.value
+
+
+def _test_ca():
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, 'SID Extension Test CA')])
+    now = datetime.now(timezone.utc)
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(name).issuer_name(name)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now - timedelta(days=1))
+        .not_valid_after(now + timedelta(days=3650))
+        .add_extension(x509.BasicConstraints(ca=True, path_length=None), critical=True)
+        .sign(key, hashes.SHA256())
+    )
+    return cert, key
+
+
+def _csr(common_name='device.hagland.domain'):
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    csr = x509.CertificateSigningRequestBuilder().subject_name(
+        x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, common_name)])
+    ).sign(key, hashes.SHA256())
+    return csr, key
+
+
+class TestSignCsrRequesterSid:
+    """TrustStoreService.sign_csr's requester_sid kwarg -- the plumbing
+    that carries a resolved SID into the issued certificate."""
+
+    def test_requester_sid_none_adds_no_extension(self, app):
+        ca_cert, ca_key = _test_ca()
+        csr, _key = _csr()
+        with app.app_context():
+            pem = TrustStoreService.sign_csr(
+                csr_pem=csr.public_bytes(serialization.Encoding.PEM),
+                ca_cert=ca_cert, ca_private_key=ca_key, validity_days=30,
+            )
+        cert = x509.load_pem_x509_certificate(pem, default_backend())
+        with pytest.raises(x509.ExtensionNotFound):
+            cert.extensions.get_extension_for_oid(_SID_SECURITY_EXT_OID)
+
+    def test_requester_sid_set_adds_extension(self, app):
+        ca_cert, ca_key = _test_ca()
+        csr, _key = _csr()
+        with app.app_context():
+            pem = TrustStoreService.sign_csr(
+                csr_pem=csr.public_bytes(serialization.Encoding.PEM),
+                ca_cert=ca_cert, ca_private_key=ca_key, validity_days=30,
+                requester_sid=_REAL_CAPTURED_SID,
+            )
+        cert = x509.load_pem_x509_certificate(pem, default_backend())
+        ext = cert.extensions.get_extension_for_oid(_SID_SECURITY_EXT_OID)
+        assert ext.critical is False
+        assert ext.value.value.hex() == _REAL_CAPTURED_EXTENSION_HEX

--- a/backend/tests/test_wstep_kerberos_issue.py
+++ b/backend/tests/test_wstep_kerberos_issue.py
@@ -156,6 +156,11 @@ def test_issue_succeeds_with_authenticated_negotiation(client, app, wstep_kerber
         negotiate_auth, 'authenticate_negotiate',
         lambda auth_header, connection_key: _authenticated_result('bXV0dWFsLXRva2Vu'),
     )
+    # Strong cert mapping (KB5014754) is unconditional whenever AD Connector
+    # is configured+enabled -- this test doesn't configure it itself, but
+    # module-scoped app/db state can leak an enabled connector in from an
+    # earlier test in this file, so mock defensively regardless.
+    monkeypatch.setattr(ad_lookup, 'lookup_object_sid', lambda sam_account_name: 'S-1-5-21-1-2-3-1000')
 
     csr, key = _make_csr()
     r = client.post(
@@ -234,6 +239,7 @@ class TestNakedCsrSubjectDerivation:
             ad_lookup, 'lookup_computer_dns_hostname',
             lambda sam_account_name: 'win11.hagland.domain',
         )
+        monkeypatch.setattr(ad_lookup, 'lookup_object_sid', lambda sam_account_name: 'S-1-5-21-1-2-3-1000')
 
         csr, key = _make_naked_csr()
         r = client.post(
@@ -335,6 +341,7 @@ class TestNakedCsrSubjectDerivation:
                 'upn': self._GOLDEN_USER_UPN,
             },
         )
+        monkeypatch.setattr(ad_lookup, 'lookup_object_sid', lambda sam_account_name: 'S-1-5-21-1-2-3-1000')
 
         csr, key = _make_naked_csr()
         r = client.post(
@@ -387,6 +394,7 @@ class TestNakedCsrSubjectDerivation:
                 'mail': self._GOLDEN_USER_UPN,
             },
         )
+        monkeypatch.setattr(ad_lookup, 'lookup_object_sid', lambda sam_account_name: 'S-1-5-21-1-2-3-1000')
 
         csr, key = _make_naked_csr()
         r = client.post(
@@ -547,6 +555,7 @@ class TestEnrollAcl:
             ad_lookup, 'is_member_of_group',
             lambda sam_account_name, group: (sam_account_name, group) == ('HOST$', 'VPN-Enroll'),
         )
+        monkeypatch.setattr(ad_lookup, 'lookup_object_sid', lambda sam_account_name: 'S-1-5-21-1-2-3-1000')
 
         try:
             csr, key = _make_csr()
@@ -625,6 +634,7 @@ class TestEnrollAcl:
             raise AssertionError('is_member_of_group must not be called when nothing is restricted')
 
         monkeypatch.setattr(ad_lookup, 'is_member_of_group', _fail_if_called)
+        monkeypatch.setattr(ad_lookup, 'lookup_object_sid', lambda sam_account_name: 'S-1-5-21-1-2-3-1000')
 
         try:
             csr, key = _make_csr()
@@ -694,6 +704,7 @@ class TestEnrollAcl:
             ad_lookup, 'is_member_of_group',
             lambda sam_account_name, group: (sam_account_name, group) == ('HOST$', 'VPN-Enroll'),
         )
+        monkeypatch.setattr(ad_lookup, 'lookup_object_sid', lambda sam_account_name: 'S-1-5-21-1-2-3-1000')
 
         try:
             csr, key = _make_naked_csr()

--- a/backend/tests/test_wstep_strong_cert_mapping.py
+++ b/backend/tests/test_wstep_strong_cert_mapping.py
@@ -1,0 +1,171 @@
+"""End-to-end tests for KB5014754 strong certificate mapping via
+wstep_service.issue() -- the SID security extension gets embedded whenever
+a Kerberos principal resolves and the AD Connector is configured/enabled,
+independent of whether the CSR is naked (see issue()'s docstring and
+services/ad_connector/lookup.py's lookup_object_sid).
+
+Direct wstep_service.issue() calls, no SOAP/HTTP layer -- same pattern as
+test_wstep_template_eku.py, since the enforcement lives entirely in
+issue() and its helpers.
+"""
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.hazmat.primitives.serialization import Encoding
+from cryptography.x509.oid import NameOID
+
+from models import CA, ADConnectorConfig, db
+from services.ad_connector import lookup as ad_lookup
+from services.trust_store.csr_operations_mixin import _SID_SECURITY_EXT_OID
+from services.wstep import wstep_service
+
+_REAL_SID = 'S-1-5-21-1608104657-630783805-1473387121-1105'
+KERBEROS_MACHINE_PRINCIPAL = 'WIN11$@HAGLAND.DOMAIN'
+
+
+def _make_csr(common_name=None):
+    """A naked (no CN, no SAN) CSR when common_name is None -- what real
+    Windows GPO machine autoenrollment submits -- else a normal CSR with
+    its own subject, e.g. a manually-typed certmgr.msc/certreq request."""
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    attrs = [x509.NameAttribute(NameOID.COMMON_NAME, common_name)] if common_name else []
+    csr = x509.CertificateSigningRequestBuilder().subject_name(
+        x509.Name(attrs)
+    ).sign(key, hashes.SHA256())
+    return csr, key
+
+
+def _configure_ad_connector(app, enabled=True):
+    with app.app_context():
+        ADConnectorConfig.query.delete()
+        config = ADConnectorConfig(
+            server='dc1.hagland.domain', base_dn='DC=hagland,DC=domain',
+            bind_dn='svc-ucm', enabled=enabled,
+        )
+        config.bind_password = 'irrelevant'
+        db.session.add(config)
+        db.session.commit()
+
+
+def _clear_ad_connector(app):
+    with app.app_context():
+        ADConnectorConfig.query.delete()
+        db.session.commit()
+
+
+def _sid_extension_value(cert):
+    try:
+        return cert.extensions.get_extension_for_oid(_SID_SECURITY_EXT_OID)
+    except x509.ExtensionNotFound:
+        return None
+
+
+class TestStrongCertMapping:
+    def test_naked_csr_kerberos_bound_gets_sid_extension(self, app, create_ca, monkeypatch):
+        """GPO machine autoenrollment: naked CSR, AD-derived CN, AND the
+        SID extension, both present on the same issued cert."""
+        ca_data = create_ca(cn='Strong Mapping Naked CA')
+        _configure_ad_connector(app)
+        monkeypatch.setattr(ad_lookup, 'lookup_computer_dns_hostname', lambda sam: 'win11.hagland.domain')
+        monkeypatch.setattr(ad_lookup, 'lookup_object_sid', lambda sam: _REAL_SID)
+
+        csr, _key = _make_csr()
+        with app.app_context():
+            ca = db.session.get(CA, ca_data['id'])
+            cert_pem, err = wstep_service.issue(
+                ca, csr.public_bytes(Encoding.DER), validity_days=30,
+                kerberos_principal=KERBEROS_MACHINE_PRINCIPAL,
+            )
+        assert err is None, err
+        cert = x509.load_pem_x509_certificate(cert_pem.encode())
+        assert cert.subject.get_attributes_for_oid(NameOID.COMMON_NAME)[0].value == 'win11.hagland.domain'
+        ext = _sid_extension_value(cert)
+        assert ext is not None
+        assert ext.critical is False
+
+    def test_non_naked_csr_kerberos_bound_also_gets_sid_extension(self, app, create_ca, monkeypatch):
+        """Manual enrollment (certmgr.msc/certreq, a CSR with its own
+        subject) also gets the SID extension -- proves this is independent
+        of _is_naked_csr, unlike the AD-derived-subject mechanism."""
+        ca_data = create_ca(cn='Strong Mapping Manual CA')
+        _configure_ad_connector(app)
+        monkeypatch.setattr(ad_lookup, 'lookup_object_sid', lambda sam: _REAL_SID)
+
+        csr, _key = _make_csr(common_name='win11-manual.hagland.domain')
+        with app.app_context():
+            ca = db.session.get(CA, ca_data['id'])
+            cert_pem, err = wstep_service.issue(
+                ca, csr.public_bytes(Encoding.DER), validity_days=30,
+                kerberos_principal=KERBEROS_MACHINE_PRINCIPAL,
+            )
+        assert err is None, err
+        cert = x509.load_pem_x509_certificate(cert_pem.encode())
+        assert cert.subject.get_attributes_for_oid(NameOID.COMMON_NAME)[0].value == 'win11-manual.hagland.domain'
+        assert _sid_extension_value(cert) is not None
+
+    def test_ad_connector_not_configured_issues_normally_without_extension(self, app, create_ca, monkeypatch):
+        """The feature doesn't apply at all when AD Connector isn't
+        configured/enabled -- regression guard for every existing
+        Kerberos-bound WSTEP install that has never set up AD Connector.
+        A spy proves lookup_object_sid is never even called, not just
+        that it happens to return something falsy."""
+        ca_data = create_ca(cn='Strong Mapping Unconfigured CA')
+        _clear_ad_connector(app)
+
+        def _fail_if_called(sam):
+            raise AssertionError('lookup_object_sid must not be called when AD Connector is unconfigured')
+
+        monkeypatch.setattr(ad_lookup, 'lookup_object_sid', _fail_if_called)
+
+        csr, _key = _make_csr(common_name='win11-manual.hagland.domain')
+        with app.app_context():
+            ca = db.session.get(CA, ca_data['id'])
+            cert_pem, err = wstep_service.issue(
+                ca, csr.public_bytes(Encoding.DER), validity_days=30,
+                kerberos_principal=KERBEROS_MACHINE_PRINCIPAL,
+            )
+        assert err is None, err
+        cert = x509.load_pem_x509_certificate(cert_pem.encode())
+        assert _sid_extension_value(cert) is None
+
+    def test_ad_connector_configured_but_lookup_fails_refuses_issuance(self, app, create_ca, monkeypatch):
+        """The real 'fail closed' case: AD Connector is enabled, but this
+        specific request's SID can't be resolved (account not found, LDAP
+        error, ...) -- issuance must be refused, not silently downgraded
+        to a weaker-mapped cert."""
+        ca_data = create_ca(cn='Strong Mapping Lookup Fail CA')
+        _configure_ad_connector(app)
+        monkeypatch.setattr(ad_lookup, 'lookup_object_sid', lambda sam: None)
+
+        csr, _key = _make_csr(common_name='win11-manual.hagland.domain')
+        with app.app_context():
+            ca = db.session.get(CA, ca_data['id'])
+            cert_pem, err = wstep_service.issue(
+                ca, csr.public_bytes(Encoding.DER), validity_days=30,
+                kerberos_principal=KERBEROS_MACHINE_PRINCIPAL,
+            )
+        assert cert_pem is None
+        assert err is not None
+
+    def test_username_password_bound_never_gets_sid_extension(self, app, create_ca, monkeypatch):
+        """No per-request AD identity exists on the UsernamePassword-bound
+        path (kerberos_principal=None) -- same limitation Enroll ACL
+        already documents. A spy proves lookup_object_sid is never called,
+        even with AD Connector configured and enabled."""
+        ca_data = create_ca(cn='Strong Mapping UP CA')
+        _configure_ad_connector(app)
+
+        def _fail_if_called(sam):
+            raise AssertionError('lookup_object_sid must not be called for UsernamePassword-bound issuance')
+
+        monkeypatch.setattr(ad_lookup, 'lookup_object_sid', _fail_if_called)
+
+        csr, _key = _make_csr(common_name='device.hagland.domain')
+        with app.app_context():
+            ca = db.session.get(CA, ca_data['id'])
+            cert_pem, err = wstep_service.issue(
+                ca, csr.public_bytes(Encoding.DER), validity_days=30, kerberos_principal=None,
+            )
+        assert err is None, err
+        cert = x509.load_pem_x509_certificate(cert_pem.encode())
+        assert _sid_extension_value(cert) is None


### PR DESCRIPTION
## Summary

WSTEP-issued certificates now carry the SID security extension (`szOID_NTDS_CA_SECURITY_EXT`, `1.3.6.1.4.1.311.25.2`) whenever the requester authenticated via Kerberos and the AD Connector can resolve their SID — this is what Windows Server's KB5014754 "strong certificate mapping" (mandatory Full Enforcement since Feb 2025) checks for. Answers a feasibility question from `stefanelul2000` on #229.

Unlike the pinned-subject-fields PR (#274), **this one is real ADCS parity, not a new capability** — Enterprise CAs have auto-embedded this exact extension since a 2021-era hotfix, specifically so admins don't have to hand-populate `altSecurityIdentities`.

## Design

- **Unconditional, not a per-template opt-in** — matches real ADCS's own automatic behavior. Every other AD Connector feature in this codebase (`ad_derived_subject`, `allowed_ad_group`, `pinned_subject_fields`) is an explicit per-template toggle; this one isn't, because it's not a UCM-specific policy decision, it's how strong mapping works.
- **Independent of whether the CSR is naked** — the existing AD-derivation code only fires for naked CSRs (GPO autoenrollment), but the SID identifies who authenticated, not what subject was requested, so this applies to manually-typed Kerberos-bound CSRs too (certmgr.msc, certreq).
- **AD Connector not configured/enabled → feature doesn't apply**, issuance proceeds exactly as today. **AD Connector configured but this request's SID lookup fails → issuance is refused.** Worth being explicit about the practical effect: on any install that already uses naked-CSR autoenrollment, this just adds one more lookup to a connection that already has to work. For Kerberos-bound *manual* enrollment specifically, this is a new dependency — today that path never touches AD Connector at all, since only naked CSRs do. `objectSid` is an unprivileged, always-present attribute (not something admins typically restrict), so I don't expect this to bite in practice, but it's a real behavior change worth flagging rather than discovering later.
- UsernamePassword-bound issuance is unaffected — no per-request AD identity exists there, same limitation Enroll ACL already has.

## Ground truth, not spec text

The extension's byte structure was captured from a real certificate issued by a real ADCS Enterprise CA in the lab (not derived from documentation). One non-obvious finding: the SID is embedded as its **string form** (`"S-1-5-21-..."`), not raw binary, despite what the OID name might suggest. Also confirmed empirically that `ldap3` doesn't auto-format AD's `objectSid` — the real binary SID has to be read from `raw_values`, not `.value`.

## Testing

- Unit tests for the SID binary→string conversion and the extension builder, both using the real captured bytes as golden fixtures (byte-for-byte match, not just "doesn't crash").
- End-to-end `issue()` tests covering all the branches above (naked/non-naked Kerberos-bound, AD Connector unconfigured, lookup failure, UsernamePassword-bound).
- Full backend suite: 3508 passed, 6 skipped, 0 failed. (A few existing Kerberos-bound WSTEP tests needed a mock added for the new unconditional lookup — expected, not a sign of anything wrong.)
- Real lab verification: retriggered actual GPO autoenrollment on a domain-joined Windows 11 client, decoded the issued certificate's SID extension, and confirmed it's byte-for-byte the client's real AD SID.