### PR TITLE
fix(search): wire certificate search boxes to backend across paginated pages

### DIFF
--- a/backend/api/v2/discovery.py
+++ b/backend/api/v2/discovery.py
@@ -301,10 +301,12 @@ def list_discovered():
     offset = _safe_int(request.args.get('offset', 0), 0, lo=0)
     profile_id = request.args.get('profile_id', type=int)
     status_list = request.args.getlist('status')
+    search = request.args.get('search', '').strip()
     svc = _get_service()
     items, total = svc.get_all(limit=limit, offset=offset,
                                profile_id=profile_id,
-                               status=status_list if status_list else None)
+                               status=status_list if status_list else None,
+                               search=search or None)
     return success_response(data={'items': items, 'total': total})
 
 

--- a/backend/services/discovery/query.py
+++ b/backend/services/discovery/query.py
@@ -40,7 +40,7 @@ class QueryMixin:
         return {'total': len(certs), 'updated': updated}
 
     def get_all(self, limit: int = 200, offset: int = 0,
-                profile_id: int = None, status=None) -> Tuple[List[Dict], int]:
+                profile_id: int = None, status=None, search: str = None) -> Tuple[List[Dict], int]:
         """Return discovered certificates with pagination. Returns (items, total).
         status can be str or list[str] for multi-select.
         """
@@ -52,6 +52,15 @@ class QueryMixin:
                 query = query.filter(DiscoveredCertificate.status.in_(status))
             else:
                 query = query.filter_by(status=status)
+        if search:
+            safe_search = search.replace('\\', '\\\\').replace('%', '\\%').replace('_', '\\_')
+            pattern = f'%{safe_search}%'
+            query = query.filter(db.or_(
+                DiscoveredCertificate.subject.ilike(pattern, escape='\\'),
+                DiscoveredCertificate.issuer.ilike(pattern, escape='\\'),
+                DiscoveredCertificate.target.ilike(pattern, escape='\\'),
+                DiscoveredCertificate.serial_number.ilike(pattern, escape='\\'),
+            ))
         total = query.count()
         rows = query.order_by(DiscoveredCertificate.last_seen.desc()
                               ).offset(offset).limit(limit).all()

--- a/frontend/src/pages/DiscoveryPage.jsx
+++ b/frontend/src/pages/DiscoveryPage.jsx
@@ -70,9 +70,16 @@ export default function DiscoveryPage() {
   const [page, setPage] = useState(1)
   const [perPage, setPerPage] = useState(25)
 
-  // Filters
+  // Search & Filters
+  const [discoveredSearch, setDiscoveredSearch] = useState('')
   const [statusFilter, setStatusFilter] = useState([])   // [] = all, ['managed', 'unmanaged', 'error']
   const [profileFilter, setProfileFilter] = useState(null)  // null = all, profile id
+
+  // Reset to first page and update search term (discovered tab)
+  const handleDiscoveredSearchChange = useCallback((val) => {
+    setPage(1)
+    setDiscoveredSearch(val)
+  }, [])
 
   // ── Data loaders ──────────────────────────────────────
   const loadStats = useCallback(async () => {
@@ -91,7 +98,7 @@ export default function DiscoveryPage() {
 
   const loadDiscovered = useCallback(async () => {
     try {
-      const params = { limit: perPage, offset: (page - 1) * perPage }
+      const params = { limit: perPage, offset: (page - 1) * perPage, search: discoveredSearch || undefined }
       if (statusFilter.length > 0) params.status = statusFilter
       if (profileFilter) params.profile_id = profileFilter
       const res = await discoveryService.getAll(params)
@@ -104,7 +111,7 @@ export default function DiscoveryPage() {
         setDiscoveredTotal(data.total ?? data.items?.length ?? 0)
       }
     } catch { /* silent */ }
-  }, [page, perPage, JSON.stringify(statusFilter), profileFilter])
+  }, [page, perPage, discoveredSearch, JSON.stringify(statusFilter), profileFilter])
 
   const loadRuns = useCallback(async () => {
     try {
@@ -621,7 +628,8 @@ export default function DiscoveryPage() {
             onRowClick={(item) => item ? setSelectedItem(item) : setSelectedItem(null)}
             searchable
             searchPlaceholder={t('discovery.searchDiscovered')}
-            searchKeys={['subject', 'target', 'issuer', 'serial_number']}
+            externalSearch={discoveredSearch}
+            onSearchChange={handleDiscoveredSearchChange}
             columnStorageKey="ucm-discovery-columns"
             densityStorageKey="ucm-discovery-density"
             sortable


### PR DESCRIPTION
## Summary

Fixes #280. Certificates, SSH Certificates, User Certificates, and the Discovery "Discovered" tab all paginate results server-side, but each page's search box was filtering only the currently-loaded page's rows client-side. A match sitting on a different page was invisible until you navigated to that page.

- Wires each page's search input to the backend's `search` query param and resets to page 1 when the term changes, matching the pattern already used by the Audit Logs and Backup pages.
- The Certificates, SSH Certificates, and User Certificates backend endpoints already supported server-side `search` — the fix there is frontend-only.
- The Discovery `list_discovered` endpoint had no `search` param at all, so this adds one (ilike across subject/issuer/target/serial_number, applied before pagination), consistent with the existing pattern in `cert_list.py`.

Other list pages in the app (CAs, CSRs, Templates, SSH CAs, ACME, SCEP, CRL/OCSP, TrustStore, Operations, Policies, Approvals, Users/Groups, RBAC, HSM) were audited for the same pattern and don't have this bug — they fetch their full dataset unpaginated and filter client-side, so search already covers all records there.

## Test plan
- [x] Deployed to test server (ucm2) and manually verified: Certificates page — searched for a certificate that only existed on page 3 while sitting on page 1, confirmed it was found and pagination reset correctly
- [x] Verified SSH Certificates and User Certificates search requests now include `search=` and return 200
- [x] Verified Discovery's `GET /api/v2/discovery?search=...` returns 200 with the new backend param
- [x] No console errors on any of the four pages