### PR TITLE
fix(ui): password reveal toggle on empty fields, toast message wrapping

### DIFF
--- a/frontend/src/components/Input.jsx
+++ b/frontend/src/components/Input.jsx
@@ -123,8 +123,13 @@ export const Input = forwardRef(function Input({
           {...props}
         />
         
-        {/* Password toggle */}
-        {isPassword && (
+        {/* Password toggle -- hidden when there's nothing typed to reveal.
+            An "already set" field shows a literal '••••••••' placeholder
+            (never a real loaded secret, which is never sent to the browser),
+            and placeholders are never masked/unmasked by type or CSS in any
+            browser -- showing the toggle there just invites a user to click
+            "reveal" on text that was never masked in the first place. */}
+        {isPassword && (props.value || internalValue) && (
           <button
             type="button"
             onClick={() => setShowPassword(!showPassword)}

--- a/frontend/src/contexts/NotificationContext.jsx
+++ b/frontend/src/contexts/NotificationContext.jsx
@@ -124,7 +124,7 @@ export function NotificationProvider({ children }) {
               <div className="flex-shrink-0 mt-0.5">
                 {getIcon(toast.type)}
               </div>
-              <Toast.Description className="flex-1 text-sm text-text-primary">
+              <Toast.Description className="flex-1 min-w-0 text-sm text-text-primary break-words">
                 {toast.message}
               </Toast.Description>
               <Toast.Close className="flex-shrink-0">


### PR DESCRIPTION
## Summary

Split out from #281 per NeySlim's review note — these two UI fixes are unrelated to the Intune SCEP work and merge cleanly on their own.

- Hide the password reveal (eye) toggle when a field is empty. Fields showing an already-saved secret display a literal `••••••••` placeholder (real secrets are never sent to the browser), and a placeholder can never be masked/unmasked by any browser regardless of `type`. Reproduced across the app, including the pre-existing XCEP/WSTEP Kerberos password fields, so this predates and is independent of the SCEP work.
- Wrap long toast messages (`Toast.Description`) instead of letting them overflow the fixed-width toast bubble — surfaced by a long Microsoft error URL during Intune testing, but the fix itself is generic to `NotificationContext.jsx`.

## Test plan
- [x] Verified live on ucm2: empty secret fields no longer show a reveal toggle, populated fields still do
- [x] Verified a long toast message wraps instead of overflowing