### PR TITLE
fix(packaging): preserve optional Kerberos extras across venv rebuild

### DIFF
--- a/packaging/debian/postinst
+++ b/packaging/debian/postinst
@@ -204,6 +204,21 @@ ENVEOF
         # Always recreate venv to ensure correct dependencies
         # This handles both fresh install and upgrades
         echo "Creating/updating Python virtual environment..."
+
+        # requests-kerberos and pyspnego[kerberos] are optional (excluded from
+        # requirements.txt, see there for why) and admin-installed manually.
+        # The rm -rf below would silently drop them on every upgrade even
+        # though the admin already opted in, breaking MS CA Kerberos auth /
+        # Autoenrollment's SPNEGO binding a few days after every update.
+        # Remember what was there and reinstall it after, rather than making
+        # either package part of the default install for everyone.
+        HAD_REQUESTS_KERBEROS=""
+        HAD_PYSPNEGO_KERBEROS=""
+        if [ -x "$UCM_HOME/venv/bin/pip" ]; then
+            "$UCM_HOME/venv/bin/pip" show requests-kerberos >/dev/null 2>&1 && HAD_REQUESTS_KERBEROS=1 || true
+            "$UCM_HOME/venv/bin/pip" show gssapi >/dev/null 2>&1 && HAD_PYSPNEGO_KERBEROS=1 || true
+        fi
+
         rm -rf "$UCM_HOME/venv" 2>/dev/null || true
         python3 -m venv "$UCM_HOME/venv"
         "$UCM_HOME/venv/bin/pip" install --quiet --upgrade pip
@@ -213,7 +228,18 @@ ENVEOF
         # only used by pyjks for the BKS UBER format which UCM does not export).
         # See backend/requirements.txt for full rationale.
         "$UCM_HOME/venv/bin/pip" install --quiet --no-deps pyjks==20.0.0
-        
+
+        if [ -n "$HAD_REQUESTS_KERBEROS" ]; then
+            echo "Reinstalling requests-kerberos (was present before upgrade)..."
+            "$UCM_HOME/venv/bin/pip" install --quiet requests-kerberos || \
+                echo "WARNING: requests-kerberos reinstall failed, Kerberos auth to the upstream CA is unavailable until 'pip install requests-kerberos' is run manually in $UCM_HOME/venv"
+        fi
+        if [ -n "$HAD_PYSPNEGO_KERBEROS" ]; then
+            echo "Reinstalling pyspnego[kerberos] (was present before upgrade)..."
+            "$UCM_HOME/venv/bin/pip" install --quiet 'pyspnego[kerberos]' || \
+                echo "WARNING: pyspnego[kerberos] reinstall failed (needs libkrb5-dev/gcc), Autoenrollment's Kerberos/SPNEGO binding is unavailable until 'pip install pyspnego[kerberos]' is run manually in $UCM_HOME/venv"
+        fi
+
         # Set permissions
         chown -R "$UCM_USER":"$UCM_GROUP" "$UCM_HOME"
         chown -R "$UCM_USER":"$UCM_GROUP" "$UCM_DATA"

--- a/packaging/rpm/ucm.spec
+++ b/packaging/rpm/ucm.spec
@@ -178,6 +178,21 @@ fi
 
 # Create venv and install dependencies
 echo "Creating Python virtual environment..."
+
+# requests-kerberos and pyspnego[kerberos] are optional (excluded from
+# requirements.txt, see there for why) and admin-installed manually. The
+# rm -rf below would silently drop them on every upgrade even though the
+# admin already opted in, breaking MS CA Kerberos auth / Autoenrollment's
+# SPNEGO binding a few days after every update. Remember what was there and
+# reinstall it after, rather than making either package part of the default
+# install for everyone.
+HAD_REQUESTS_KERBEROS=""
+HAD_PYSPNEGO_KERBEROS=""
+if [ -x "$UCM_HOME/venv/bin/pip" ]; then
+    "$UCM_HOME/venv/bin/pip" show requests-kerberos >/dev/null 2>&1 && HAD_REQUESTS_KERBEROS=1 || true
+    "$UCM_HOME/venv/bin/pip" show gssapi >/dev/null 2>&1 && HAD_PYSPNEGO_KERBEROS=1 || true
+fi
+
 rm -rf "$UCM_HOME/venv" 2>/dev/null || true
 python3 -m venv "$UCM_HOME/venv"
 "$UCM_HOME/venv/bin/pip" install --quiet --upgrade pip
@@ -187,6 +202,17 @@ python3 -m venv "$UCM_HOME/venv"
 # only used by pyjks for the BKS UBER format which UCM does not export).
 # See backend/requirements.txt for full rationale.
 "$UCM_HOME/venv/bin/pip" install --quiet --no-deps pyjks==20.0.0
+
+if [ -n "$HAD_REQUESTS_KERBEROS" ]; then
+    echo "Reinstalling requests-kerberos (was present before upgrade)..."
+    "$UCM_HOME/venv/bin/pip" install --quiet requests-kerberos || \
+        echo "WARNING: requests-kerberos reinstall failed, Kerberos auth to the upstream CA is unavailable until 'pip install requests-kerberos' is run manually in $UCM_HOME/venv"
+fi
+if [ -n "$HAD_PYSPNEGO_KERBEROS" ]; then
+    echo "Reinstalling pyspnego[kerberos] (was present before upgrade)..."
+    "$UCM_HOME/venv/bin/pip" install --quiet 'pyspnego[kerberos]' || \
+        echo "WARNING: pyspnego[kerberos] reinstall failed (needs libkrb5-dev/gcc), Autoenrollment's Kerberos/SPNEGO binding is unavailable until 'pip install pyspnego[kerberos]' is run manually in $UCM_HOME/venv"
+fi
 
 # Set permissions
 chown -R %{name}:%{name} $UCM_HOME


### PR DESCRIPTION
## Summary
- postinst (.deb) and %post (.rpm) always `rm -rf` and recreate the venv on every install/upgrade, which silently dropped a manually installed `requests-kerberos` or `pyspnego[kerberos]` the instant the next update ran, even though I'd already opted in
- Both scripts now snapshot whether either package was present in the old venv before the rebuild, and reinstall it afterward, only if it was already there
- Neither package becomes part of the default install for everyone else; installs that never used Kerberos see no change, and a reinstall failure (e.g. build headers missing) prints a warning instead of aborting the whole package install

## Testing
- Extracted the exact new logic into a standalone script and ran it against a scratch venv on a real Debian 13 box with the actual requirements.txt: a fresh venv without the extras stays extras-free, and a venv with the extras pre-seeded keeps both packages across the rebuild
- Hit this myself on my own production instance (SPNEGO warning back on the Autoenrollment page right after an update); confirmed reinstalling `pyspnego[kerberos]` and restarting the service cleared it