### PR TITLE
fix(acme): Allow bare TLD registration in 'Local Domains' & Bugfix for DATA_DIR

### DIFF
--- a/backend/api/v2/acme_local_domains.py
+++ b/backend/api/v2/acme_local_domains.py
@@ -1,7 +1,6 @@
 """
 ACME Local Domains API Routes
 Manages domain-to-CA mappings for the Local ACME server.
-
 """
 import re
 import logging

--- a/backend/api/v2/acme_local_domains.py
+++ b/backend/api/v2/acme_local_domains.py
@@ -1,6 +1,9 @@
 """
 ACME Local Domains API Routes
 Manages domain-to-CA mappings for the Local ACME server.
+
+Patched: allow bare TLD registration (e.g. "local", "internal") so that
+parent-walking in find_local_domain_ca covers all subdomains of that TLD.
 """
 import re
 import logging
@@ -39,40 +42,40 @@ def create_local_domain():
     data = request.json
     if not data:
         return error_response('Request body required', 400)
-    
+
     domain_name = data.get('domain', '').strip().lower()
     if not domain_name:
         return error_response('Domain is required', 400)
-    
+
     if not _is_valid_domain(domain_name):
         return error_response('Invalid domain format', 400)
-    
+
     issuing_ca_id = data.get('issuing_ca_id')
     if not issuing_ca_id:
         return error_response('Issuing CA is required', 400)
-    
+
     ca = db.session.get(CA, issuing_ca_id)
     if not ca:
         return error_response('Issuing CA not found', 404)
     if not ca.has_private_key:
         return error_response('Selected CA has no private key', 400)
-    
+
     existing = AcmeLocalDomain.query.filter_by(domain=domain_name).first()
     if existing:
         return error_response(f'Domain {domain_name} is already registered', 409)
-    
+
     domain = AcmeLocalDomain(
         domain=domain_name,
         issuing_ca_id=issuing_ca_id,
         auto_approve=data.get('auto_approve', False),
         created_by=g.user.username if hasattr(g, 'user') and g.user else None
     )
-    
+
     db.session.add(domain)
     ok, _err = safe_commit(logger, "Failed to create local ACME domain")
     if not ok:
         return _err
-    
+
     AuditService.log_action(
         action='acme_local_domain_create',
         resource_type='acme_local_domain',
@@ -81,7 +84,7 @@ def create_local_domain():
         details=f'Registered local ACME domain: {domain_name} -> CA {ca.common_name}',
         success=True
     )
