### PR TITLE
fix: unlink cert/key/csr files on delete instead of leaving them orphaned

### DIFF
--- a/backend/api/v2/cas/crud.py
+++ b/backend/api/v2/cas/crud.py
@@ -693,8 +693,6 @@ def delete_ca(ca_id):
             409
         )
 
-    ca_snapshot = ca.to_dict()
-
     try:
         # Delete dependent records before deleting CA
         from models.crl import CRLMetadata
@@ -706,24 +704,11 @@ def delete_ca(ca_id):
         if crl_count or ocsp_count:
             logger.info(f"Deleted {crl_count} CRL(s) and {ocsp_count} OCSP response(s) for CA {ca_name}")
 
-        db.session.delete(ca)
-        ok, err = safe_commit(logger, "Failed to delete CA")
-        if not ok:
-            return err
-
-        # Audit log
-        AuditService.log_action(
-            action='ca_deleted',
-            resource_type='ca',
-            resource_id=ca_id,
-            resource_name=ca_name,
-            details=f'Deleted CA: {ca_name} (cleaned {crl_count} CRLs, {ocsp_count} OCSP responses)',
-            success=True
-        )
-
         username = g.current_user.username if hasattr(g, 'current_user') else 'system'
-        from services.webhook_service import emit_ca_deleted
-        emit_ca_deleted(ca_snapshot, actor=username)
+        # Delegate to the service so the CA cert/key files on disk are
+        # unlinked along with the DB row instead of leaving them orphaned
+        # (audit log and webhook are emitted by the service itself).
+        CAService.delete_ca(ca_id=ca_id, username=username)
 
         return no_content_response()
     except Exception as e:

--- a/backend/api/v2/certificates/bulk.py
+++ b/backend/api/v2/certificates/bulk.py
@@ -204,24 +204,21 @@ def bulk_delete_certificates():
         return error_response('ids array required', 400)
 
     ids = data['ids']
+    username = g.current_user.username if hasattr(g, 'current_user') else 'system'
     results = {'success': [], 'failed': []}
 
     for cert_id in ids:
         try:
-            cert = db.session.get(Certificate, cert_id)
-            if not cert:
+            if not db.session.get(Certificate, cert_id):
                 results['failed'].append({'id': cert_id, 'error': 'Not found'})
                 continue
 
-            from models import ApprovalRequest
-            ApprovalRequest.query.filter_by(certificate_id=cert_id).delete()
-
-            db.session.delete(cert)
-            ok, err = safe_commit(logger, f"Bulk delete failed for cert {cert_id}")
-            if not ok:
+            # Delegate to the service so cert/key/csr files on disk are
+            # unlinked along with the DB row instead of leaving them orphaned.
+            if CertificateService.delete_certificate(cert_id=cert_id, username=username):
+                results['success'].append(cert_id)
+            else:
                 results['failed'].append({'id': cert_id, 'error': 'Deletion failed'})
-                continue
-            results['success'].append(cert_id)
         except Exception as e:
             db.session.rollback()
             logger.error(f"Bulk delete failed for cert {cert_id}: {e}")

--- a/backend/api/v2/certificates/cert_lifecycle.py
+++ b/backend/api/v2/certificates/cert_lifecycle.py
@@ -26,30 +26,13 @@ def delete_certificate(cert_id):
         return error_response('Certificate not found', 404)
 
     cert_name = cert.descr or f'Certificate #{cert_id}'
-    cert_snapshot = cert.to_dict()
-    cert_caref = cert.caref
 
     try:
-        # Clean up dependent records
-        from models import ApprovalRequest
-        ApprovalRequest.query.filter_by(certificate_id=cert_id).delete()
-
-        db.session.delete(cert)
-        db.session.commit()
-
-        # Audit log
-        AuditService.log_action(
-            action='certificate_deleted',
-            resource_type='certificate',
-            resource_id=cert_id,
-            resource_name=cert_name,
-            details=f'Deleted certificate: {cert_name}',
-            success=True
-        )
-
         username = g.current_user.username if hasattr(g, 'current_user') else 'system'
-        from services.webhook_service import emit_cert_deleted
-        emit_cert_deleted(cert_snapshot, ca_refid=cert_caref, actor=username)
+        # Delegate to the service so cert/key/csr files on disk are unlinked
+        # along with the DB row instead of leaving them orphaned (audit log
+        # and webhook are emitted by the service itself).
+        CertificateService.delete_certificate(cert_id=cert_id, username=username)
 
         return no_content_response()
     except Exception as e:

--- a/backend/services/ca/ca_crud.py
+++ b/backend/services/ca/ca_crud.py
@@ -77,6 +77,6 @@ class CAcrudMixin:
             raise
 
         from services.webhook_service import emit_ca_deleted
-        emit_ca_deleted(_ca_snapshot)
+        emit_ca_deleted(_ca_snapshot, actor=username)
 
         return True


### PR DESCRIPTION
## Summary
- Found that deleting a certificate (single or bulk) or a CA only removed the DB row — the cert/key/csr (or CA cert/key) files stayed on disk indefinitely. Confirmed this on a real system: a cert was created then deleted 47 seconds later, and its files were still there.
- `LifecycleMixin.delete_certificate` and `CAcrudMixin.delete_ca` already existed and correctly unlink files before deleting the row, but the actual API routes (`DELETE /api/v2/certificates/<id>`, `POST /api/v2/certificates/bulk/delete`, `DELETE /api/v2/cas/<id>`) bypassed them and deleted the row directly.
- Routed all three to the existing service methods instead. Also fixed `CAcrudMixin.delete_ca`'s webhook call to forward `actor=username` (it was dropping the acting user, unlike the equivalent cert path).

## Test plan
- [x] Deployed to a test box and exercised all three delete paths against a running instance (create cert -> single delete -> confirm cert/key files gone; create 2 certs -> bulk delete -> confirm gone; create CA -> delete -> confirm CA cert/key files gone)
- [x] Confirmed audit log entries (`cert_deleted`, `certificates_bulk_deleted`, `ca_deleted`) are still recorded correctly with the right actor
- [x] `python -m py_compile` on all changed files