-    
+
     return success_response(
         data=domain.to_dict(),
         message=f'Domain {domain_name} registered successfully',
@@ -95,10 +98,10 @@ def update_local_domain(domain_id):
     """Update a local domain mapping"""
     domain = db.get_or_404(AcmeLocalDomain, domain_id)
     data = request.json
-    
+
     if not data:
         return error_response('Request body required', 400)
-    
+
     if 'issuing_ca_id' in data:
         ca = db.session.get(CA, data['issuing_ca_id'])
         if not ca:
@@ -106,14 +109,14 @@ def update_local_domain(domain_id):
         if not ca.has_private_key:
             return error_response('Selected CA has no private key', 400)
         domain.issuing_ca_id = data['issuing_ca_id']
-    
+
     if 'auto_approve' in data:
         domain.auto_approve = bool(data['auto_approve'])
-    
+
     ok, _err = safe_commit(logger, "Failed to update local ACME domain")
     if not ok:
         return _err
-    
+
     AuditService.log_action(
         action='acme_local_domain_update',
         resource_type='acme_local_domain',
@@ -122,7 +125,7 @@ def update_local_domain(domain_id):
         details=f'Updated local ACME domain: {domain.domain}',
         success=True
     )
-    
+
     return success_response(
         data=domain.to_dict(),
         message='Domain updated successfully'
@@ -135,12 +138,12 @@ def delete_local_domain(domain_id):
     """Delete a local domain mapping"""
     domain = db.get_or_404(AcmeLocalDomain, domain_id)
     domain_name = domain.domain
-    
+
     db.session.delete(domain)
     ok, _err = safe_commit(logger, "Failed to delete local ACME domain")
     if not ok:
         return _err
-    
+
     AuditService.log_action(
         action='acme_local_domain_delete',
         resource_type='acme_local_domain',
@@ -149,25 +152,25 @@ def delete_local_domain(domain_id):
         details=f'Removed local ACME domain: {domain_name}',
         success=True
     )
-    
+
     return success_response(message=f'Domain {domain_name} removed')
 
 
 def find_local_domain_ca(domain: str) -> int | None:
     """Find which CA should sign for a local ACME domain.
-    
+
     Uses hierarchical matching: exact → parent → grandparent.
     Returns issuing_ca_id or None.
     """
     domain = domain.strip().lower()
     if domain.startswith('*.'):
         domain = domain[2:]
-    
+
     # Exact match
     local = AcmeLocalDomain.query.filter_by(domain=domain).first()
     if local:
         return local.issuing_ca_id
-    
+
     # Parent domains
     parts = domain.split('.')
     for i in range(1, len(parts)):
@@ -175,11 +178,24 @@ def find_local_domain_ca(domain: str) -> int | None:
         local = AcmeLocalDomain.query.filter_by(domain=parent).first()
         if local:
             return local.issuing_ca_id
-    
+
     return None
 
 
 def _is_valid_domain(domain: str) -> bool:
-    """Validate domain format"""
-    pattern = r'^(\*\.)?([a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,}$'
+    """Validate domain format.
+
+    Patched: the label+dot group is now optional so bare TLDs
+    (e.g. "local", "internal", "lab") are accepted. This lets
+    admins register a bare TLD and have find_local_domain_ca's
+    parent-walking cover every subdomain automatically.
+
+    Accepted examples:
+      local               ← bare TLD (NEW)
+      *.local             ← wildcard bare TLD (NEW)
+      example.com         ← standard domain
+      *.example.com       ← wildcard domain
+      foo.example.com     ← subdomain
+    """
+    pattern = r'^(\*\.)?(([a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?\.)+)?[a-zA-Z]{2,}$'
     return bool(re.match(pattern, domain))

--- a/backend/api/v2/acme_local_domains.py
+++ b/backend/api/v2/acme_local_domains.py
@@ -2,8 +2,6 @@
 ACME Local Domains API Routes
 Manages domain-to-CA mappings for the Local ACME server.
 
-Patched: allow bare TLD registration (e.g. "local", "internal") so that
-parent-walking in find_local_domain_ca covers all subdomains of that TLD.
 """
 import re
 import logging
@@ -184,11 +182,6 @@ def find_local_domain_ca(domain: str) -> int | None:
 
 def _is_valid_domain(domain: str) -> bool:
     """Validate domain format.
-
-    Patched: the label+dot group is now optional so bare TLDs
-    (e.g. "local", "internal", "lab") are accepted. This lets
-    admins register a bare TLD and have find_local_domain_ca's
-    parent-walking cover every subdomain automatically.
 
     Accepted examples:
       local               ← bare TLD (NEW)

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -10,6 +10,7 @@ from typing import Optional
 from datetime import timedelta
 from dotenv import load_dotenv
 
+# Load environment variables FIRST (before using them)
 # Try multiple locations for .env files
 load_dotenv("/etc/ucm/ucm.env")  # System config (DEB/RPM)
 load_dotenv(Path(__file__).resolve().parent.parent.parent / ".env")  # Local dev

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -10,7 +10,6 @@ from typing import Optional
 from datetime import timedelta
 from dotenv import load_dotenv
 
-# Load environment variables FIRST (before using them)
 # Try multiple locations for .env files
 load_dotenv("/etc/ucm/ucm.env")  # System config (DEB/RPM)
 load_dotenv(Path(__file__).resolve().parent.parent.parent / ".env")  # Local dev
@@ -61,7 +60,7 @@ def get_system_fqdn():
     # Docker: MUST use environment variable
     if is_docker():
         return os.getenv('UCM_FQDN')
-    
+
     # Native installation: Try hostname -f first
     try:
         result = subprocess.run(
@@ -77,22 +76,29 @@ def get_system_fqdn():
                 return fqdn
     except (subprocess.SubprocessError, FileNotFoundError, subprocess.TimeoutExpired):
         pass
-    
+
     # Fallback: Check environment variable
     env_fqdn = os.getenv('FQDN')
     if env_fqdn and env_fqdn not in ['localhost', 'ucm.local', 'ucm.example.com']:
         return env_fqdn
-    
+
     # Last resort: Will be loaded from database later via Config.get_db_setting()
     return None
 
 
 class Config:
     """Base configuration - values can be overridden by database settings"""
-    
+
     # Application
     APP_NAME = os.getenv("APP_NAME", "Ultimate Certificate Manager")
-    
+
+    # Patched: expose DATA_DIR as a class attribute so code that references
+    # Config.DATA_DIR (or app.config['DATA_DIR']) works correctly. Previously
+    # only the module-level DATA_DIR existed; the class derived paths from it
+    # but never exposed DATA_DIR itself, causing AttributeError or missing
+    # config keys for any consumer that accessed Config.DATA_DIR directly.
+    DATA_DIR = DATA_DIR
+
     # Version - single source of truth: VERSION file at repo/install root
     @staticmethod
     def _get_version():
@@ -104,42 +110,42 @@ class Config:
         except Exception:
             pass
         return os.getenv("APP_VERSION", "unknown")
-    
+
     APP_VERSION = _get_version.__func__()
-    
+
     # SECRET_KEY validation - deferred to runtime
     _secret_key = os.getenv("SECRET_KEY")
-    
+
     # For packaging: allow missing secrets during install, but validate at runtime
     SECRET_KEY = _secret_key if _secret_key else "INSTALL_TIME_PLACEHOLDER"
     DEBUG = os.getenv("DEBUG", "false").lower() == "true"
-    
+
     # Server - HTTPS mandatory
     HOST = os.getenv("HOST", "0.0.0.0")
     HTTPS_PORT = int(os.getenv("HTTPS_PORT", "8443"))
     HTTP_REDIRECT = os.getenv("HTTP_REDIRECT", "true").lower() == "true"
     HTTP_PROTOCOL_PORT = int(os.getenv("HTTP_PROTOCOL_PORT", "8080"))  # 8080 = default
-    
+
     # HTTPS Certificate
     # Respect package installation paths: /var/lib/ucm (Debian) or /etc/ucm (RPM)
     # Fallback to DATA_DIR for Docker or manual installations
     _https_cert_default = str(DATA_DIR / "https_cert.pem")
     _https_key_default = str(DATA_DIR / "https_key.pem")
-    
+
     HTTPS_CERT_PATH = Path(os.getenv("HTTPS_CERT_PATH", _https_cert_default))
     HTTPS_KEY_PATH = Path(os.getenv("HTTPS_KEY_PATH", _https_key_default))
     HTTPS_AUTO_GENERATE = os.getenv("HTTPS_AUTO_GENERATE", "true").lower() == "true"
-    
+
     # File Upload Limits (security)
     MAX_CONTENT_LENGTH = 50 * 1024 * 1024  # 50MB max (base64 inflates ~33%)
-    
+
     # Database
     # Supports SQLite (default) or PostgreSQL for high availability
     # DATABASE_URL takes precedence (PostgreSQL), else fallback to SQLite
     _db_url = os.getenv("DATABASE_URL")
     _db_default = str(DATA_DIR / "ucm.db")
     DATABASE_PATH = Path(os.getenv("DATABASE_PATH", _db_default))
-    
+
     if _db_url:
         # PostgreSQL or external database (HA mode)
         # Format: postgresql://user:password@host:port/dbname
@@ -149,9 +155,9 @@ class Config:
         # SQLite (standalone mode)
         SQLALCHEMY_DATABASE_URI = f"sqlite:///{DATABASE_PATH}"
         DATABASE_TYPE = "sqlite"
-    
+
     SQLALCHEMY_TRACK_MODIFICATIONS = False
-    
+
     # PostgreSQL-specific settings
     SQLALCHEMY_ENGINE_OPTIONS = {
         "pool_size": int(os.getenv("DB_POOL_SIZE", "5")),
@@ -159,8 +165,8 @@ class Config:
         "pool_timeout": int(os.getenv("DB_POOL_TIMEOUT", "30")),
         "pool_recycle": int(os.getenv("DB_POOL_RECYCLE", "1800")),
     } if _db_url else {}
-    
-    
+
+
     @classmethod
     def validate_secrets(cls):
         """Validate that secrets are properly set - called at app startup"""
@@ -169,13 +175,13 @@ class Config:
                 "SECRET_KEY must be set in environment. "
                 "Check /etc/ucm/ucm.env or load environment variables."
             )
-    
+
     # Session settings
-    
+
     # Session Configuration - Flask server-side sessions
     # Supports filesystem (default) or Redis (HA mode)
     _redis_url = os.getenv("REDIS_URL")
-    
+
     if _redis_url:
         # Redis session store for HA deployments
         SESSION_TYPE = 'redis'
@@ -185,18 +191,18 @@ class Config:
         # Filesystem sessions for standalone deployment
         SESSION_TYPE = 'filesystem'
         SESSION_FILE_DIR = DATA_DIR / 'sessions'
-    
+
     SESSION_COOKIE_SECURE = True  # HTTPS only
     SESSION_COOKIE_HTTPONLY = True
     SESSION_COOKIE_SAMESITE = 'Lax'
     PERMANENT_SESSION_LIFETIME = timedelta(hours=24)  # 24 hours session
     SESSION_REFRESH_EACH_REQUEST = True  # Reset timeout on each request
-    
+
     # Initial Admin User (only used on first run)
     INITIAL_ADMIN_USERNAME = os.getenv("INITIAL_ADMIN_USERNAME", "admin")
     INITIAL_ADMIN_PASSWORD = os.getenv("INITIAL_ADMIN_PASSWORD", "changeme123")
     INITIAL_ADMIN_EMAIL = os.getenv("INITIAL_ADMIN_EMAIL", "admin@localhost")
-    
+
     # SCEP Configuration
     SCEP_ENABLED = os.getenv("SCEP_ENABLED", "true").lower() == "true"
     SCEP_CA_ID = os.getenv("SCEP_CA_ID")
@@ -206,17 +212,17 @@ class Config:
     SCEP_CERT_LIFETIME = int(os.getenv("SCEP_CERT_LIFETIME", "365"))
     SCEP_KEY_SIZE = int(os.getenv("SCEP_KEY_SIZE", "2048"))
     SCEP_RENEWAL_DAYS = int(os.getenv("SCEP_RENEWAL_DAYS", "30"))
-    
+
     # Rate Limiting
     RATE_LIMIT_ENABLED = os.getenv("RATE_LIMIT_ENABLED", "true").lower() == "true"
     RATE_LIMIT_PER_MINUTE = int(os.getenv("RATE_LIMIT_PER_MINUTE", "60"))
     RATE_LIMIT_PER_HOUR = int(os.getenv("RATE_LIMIT_PER_HOUR", "1000"))
-    
+
     # Logging
     LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO")
     LOG_FILE = DATA_DIR / "ucm.log"
     AUDIT_LOG_FILE = DATA_DIR / "audit.log"
-    
+
     # CORS - auto-include FQDN and hostname
     _https_port = int(os.getenv("HTTPS_PORT", "8443"))
     _port_suffix = "" if _https_port == 443 else f":{_https_port}"
@@ -233,13 +239,13 @@ class Config:
     if _extra:
         _cors_origins.extend([o.strip() for o in _extra.split(",") if o.strip()])
     CORS_ORIGINS = _cors_origins
-    
+
     # FQDN for redirect - auto-detected based on environment
     # Docker: Uses UCM_FQDN env var
     # Native: Uses hostname -f or FQDN env var
     FQDN = get_system_fqdn()
     HTTP_PORT = int(os.getenv("HTTP_PORT", "80"))  # For redirect URL construction
-    
+
     # File paths
     CA_DIR = DATA_DIR / "ca"
     CERT_DIR = DATA_DIR / "certs"
@@ -247,13 +253,13 @@ class Config:
     CRL_DIR = DATA_DIR / "crl"
     SCEP_DIR = DATA_DIR / "scep"
     BACKUP_DIR = DATA_DIR / "backups"
-    
+
     @classmethod
     def get_db_setting(cls, key: str, default=None):
         """Retrieve setting from database (overrides env vars)"""
         # Will be implemented after DB models are created
         return default
-    
+
     @classmethod
     def set_db_setting(cls, key: str, value):
         """Store setting in database"""
@@ -282,7 +288,6 @@ class TestingConfig(Config):
     # Inherit Config.SQLALCHEMY_ENGINE_OPTIONS when DATABASE_URL is set in the
     # environment (PG CI job) but force in-memory SQLite — pool_* args are invalid.
     SQLALCHEMY_ENGINE_OPTIONS = {}
-
 
 # Configuration dictionary
 config = {

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -92,11 +92,8 @@ class Config:
     # Application
     APP_NAME = os.getenv("APP_NAME", "Ultimate Certificate Manager")
 
-    # Patched: expose DATA_DIR as a class attribute so code that references
-    # Config.DATA_DIR (or app.config['DATA_DIR']) works correctly. Previously
-    # only the module-level DATA_DIR existed; the class derived paths from it
-    # but never exposed DATA_DIR itself, causing AttributeError or missing
-    # config keys for any consumer that accessed Config.DATA_DIR directly.
+    # Expose DATA_DIR as a class attribute so code that references
+    # Config.DATA_DIR (or app.config['DATA_DIR']) works correctly.
     DATA_DIR = DATA_DIR
 
     # Version - single source of truth: VERSION file at repo/install root

--- a/backend/tests/test_acme_is_valid_domain.py
+++ b/backend/tests/test_acme_is_valid_domain.py
@@ -2,18 +2,12 @@
 Tests for _is_valid_domain in backend/api/v2/acme_local_domains.py
 
 """
-import re
 import sys
 import os
 
-# Ensure backend is on sys.path
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-
-def _is_valid_domain(domain: str) -> bool:
-    """Copy of the patched regex for standalone testing."""
-    pattern = r'^(\*\.)?(([a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?\.)+)?[a-zA-Z]{2,}$'
-    return bool(re.match(pattern, domain))
+from api.v2.acme_local_domains import _is_valid_domain
 
 
 # ---- Test cases: (domain, expected_result, reason) ----

--- a/backend/tests/test_acme_is_valid_domain.py
+++ b/backend/tests/test_acme_is_valid_domain.py
@@ -1,0 +1,129 @@
+"""
+Tests for _is_valid_domain in backend/api/v2/acme_local_domains.py
+
+"""
+import re
+import sys
+import os
+
+# Ensure backend is on sys.path
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+def _is_valid_domain(domain: str) -> bool:
+    """Copy of the patched regex for standalone testing."""
+    pattern = r'^(\*\.)?(([a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?\.)+)?[a-zA-Z]{2,}$'
+    return bool(re.match(pattern, domain))
+
+
+# ---- Test cases: (domain, expected_result, reason) ----
+
+VALID_DOMAINS = [
+    # Bare TLDs
+    ("local",            True,  "bare TLD"),
+    ("internal",         True,  "bare TLD"),
+    ("lab",              True,  "bare TLD"),
+    ("corp",             True,  "bare TLD"),
+    ("home",             True,  "bare TLD"),
+
+    # Wildcard bare TLDs
+    ("*.local",          True,  "wildcard bare TLD"),
+    ("*.internal",       True,  "wildcard bare TLD"),
+
+    # Standard domains
+    ("example.com",      True,  "standard domain"),
+    ("foo.example.com",  True,  "subdomain"),
+    ("bar.foo.example.com", True, "deep subdomain"),
+
+    # Wildcard domains
+    ("*.example.com",    True,  "wildcard domain"),
+    ("*.foo.example.com", True, "wildcard subdomain"),
+
+    # Hyphens in labels
+    ("my-domain.com",    True,  "hyphen in label"),
+    ("a-b.example.com",  True,  "hyphen in subdomain"),
+
+    # Numeric labels
+    ("123.com",          True,  "numeric label"),
+    ("s1.example.com",   True,  "alphanumeric label"),
+
+    # Single-char TLD edge (regex requires [a-zA-Z]{2,} so 2+ chars)
+    ("ab",               True,  "two-letter bare TLD"),
+]
+
+INVALID_DOMAINS = [
+    # Empty / whitespace
+    ("",                 False, "empty string"),
+    ("   ",              False, "whitespace only"),
+
+    # Wildcard without TLD
+    ("*",                False, "bare wildcard"),
+    ("*.",               False, "wildcard with dot, no TLD"),
+
+    # Leading/trailing dot
+    (".com",             False, "leading dot"),
+    ("example.com.",     False, "trailing dot"),
+
+    # Double wildcard
+    ("**.example.com",   False, "double asterisk"),
+    ("*.*.example.com",  False, "double wildcard labels"),
+
+    # Invalid characters
+    ("exa_mple.com",     False, "underscore in label"),
+    ("exa mple.com",     False, "space in label"),
+    ("example!.com",     False, "special char in label"),
+
+    # Single-char TLD (regex requires 2+ alpha chars)
+    ("a",                False, "single-char TLD"),
+
+    # Numeric-only TLD (regex requires [a-zA-Z]{2,})
+    ("example.123",      False, "numeric TLD"),
+
+    # Hyphen at start/end of label
+    ("-example.com",     False, "leading hyphen in label"),
+    ("example-.com",     False, "trailing hyphen in label"),
+
+    # Path traversal attempts
+    ("../etc/passwd",    False, "path traversal"),
+    ("..",               False, "dot-dot"),
+
+    # Newline injection
+    ("example.com\n",    False, "trailing newline"),
+    ("ex\nample.com",    False, "embedded newline"),
+]
+
+
+def run_tests():
+    """Run all test cases and report results."""
+    passed = 0
+    failed = 0
+    failures = []
+
+    for domain, expected, reason in VALID_DOMAINS:
+        result = _is_valid_domain(domain)
+        if result == expected:
+            passed += 1
+        else:
+            failed += 1
+            failures.append(f"  FAIL: {domain!r:30s} expected={expected} got={result}  ({reason})")
+
+    for domain, expected, reason in INVALID_DOMAINS:
+        result = _is_valid_domain(domain)
+        if result == expected:
+            passed += 1
+        else:
+            failed += 1
+            failures.append(f"  FAIL: {domain!r:30s} expected={expected} got={result}  ({reason})")
+
+    print(f"\n_is_valid_domain tests: {passed} passed, {failed} failed, {passed + failed} total\n")
+    if failures:
+        print("Failures:")
+        for f in failures:
+            print(f)
+        print()
+    return failed == 0
+
+
+if __name__ == "__main__":
+    ok = run_tests()
+    sys.exit(0 if ok else 1)


### PR DESCRIPTION
#### Change Log:

1. Make the label+dot group optional so bare TLDs are accepted. Combined with find_local_domain_ca's existing parent-walking logic, registering a bare TLD (e.g. "local") now covers all subdomains (foo.local, bar.local, *.foo.local) automatically.

2. The Config class in settings.py derived all path attributes (CA_DIR, CERT_DIR, LOG_FILE, etc.) from the module-level DATA_DIR variable but never exposed DATA_DIR itself as a class attribute. Any code referencing Config.DATA_DIR directly would raise AttributeError, and consumers reading app.config['DATA_DIR'] would find no key. Fixed `settings.py` to expose DATA_DIR to other classes.

_____________

_This PR is sponsored by PMGA Tech LLP_