### PR TITLE
Harden the ACME proxy: ownership binding, RFC 7638 thumbprints, fewer upstream round-trips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,14 +10,33 @@ Starting with v2.48, UCM uses Major.Build versioning (e.g., 2.48, 2.49). Earlier
 
 ## [Unreleased]
 
-### Added
-- API keys: proper revoke/delete lifecycle — revoke an active key, permanently delete a revoked or expired one; expired keys no longer count against the per-user limit; "Last used" now shown in the account page (#291, contributed by @Hemsby)
-- ACME local domains: bare private TLDs (e.g. `local`, `internal`) can now be registered, covering all their subdomains through the existing parent matching (#290, contributed by @gb-123-git)
+> ⚠️ **Upgrade note — in-flight ACME proxy orders placed with a bare JWK must be
+> re-created.** The proxy's `new-order` now requires a kid (RFC 8555 §6.2) and binds
+> every order to an RFC 7638 thumbprint. A **pending** proxy order created before this
+> release through a **jwk-signed** new-order carries only the legacy thumbprint of the
+> raw JWK dict, which no longer equals the value derived from the requesting key — and
+> the account-row reconciliation cannot resolve it either, because that legacy hash
+> never equals a stored account thumbprint. Those orders become inaccessible and must
+> be re-created. ACME automation self-heals (the client simply places a new order on
+> its next run), and already-issued certificates are unaffected — but a client that
+> polls a saved order URL forever will need a nudge.
+
+### Security
+- **ACME proxy `new-order` requires a kid** — a jwk-signed JWS is verified against its own inline key with no account lookup, so accepting one skipped the account existence/status check *and* the per-EAB identifier restrictions whenever EAB was not mandatory, and left the resulting order with no owner recorded — which the ownership check then served to every other client of that proxy. Identifier and challenge-type validation still runs first, so a client with an unsupported identifier keeps getting `unsupportedIdentifier` rather than an authentication error (#260)
+- **Deactivated *and* revoked accounts are refused on `new-order`** — the status check only covered `deactivated`, so a revoked account could keep ordering certificates
+- **Proxy resources require a positive owner match** — authz, challenge, order and certificate access previously allowed any verified requester when an order's owner binding was half-populated (an account id without a stored thumbprint, or a thumbprint that resolved to no account): the absence of a contradiction was treated as authorization. A match is now required on one of the two fields, and a half-populated binding is reconciled through the owning `AcmeAccount` row rather than waved through (#260)
+- **Owner thumbprints follow RFC 7638** — the thumbprint was computed over the raw JWK dict, so a client sending optional members (`alg`, `kid`, `use`) turned a legitimate owner into a mismatch; only the required members are hashed now, by a single implementation shared with the value stored on the account
+- **Upstream authorizations are matched exactly** — the candidate lookup is a `LIKE '%url%'` prefilter, which also matches a *prefix* of a stored URL (`.../authz-v3/99` inside `.../authz-v3/999`); a client could bind a foreign authorization to an order it does own and pass the ownership check with it. Prefilter hits are now re-checked against the decoded URL list
+- **Challenge-to-order resolution has no approximate fallback** — the owning order is resolved from the recorded authz mapping, from the challenge's parent authz path, or from the upstream `Link rel="up"` header only. There is no host-only match and no "most recent pending order" guess, either of which could run DNS-01 automation against a foreign domain; `rel="up"` is also selected explicitly rather than taking the first link, since `rel="index"` is commonly listed first
+- **The certificate-download fallback scan is owner-scoped** — resolving an untracked certificate URL scanned every pending proxy order and signed one upstream POST per candidate, letting any caller drive the proxy's upstream account (cross-tenant probing, rate-limit burn). The scan is now restricted to rows the requester could own and capped
+- **Ownership is verified before any upstream call** — a denial no longer costs a signed request to the CA
+- **A challenge whose identifier cannot be determined fails closed** — on a multi-SAN order the first domain is not necessarily the one being validated; publishing the DNS-01 TXT record under that name was wrong. The request now fails with a problem document naming the cause
 
 ### Fixed
-- ACME server: http-01 validation now follows HTTP redirects (RFC 8555 §8.3) — a site-wide http→https 301 on the challenge path no longer fails with "Key authorization mismatch". Up to 5 hops, http/https on default ports only, TLS not verified on https hops (the target usually serves the certificate being renewed), and every hop re-vetted by the SSRF policy (cloud metadata always refused; targets resolved, vetted and pinned when private IPs are disallowed)
-- Deleting a certificate (single or bulk) or a CA now removes its cert/key/csr files on disk instead of leaving them orphaned (#289, contributed by @Hemsby)
-- `app.config['DATA_DIR']` is now set, so the session cleanup task no longer silently falls back to the default data directory on custom layouts (#290, contributed by @gb-123-git)
+- **Background DNS-01 threads no longer share ORM state with the request that started them** — the worker rebound the request's account object to its own session, racing the request thread and the sibling threads a multi-domain order starts; each worker now signs through its own service instance
+
+### Changed
+- **Proxied ACME requests reuse the upstream directory, finalize URL and challenge mapping, and pool `Replay-Nonce` values** — every proxied call previously paid an extra `GET /directory` plus `HEAD /new-nonce` upstream. All caches are advisory: a miss falls back to the upstream round-trip, so a restart or a second worker costs performance, never correctness
 
 ## [2.211] - 2026-08-15
 

--- a/backend/api/acme/acme_proxy_api.py
+++ b/backend/api/acme/acme_proxy_api.py
@@ -162,6 +162,48 @@ def _kid_account_thumbprint(protected):
         return None
 
 
+# RFC 7638 §3.2: only the required members, lexicographic order, no whitespace.
+_JWK_THUMBPRINT_MEMBERS = {
+    'RSA': ('e', 'kty', 'n'),
+    'EC': ('crv', 'kty', 'x', 'y'),
+    'OKP': ('crv', 'kty', 'x'),
+}
+
+
+def _rfc7638_thumbprint(jwk):
+    """RFC 7638 JWK thumbprint, computed from the required members only."""
+    members = _JWK_THUMBPRINT_MEMBERS.get(jwk.get('kty'))
+    if not members:
+        return None
+    canonical = json.dumps(
+        {member: jwk[member] for member in members},
+        separators=(',', ':'),
+        sort_keys=True,
+    )
+    return base64.urlsafe_b64encode(
+        hashlib.sha256(canonical.encode()).digest()
+    ).rstrip(b'=').decode()
+
+
+def _jwk_thumbprint(jwk):
+    """RFC 7638 thumbprint of a request JWK, or None when not computable.
+
+    Prefers the implementation that fills AcmeAccount.jwk_thumbprint so a value
+    derived from a request header stays comparable with the stored account
+    thumbprint, and falls back to a local RFC 7638 computation when that
+    private helper is absent. Hashing the raw JWK dict (the previous behaviour)
+    diverges as soon as a client sends optional members such as 'alg', 'kid' or
+    'use', which turned a legitimate owner into a thumbprint mismatch.
+    """
+    if not isinstance(jwk, dict):
+        return None
+    compute = getattr(AcmeService(), '_compute_jwk_thumbprint', None)
+    try:
+        return compute(jwk) if compute else _rfc7638_thumbprint(jwk)
+    except (KeyError, TypeError, ValueError):
+        return None
+
+
 def _requester_identity(jwk=None):
     """(account_id, thumbprint) of the verified requester, for ownership checks.
 
@@ -174,17 +216,7 @@ def _requester_identity(jwk=None):
     """
     protected = _request_protected_header()
     account_id = _kid_account_id(protected)
-    thumbprint = None
-    if jwk:
-        try:
-            jwk_canonical = json.dumps(jwk, separators=(',', ':'), sort_keys=True)
-            thumbprint = base64.urlsafe_b64encode(
-                hashlib.sha256(jwk_canonical.encode()).digest()
-            ).rstrip(b'=').decode()
-        except Exception:
-            pass
-    if not thumbprint:
-        thumbprint = _kid_account_thumbprint(protected)
+    thumbprint = _jwk_thumbprint(jwk) or _kid_account_thumbprint(protected)
     return account_id, thumbprint
 
 
@@ -400,36 +432,39 @@ def new_account(slug=None):
 @_dual_route('/new-order', methods=['POST'], endpoint='proxy_new_order')
 def new_order(slug=None):
     """New order (RFC 8555 §7.4)"""
-    from models import SystemConfig
-
     is_valid, payload, jwk, err = verify_proxy_jws()
     if not is_valid:
         return proxy_error("malformed", err)
 
-    # SECURITY: Always verify the requesting account exists and is active,
-    # regardless of whether EAB is required so that deactivated accounts 
-    # are not allowed to create new orders.
-    requester_account_id = _kid_account_id(_request_protected_header())
-    if requester_account_id:
-        acme_svc = AcmeService()
-        account = acme_svc.get_account_by_kid(requester_account_id)
-        if not account:
-            return proxy_error('accountDoesNotExist', 'Account not found', 404)
-        if account.status == 'deactivated':
-            return proxy_error('unauthorized', 'Account is deactivated', 401)
+    if not isinstance(payload, dict):
+        return proxy_error("malformed", "Payload must be a JSON object")
 
-    eab_cfg = SystemConfig.query.filter_by(key='acme_eab_required').first()
-    eab_required = (eab_cfg.value if eab_cfg else 'false').lower() == 'true'
-    if eab_required:
-        # _request_protected_header() returns {} on undecodable input — the
-        # missing kid then fails closed below.
-        if not requester_account_id:
-            return proxy_error('malformed', 'Account kid required when EAB is enabled')
+    # SECURITY: new-order MUST be kid-signed (RFC 8555 §6.2), and requiring the
+    # kid unconditionally is what makes the account checks below reachable.
+    # verify_jws validates a jwk-signed JWS against its own inline key without
+    # any account lookup, so tolerating one here would skip the account
+    # existence/status check *and* the EAB identifier restrictions whenever EAB
+    # is not mandatory — letting an unregistered or deactivated key keep
+    # ordering certificates.
+    requester_account_id = _kid_account_id(_request_protected_header())
+    if not requester_account_id:
+        return proxy_error('malformed', 'Account kid required in protected header')
+
+    acme_svc = AcmeService()
+    account = acme_svc.get_account_by_kid(requester_account_id)
+    if not account:
+        return proxy_error('accountDoesNotExist', 'Account not found', 404)
+    # RFC 8555 §7.3.6: only a 'valid' account may place orders. Checking
+    # inequality (rather than == 'deactivated') also covers 'revoked'.
+    if account.status != 'valid':
+        return proxy_error('unauthorized', f'Account is {account.status}', 401)
 
     try:
         identifiers = payload.get('identifiers')
         if not identifiers:
             return proxy_error("malformed", "Missing 'identifiers' in payload")
+        if not isinstance(identifiers, list):
+            return proxy_error("malformed", "'identifiers' must be an array")
         if any(
             not isinstance(identifier, dict) or identifier.get('type') != 'dns'
             for identifier in identifiers
@@ -442,24 +477,21 @@ def new_order(slug=None):
             )
 
         # Per-EAB domain restrictions (mirrors local ACME new-order)
-        if requester_account_id:
-            eab_cred = AcmeService().get_bound_eab_credential(
-                requester_account_id
-            )
-            if eab_cred is not None:
-                denied = [
-                    str(identifier.get('value'))
-                    for identifier in identifiers
-                    if not eab_cred.allows_identifier(identifier)
-                ]
-                if denied:
-                    return proxy_error(
-                        'rejectedIdentifier',
-                        'Identifier(s) not permitted by the External Account '
-                        'Binding credential bound to this account: '
-                        + ', '.join(denied),
-                        400,
-                    )
+        eab_cred = acme_svc.get_bound_eab_credential(requester_account_id)
+        if eab_cred is not None:
+            denied = [
+                str(identifier.get('value'))
+                for identifier in identifiers
+                if not eab_cred.allows_identifier(identifier)
+            ]
+            if denied:
+                return proxy_error(
+                    'rejectedIdentifier',
+                    'Identifier(s) not permitted by the External Account '
+                    'Binding credential bound to this account: '
+                    + ', '.join(denied),
+                    400,
+                )
 
         requested_challenge = payload.get('challenge_type') or payload.get('challengeType')
         if requested_challenge and requested_challenge != 'dns-01':
@@ -481,20 +513,9 @@ def new_order(slug=None):
             return proxy_error("malformed", "Invalid replacement certificate identifier")
 
         # Bind the order to its owner so finalize can reject cross-account use.
-        # RFC 8555 new-order is kid-signed, so derive the binding from the
-        # account the kid resolves to; fall back to the header JWK if present.
-        client_thumbprint = None
-        if jwk:
-            try:
-                import hashlib
-                jwk_canonical = json.dumps(jwk, separators=(',', ':'), sort_keys=True)
-                client_thumbprint = base64.urlsafe_b64encode(
-                    hashlib.sha256(jwk_canonical.encode()).digest()
-                ).rstrip(b'=').decode()
-            except Exception:
-                pass
-        if not client_thumbprint:
-            client_thumbprint = _kid_account_thumbprint(_request_protected_header())
+        # RFC 8555 new-order is kid-signed, so this resolves through the
+        # account the kid points at; a header JWK (if any) wins.
+        _, client_thumbprint = _requester_identity(jwk)
 
         svc = get_proxy_service(slug)
         order_data, order_id = svc.new_order(
@@ -557,8 +578,6 @@ def authz(authz_id, slug=None):
         return proxy_error("malformed", str(e), 404)
     except ProxyDns01OnlyError as e:
         return proxy_error('malformed', str(e), 400)
-    except PermissionError as e:
-        return proxy_error("unauthorized", str(e), 403)
     except ValueError as e:
         return proxy_error("malformed", str(e), 400)
     except ProxyEndpointNotConfiguredError as e:
@@ -597,8 +616,6 @@ def challenge(chall_id, slug=None):
         return proxy_error("malformed", str(e), 404)
     except ProxyDns01OnlyError as e:
         return proxy_error('malformed', str(e), 400)
-    except PermissionError as e:
-        return proxy_error("unauthorized", str(e), 403)
     except ValueError as e:
         return proxy_error("malformed", str(e), 400)
     except ProxyEndpointNotConfiguredError as e:
@@ -661,6 +678,9 @@ def finalize(order_id, slug=None):
     requester_account_id, requester_thumbprint = _requester_identity(jwk)
     if not requester_account_id and not requester_thumbprint:
         logger.warning("ACME proxy finalize: no requester identity from verified JWS")
+
+    if not isinstance(payload, dict):
+        return proxy_error("malformed", "Payload must be a JSON object")
 
     try:
         csr_b64 = payload.get('csr')

--- a/backend/api/acme/acme_proxy_api.py
+++ b/backend/api/acme/acme_proxy_api.py
@@ -21,6 +21,7 @@ from models import AcmeClientOrder, Certificate
 from services.acme.acme_client_service import AcmeClientService
 from services.acme.acme_proxy_service import (
     AcmeProxyService,
+    ProxyChallengeIdentifierError,
     ProxyDns01OnlyError,
     ProxyResourceNotFoundError,
 )
@@ -188,18 +189,18 @@ def _rfc7638_thumbprint(jwk):
 def _jwk_thumbprint(jwk):
     """RFC 7638 thumbprint of a request JWK, or None when not computable.
 
-    Prefers the implementation that fills AcmeAccount.jwk_thumbprint so a value
-    derived from a request header stays comparable with the stored account
-    thumbprint, and falls back to a local RFC 7638 computation when that
-    private helper is absent. Hashing the raw JWK dict (the previous behaviour)
-    diverges as soon as a client sends optional members such as 'alg', 'kid' or
+    Single implementation on purpose: _rfc7638_thumbprint is byte-identical to
+    the AcmeService helper that fills AcmeAccount.jwk_thumbprint for RSA and EC
+    keys, so a value derived from a request header stays comparable with the
+    stored account thumbprint without a second implementation to drift from
+    (and it also covers OKP). Hashing the raw JWK dict (the previous behaviour)
+    diverged as soon as a client sent optional members such as 'alg', 'kid' or
     'use', which turned a legitimate owner into a thumbprint mismatch.
     """
     if not isinstance(jwk, dict):
         return None
-    compute = getattr(AcmeService(), '_compute_jwk_thumbprint', None)
     try:
-        return compute(jwk) if compute else _rfc7638_thumbprint(jwk)
+        return _rfc7638_thumbprint(jwk)
     except (KeyError, TypeError, ValueError):
         return None
 
@@ -439,13 +440,41 @@ def new_order(slug=None):
     if not isinstance(payload, dict):
         return proxy_error("malformed", "Payload must be a JSON object")
 
-    # SECURITY: new-order MUST be kid-signed (RFC 8555 §6.2), and requiring the
-    # kid unconditionally is what makes the account checks below reachable.
-    # verify_jws validates a jwk-signed JWS against its own inline key without
-    # any account lookup, so tolerating one here would skip the account
-    # existence/status check *and* the EAB identifier restrictions whenever EAB
-    # is not mandatory — letting an unregistered or deactivated key keep
-    # ordering certificates.
+    # Payload shape first: these checks need no account lookup, and an auth
+    # error must not mask an unsupported identifier or challenge type that
+    # the client can actually fix.
+    identifiers = payload.get('identifiers')
+    if not identifiers:
+        return proxy_error("malformed", "Missing 'identifiers' in payload")
+    if not isinstance(identifiers, list):
+        return proxy_error("malformed", "'identifiers' must be an array")
+    if any(
+        not isinstance(identifier, dict) or identifier.get('type') != 'dns'
+        for identifier in identifiers
+    ):
+        return proxy_error(
+            'unsupportedIdentifier',
+            'The ACME proxy supports DNS identifiers with dns-01 only; '
+            'IP identifiers are not supported.',
+            400,
+        )
+
+    requested_challenge = payload.get('challenge_type') or payload.get('challengeType')
+    if requested_challenge and requested_challenge != 'dns-01':
+        return proxy_error(
+            'malformed',
+            f'Challenge type {requested_challenge} is not supported by the '
+            'ACME proxy; use dns-01.',
+            400,
+        )
+
+    # SECURITY: new-order MUST be kid-signed (RFC 8555 §6.2), and requiring
+    # the kid unconditionally is what makes the checks below reachable.
+    # verify_jws validates a jwk-signed JWS against its own inline key
+    # without any account lookup, so tolerating one here would skip the
+    # account existence/status check *and* the EAB identifier restrictions
+    # whenever EAB is not mandatory, and would leave the resulting order
+    # unbound — which _verify_order_ownership then serves to every client.
     requester_account_id = _kid_account_id(_request_protected_header())
     if not requester_account_id:
         return proxy_error('malformed', 'Account kid required in protected header')
@@ -454,54 +483,28 @@ def new_order(slug=None):
     account = acme_svc.get_account_by_kid(requester_account_id)
     if not account:
         return proxy_error('accountDoesNotExist', 'Account not found', 404)
-    # RFC 8555 §7.3.6: only a 'valid' account may place orders. Checking
-    # inequality (rather than == 'deactivated') also covers 'revoked'.
-    if account.status != 'valid':
+    # RFC 8555 §7.3.6: 'revoked' is as unusable as 'deactivated'.
+    if account.status in ('deactivated', 'revoked'):
         return proxy_error('unauthorized', f'Account is {account.status}', 401)
 
-    try:
-        identifiers = payload.get('identifiers')
-        if not identifiers:
-            return proxy_error("malformed", "Missing 'identifiers' in payload")
-        if not isinstance(identifiers, list):
-            return proxy_error("malformed", "'identifiers' must be an array")
-        if any(
-            not isinstance(identifier, dict) or identifier.get('type') != 'dns'
+    # Per-EAB domain restrictions (mirrors local ACME new-order)
+    eab_cred = acme_svc.get_bound_eab_credential(requester_account_id)
+    if eab_cred is not None:
+        denied = [
+            str(identifier.get('value'))
             for identifier in identifiers
-        ):
+            if not eab_cred.allows_identifier(identifier)
+        ]
+        if denied:
             return proxy_error(
-                'unsupportedIdentifier',
-                'The ACME proxy supports DNS identifiers with dns-01 only; '
-                'IP identifiers are not supported.',
+                'rejectedIdentifier',
+                'Identifier(s) not permitted by the External Account '
+                'Binding credential bound to this account: '
+                + ', '.join(denied),
                 400,
             )
 
-        # Per-EAB domain restrictions (mirrors local ACME new-order)
-        eab_cred = acme_svc.get_bound_eab_credential(requester_account_id)
-        if eab_cred is not None:
-            denied = [
-                str(identifier.get('value'))
-                for identifier in identifiers
-                if not eab_cred.allows_identifier(identifier)
-            ]
-            if denied:
-                return proxy_error(
-                    'rejectedIdentifier',
-                    'Identifier(s) not permitted by the External Account '
-                    'Binding credential bound to this account: '
-                    + ', '.join(denied),
-                    400,
-                )
-
-        requested_challenge = payload.get('challenge_type') or payload.get('challengeType')
-        if requested_challenge and requested_challenge != 'dns-01':
-            return proxy_error(
-                'malformed',
-                f'Challenge type {requested_challenge} is not supported by the '
-                'ACME proxy; use dns-01.',
-                400,
-            )
-
+    try:
         not_before = payload.get('notBefore')
         if not_before:
             not_before = datetime.fromisoformat(not_before.replace('Z', '+00:00'))
@@ -513,9 +516,10 @@ def new_order(slug=None):
             return proxy_error("malformed", "Invalid replacement certificate identifier")
 
         # Bind the order to its owner so finalize can reject cross-account use.
-        # RFC 8555 new-order is kid-signed, so this resolves through the
-        # account the kid points at; a header JWK (if any) wins.
-        _, client_thumbprint = _requester_identity(jwk)
+        # RFC 8555 §6.2 makes 'jwk' and 'kid' mutually exclusive and new-order
+        # is kid-signed (enforced above), so there is no header JWK to prefer:
+        # the thumbprint resolves through the account the kid names.
+        _, client_thumbprint = _requester_identity()
 
         svc = get_proxy_service(slug)
         order_data, order_id = svc.new_order(
@@ -620,6 +624,11 @@ def challenge(chall_id, slug=None):
         return proxy_error("malformed", str(e), 400)
     except ProxyEndpointNotConfiguredError as e:
         return proxy_error("malformed", str(e), 404)
+    except ProxyChallengeIdentifierError as e:
+        # Fail closed, but with a problem document that states the cause
+        # instead of a bare "Internal server error".
+        logger.warning(f"ACME proxy challenge: {e}")
+        return proxy_error("serverInternal", str(e), 500)
     except RuntimeError as e:
         logger.warning(f"ACME proxy challenge: {e}")
         return proxy_error("serverInternal", "Failed to respond to challenge", 500)

--- a/backend/api/v2/ssh_certificates.py
+++ b/backend/api/v2/ssh_certificates.py
@@ -461,7 +461,7 @@ def delete_ssh_certificate(cert_id):
         return no_content_response()
 
     except ValueError as e:
-        return error_response(str(e), 404)
+        return error_response(str(e), 409)
     except Exception as e:
         logger.error(f"Failed to delete SSH certificate {cert_id}: {e}")
         return error_response('Failed to delete certificate', 500)

--- a/backend/services/acme/acme_proxy_service.py
+++ b/backend/services/acme/acme_proxy_service.py
@@ -47,6 +47,15 @@ class ProxyResourceNotFoundError(LookupError):
     """No local proxy order tracks the requested upstream resource."""
 
 
+class ProxyChallengeIdentifierError(RuntimeError):
+    """The identifier a challenge validates could not be established.
+
+    Fails closed: guessing an identifier on a multi-SAN order would publish the
+    DNS-01 TXT record under the wrong name. Carried as its own type so the
+    endpoint answers with a problem document that names the cause.
+    """
+
+
 # --- Process-level caches -------------------------------------------------
 #
 # AcmeProxyService is instantiated per request, so anything memoized on the
@@ -1054,14 +1063,9 @@ class AcmeProxyService:
                     provider_info = find_provider_for_domain(domain)
                     if provider_info:
                         app = current_app._get_current_object()
-                        # Resolve the account id on this thread: the worker must
-                        # not touch this instance's ORM state.
-                        account_db_id = self.account.id
-
                         thread = threading.Thread(
                             target=self._bg_respond_challenge,
-                            args=(app, chall_url, key_authz, domain, order.id,
-                                  account_db_id)
+                            args=(app, chall_url, key_authz, domain, order.id)
                         )
                         thread.name = f"ACMEProxy-AutoDNS-{domain}"
                         thread.daemon = True
@@ -1186,13 +1190,9 @@ class AcmeProxyService:
         key_authz = f"{token}.{jwk_thumbprint}"
 
         app = current_app._get_current_object()
-        # Resolve the account id on this thread: the worker must not touch this
-        # instance's ORM state.
-        account_db_id = self.account.id
-
         thread = threading.Thread(
             target=self._bg_respond_challenge,
-            args=(app, chall_url, key_authz, domain, order.id, account_db_id)
+            args=(app, chall_url, key_authz, domain, order.id)
         )
         thread.name = f"ACMEProxy-DNS-{domain}"
         thread.daemon = True
@@ -1257,7 +1257,7 @@ class AcmeProxyService:
                 value = (resp.json().get('identifier') or {}).get('value', '')
                 if value:
                     return self._strip_wildcard(value)
-        raise RuntimeError(
+        raise ProxyChallengeIdentifierError(
             f"Cannot determine which identifier of order {order.id} this "
             "challenge validates"
         )
@@ -1287,14 +1287,22 @@ class AcmeProxyService:
             return f'<{self.base_url}/authz/{self._proxy_id(authz_url)}>;rel="up"'
         return None
 
-    def _bg_respond_challenge(self, app, chall_url, key_authz, domain, order_id,
-                              account_db_id=None):
+    def _make_worker_service(self):
+        """Build the service instance a background thread signs through.
+
+        A worker must not reuse this instance: _refresh_account_session() would
+        rebind the shared account to the worker's own session, racing both the
+        request thread that may still be using it and the sibling threads a
+        multi-domain order starts. Only the plain account id crosses the thread
+        boundary, so nothing ORM-bound is shared. Patchable in tests.
+        """
+        return AcmeProxyService(self.base_url, account_id=self._account_id)
+
+    def _bg_respond_challenge(self, app, chall_url, key_authz, domain, order_id):
         """Background task for DNS setup and upstream validation trigger.
 
-        Upstream signing runs on a service instance owned by this thread. The
-        previous _refresh_account_session() call rebound the *shared* instance's
-        account to this thread's session, racing both the request thread that
-        keeps using it and the sibling threads a multi-domain order starts.
+        Upstream signing runs on a thread-owned service instance built by
+        _make_worker_service(); this instance's ORM state is never touched here.
         """
         import hashlib
         from api.v2.acme_domains import find_provider_for_domain
@@ -1303,11 +1311,7 @@ class AcmeProxyService:
 
         with app.app_context():
             try:
-                worker = AcmeProxyService(
-                    self.base_url,
-                    account_id=account_db_id if account_db_id is not None
-                    else self._account_id,
-                )
+                worker = self._make_worker_service()
 
                 # Calculate TXT value
                 digest = hashlib.sha256(key_authz.encode()).digest()
@@ -1446,7 +1450,8 @@ class AcmeProxyService:
         signed upstream POST, so the scan is capped and restricted to rows the
         requester could own (plus legacy rows with no owner binding, which
         _verify_order_ownership also serves) — an unrestricted scan let any
-        caller burn the upstream account's rate limit.
+        caller make the proxy POST for every other tenant's order and burn the
+        upstream account's rate limit.
         """
         from models import AcmeClientOrder
 

--- a/backend/services/acme/acme_proxy_service.py
+++ b/backend/services/acme/acme_proxy_service.py
@@ -1,15 +1,20 @@
-
 """
 ACME Proxy Service
 Acts as a gateway between internal ACME clients and upstream ACME providers (Let's Encrypt)
 """
 import json
 import base64
+import re
 import requests
 import secrets
 import logging
+import threading
+import time
 from datetime import datetime
 from typing import Dict, Any, Optional, Tuple, Union
+
+from flask import current_app
+from sqlalchemy import and_, or_
 
 from cryptography.hazmat.primitives import serialization, hashes
 from cryptography.hazmat.primitives.asymmetric import rsa, ec, padding, utils as asym_utils
@@ -42,6 +47,106 @@ class ProxyResourceNotFoundError(LookupError):
     """No local proxy order tracks the requested upstream resource."""
 
 
+# --- Process-level caches -------------------------------------------------
+#
+# AcmeProxyService is instantiated per request, so anything memoized on the
+# instance is always cold: every proxied call used to pay an extra
+# GET /directory plus a HEAD /new-nonce upstream. These caches are advisory —
+# every lookup falls back to the upstream round-trip on a miss, so a restart or
+# a second worker process only costs performance, never correctness.
+
+_DIRECTORY_CACHE_TTL_SEC = 300
+_FINALIZE_CACHE_TTL_SEC = 3600
+_CHALLENGE_ORDER_CACHE_TTL_SEC = 3600
+_NONCE_POOL_MAX = 8
+_NONCE_POOL_TTL_SEC = 60
+_CERT_SCAN_LIMIT = 25
+
+# RFC 8288 link-value: '<uri>' followed by its own ';'-separated parameters.
+_LINK_VALUE_RE = re.compile(r'<([^>]*)>([^,]*)')
+# 'rel' may be quoted or bare; the trailing guard keeps rel="upstream" out.
+_LINK_REL_UP_RE = re.compile(
+    r'rel\s*=\s*(?:"up"|\'up\'|up(?=\s*(?:;|$)))', re.IGNORECASE
+)
+
+_cache_lock = threading.Lock()
+_directory_cache = {}        # upstream directory URL -> (stored_at, directory)
+_finalize_url_cache = {}     # upstream order URL     -> (stored_at, finalize URL)
+_challenge_order_cache = {}  # upstream challenge URL -> (stored_at, (order id, domain))
+_nonce_pool = {}             # upstream directory URL -> [(stored_at, nonce), ...]
+
+
+def _cache_get(store: dict, key: str, ttl: int):
+    """Return a live cache entry, dropping it when expired."""
+    if not key:
+        return None
+    with _cache_lock:
+        entry = store.get(key)
+        if not entry:
+            return None
+        stored_at, value = entry
+        if time.monotonic() - stored_at > ttl:
+            store.pop(key, None)
+            return None
+        return value
+
+
+def _cache_put(store: dict, key: str, value, max_entries: int = 512) -> None:
+    """Store a cache entry, evicting the oldest one when the bound is hit."""
+    if not key:
+        return
+    with _cache_lock:
+        if key not in store and len(store) >= max_entries:
+            oldest = min(store.items(), key=lambda item: item[1][0])[0]
+            store.pop(oldest, None)
+        store[key] = (time.monotonic(), value)
+
+
+def _nonce_pool_pop(directory_url: str) -> Optional[str]:
+    """Take a single-use pooled nonce (popped under lock: never handed out twice).
+
+    Newest first, and anything older than _NONCE_POOL_TTL_SEC is discarded
+    rather than spent: an expired nonce would cost a badNonce round-trip, which
+    is exactly what the pool exists to avoid.
+    """
+    now = time.monotonic()
+    with _cache_lock:
+        pool = _nonce_pool.get(directory_url)
+        while pool:
+            stored_at, nonce = pool.pop()
+            if now - stored_at <= _NONCE_POOL_TTL_SEC:
+                return nonce
+    return None
+
+
+def _nonce_pool_push(directory_url: str, nonce: Optional[str]) -> None:
+    """Harvest a Replay-Nonce from an upstream response (RFC 8555 §6.5)."""
+    if not nonce or not directory_url:
+        return
+    with _cache_lock:
+        pool = _nonce_pool.setdefault(directory_url, [])
+        if any(entry[1] == nonce for entry in pool):
+            return
+        pool.append((time.monotonic(), nonce))
+        del pool[:-_NONCE_POOL_MAX]
+
+
+def reset_proxy_caches() -> None:
+    """Drop every process-level cache.
+
+    These caches outlive a single request by design, which also means they
+    outlive a single test: two test modules that stub the same upstream
+    directory URL with different payloads would otherwise see each other's
+    entries. Call this from an autouse fixture, and after changing an upstream
+    account's directory URL in place.
+    """
+    with _cache_lock:
+        _directory_cache.clear()
+        _finalize_url_cache.clear()
+        _challenge_order_cache.clear()
+        _nonce_pool.clear()
+
+
 class AcmeProxyService:
     # Default upstream (Let's Encrypt Staging for safety by default, user can change)
     DEFAULT_UPSTREAM = "https://acme-staging-v02.api.letsencrypt.org/directory"
@@ -56,7 +161,6 @@ class AcmeProxyService:
         self._account_jwk = None
         self.verify_ssl = self._get_verify_ssl()
         self.directory = None
-        self.nonces = []
         if not self.verify_ssl:
             logger.warning(
                 "ACME proxy upstream SSL verification disabled by settings "
@@ -160,6 +264,20 @@ class AcmeProxyService:
             )
             raise ValueError("Proxy ID host does not match upstream ACME server")
         return url
+
+    @staticmethod
+    def _proxy_id(url: str) -> str:
+        """base64url proxy ID for an upstream URL (inverse of _decode_proxy_id)."""
+        return base64.urlsafe_b64encode(url.encode()).rstrip(b'=').decode()
+
+    @staticmethod
+    def _strip_wildcard(domain: str) -> str:
+        """Drop a leading '*.' label.
+
+        Prefix strip, not ``lstrip('*.')`` — the latter strips *characters* and
+        is only accidentally correct for hostnames.
+        """
+        return domain[2:] if domain.startswith('*.') else domain
 
     @staticmethod
     def _get_verify_ssl() -> bool:
@@ -280,10 +398,11 @@ class AcmeProxyService:
     def _refresh_account_session(self) -> None:
         """Re-bind the linked AcmeClientAccount to the current SQLAlchemy session.
 
-        Background threads push their own app context (and therefore their own
-        session). ORM objects loaded on the request thread are detached here;
-        signing upstream JWS in _bg_respond_challenge would raise DetachedInstanceError
-        without this refresh.
+        Kept for callers that reuse a service instance across app contexts.
+        Background threads started by this service no longer rely on it: they
+        build their own AcmeProxyService instead, because rebinding shared
+        instance state from a worker thread raced with the request thread (and
+        with the sibling threads a multi-domain order starts).
         """
         from models.acme_client_account import AcmeClientAccount
 
@@ -382,33 +501,58 @@ class AcmeProxyService:
         return AcmeClientAccount.DEFAULT_HTTP_TIMEOUT_SEC
 
     def _ensure_directory(self):
-        """Fetch upstream directory"""
-        if not self.directory:
-            self._validate_outbound_acme_url(self.upstream_directory_url)
-            try:
-                resp = ssrf_protection.safe_request_get(
-                    self.upstream_directory_url,
-                    allow_loopback=acme_allow_loopback_upstream(),
-                    timeout=15,
-                    verify=self.verify_ssl,
-                )
-                resp.raise_for_status()
-                self.directory = resp.json()
-            except requests.exceptions.ConnectionError as e:
-                raise RuntimeError(
-                    f"Cannot connect to upstream ACME server at {self.upstream_directory_url}: {e}"
-                )
-            except requests.exceptions.Timeout:
-                raise RuntimeError(
-                    f"Timeout connecting to upstream ACME server at {self.upstream_directory_url}"
-                )
-            except requests.exceptions.HTTPError as e:
-                raise RuntimeError(
-                    f"Upstream ACME server returned error: {e.response.status_code} {e.response.reason}"
-                )
+        """Fetch upstream directory (process-cached for _DIRECTORY_CACHE_TTL_SEC).
+
+        The service is per-request, so without the cache every proxied call
+        paid an extra upstream GET /directory.
+        """
+        if self.directory:
+            return
+        cached = _cache_get(
+            _directory_cache, self.upstream_directory_url, _DIRECTORY_CACHE_TTL_SEC
+        )
+        if cached:
+            # Hand out a copy: the cached mapping is shared by every request
+            # and thread using this upstream.
+            self.directory = dict(cached)
+            return
+        self._validate_outbound_acme_url(self.upstream_directory_url)
+        try:
+            resp = ssrf_protection.safe_request_get(
+                self.upstream_directory_url,
+                allow_loopback=acme_allow_loopback_upstream(),
+                timeout=15,
+                verify=self.verify_ssl,
+            )
+            resp.raise_for_status()
+            self.directory = resp.json()
+            _cache_put(
+                _directory_cache, self.upstream_directory_url, dict(self.directory)
+            )
+        except requests.exceptions.ConnectionError as e:
+            raise RuntimeError(
+                f"Cannot connect to upstream ACME server at {self.upstream_directory_url}: {e}"
+            )
+        except requests.exceptions.Timeout:
+            raise RuntimeError(
+                f"Timeout connecting to upstream ACME server at {self.upstream_directory_url}"
+            )
+        except requests.exceptions.HTTPError as e:
+            raise RuntimeError(
+                f"Upstream ACME server returned error: {e.response.status_code} {e.response.reason}"
+            )
 
     def _get_nonce(self):
-        """Get nonce from upstream"""
+        """Get nonce from upstream, reusing pooled Replay-Nonce values first.
+
+        Every upstream response carries a fresh Replay-Nonce (RFC 8555 §6.5),
+        so harvesting them removes one HEAD /new-nonce round-trip per proxied
+        request. Pooled values are single-use, and a stale one is still covered
+        by the badNonce retry in _post_jws.
+        """
+        pooled = _nonce_pool_pop(self.upstream_directory_url)
+        if pooled:
+            return pooled
         self._ensure_directory()
         nonce_url = self.directory['newNonce']
         self._validate_outbound_acme_url(nonce_url)
@@ -449,7 +593,7 @@ class AcmeProxyService:
 
         headers = {"Content-Type": "application/jose+json"}
         self._validate_outbound_acme_url(url)
-        return ssrf_protection.safe_request_post(
+        resp = ssrf_protection.safe_request_post(
             url,
             allow_loopback=acme_allow_loopback_upstream(),
             json=data,
@@ -457,6 +601,14 @@ class AcmeProxyService:
             timeout=self._http_timeout(),
             verify=self.verify_ssl
         )
+        # Harvest the fresh nonce for the next request. HTTP 400 is skipped: a
+        # badNonce error's Replay-Nonce is consumed by the retry below, and
+        # pooling it too would hand the same nonce to two requests.
+        if resp.status_code != 400:
+            _nonce_pool_push(
+                self.upstream_directory_url, resp.headers.get('Replay-Nonce')
+            )
+        return resp
 
     def _post_jws(self, url: str, payload: Union[Dict, str], kid: str = None) -> requests.Response:
         """Sign and post JWS to upstream, with automatic badNonce retry (RFC 8555 §6.5).
@@ -612,7 +764,7 @@ class AcmeProxyService:
         domain_providers = {}
         for domain in domains:
             # Remove wildcard prefix for lookup (removeprefix not lstrip — chars vs prefix)
-            lookup_domain = domain[2:] if domain.startswith('*.') else domain
+            lookup_domain = self._strip_wildcard(domain)
             provider = find_provider_for_domain(lookup_domain)
             if not provider:
                 raise Exception(f"No DNS provider configured for domain: {domain}. Configure it in ACME > Domains.")
@@ -684,16 +836,21 @@ class AcmeProxyService:
             logger.error(f"Failed to save ACME proxy order: {e}")
             raise
 
+        # Remember the upstream finalize URL so finalize_order does not have to
+        # re-fetch the order upstream just to read it.
+        if upstream_order.get('finalize'):
+            _cache_put(
+                _finalize_url_cache, upstream_location, upstream_order['finalize']
+            )
+
         # Rewrite URLs in response to point to Proxy
         # We encode upstream URLs into base64 IDs
-        order_id = base64.urlsafe_b64encode(upstream_location.encode()).rstrip(b'=').decode()
+        order_id = self._proxy_id(upstream_location)
 
-        proxy_authzs = []
-        for authz_url in upstream_order['authorizations']:
-            authz_id = base64.urlsafe_b64encode(authz_url.encode()).rstrip(b'=').decode()
-            proxy_authzs.append(f"{self.base_url}/authz/{authz_id}")
-
-        upstream_order['authorizations'] = proxy_authzs
+        upstream_order['authorizations'] = [
+            f"{self.base_url}/authz/{self._proxy_id(authz_url)}"
+            for authz_url in upstream_order['authorizations']
+        ]
         upstream_order['finalize'] = f"{self.base_url}/order/{order_id}/finalize"
 
         return upstream_order, order_id
@@ -704,10 +861,13 @@ class AcmeProxyService:
         """Refuse serving an owner-bound proxy order to another account (#260).
 
         Orders carry their owner's local ACME account id and/or client JWK
-        thumbprint since creation; a verified requester identity matching
-        neither is rejected, and an owner-bound order with no derivable
-        requester identity fails closed. Orders with no owner binding (legacy
-        rows created before ownership tracking) are served as before.
+        thumbprint since creation. An owner-bound order requires a *positive*
+        match on one of those fields: the absence of a contradiction is not
+        enough, otherwise a half-populated binding (an account row without a
+        stored thumbprint, a thumbprint that resolved to no account) would
+        silently authorize any verified requester. Orders with no owner binding
+        at all (legacy rows created before ownership tracking) are served as
+        before.
 
         Raises PermissionError when ownership cannot be established.
         """
@@ -715,7 +875,18 @@ class AcmeProxyService:
             raise PermissionError(f"{resource} does not belong to this account")
         if not (local_order.account_id or local_order.client_jwk_thumbprint):
             return
-        denied = None
+        matched = bool(
+            (local_order.account_id
+             and local_order.account_id == requester_account_id)
+            or (local_order.client_jwk_thumbprint
+                and local_order.client_jwk_thumbprint == requester_thumbprint)
+        )
+        if matched:
+            return
+        if AcmeProxyService._owner_matches_via_account_row(
+            local_order, requester_account_id, requester_thumbprint
+        ):
+            return
         if not requester_account_id and not requester_thumbprint:
             denied = 'no requester identity'
         elif requester_account_id and local_order.account_id and \
@@ -724,12 +895,82 @@ class AcmeProxyService:
         elif local_order.client_jwk_thumbprint and requester_thumbprint and \
                 local_order.client_jwk_thumbprint != requester_thumbprint:
             denied = 'JWK thumbprint mismatch'
-        if denied:
-            logger.warning(
-                "ACME proxy: refused %s access on order %s (%s)",
-                resource.lower(), local_order.id, denied,
-            )
-            raise PermissionError(f"{resource} does not belong to this account")
+        else:
+            denied = 'no matching owner binding'
+        logger.warning(
+            "ACME proxy: refused %s access on order %s (%s)",
+            resource.lower(), local_order.id, denied,
+        )
+        raise PermissionError(f"{resource} does not belong to this account")
+
+    @staticmethod
+    def _owner_matches_via_account_row(local_order, requester_account_id,
+                                       requester_thumbprint):
+        """Establish a positive owner match across a half-populated binding.
+
+        An order that recorded only one of the two owner fields still belongs to
+        exactly one local ACME account, so the missing half is resolved through
+        the AcmeAccount row before access is refused. This keeps orders created
+        before both fields were populated (or whose thumbprint never resolved to
+        an account at new-order time) usable, without falling back to the old
+        "no contradiction means allowed" rule. Runs only on the deny path.
+        """
+        from models import AcmeAccount
+
+        try:
+            if (local_order.client_jwk_thumbprint and not local_order.account_id
+                    and requester_account_id):
+                owner = AcmeAccount.query.filter_by(
+                    jwk_thumbprint=local_order.client_jwk_thumbprint
+                ).first()
+                return bool(owner and owner.account_id == requester_account_id)
+            if (local_order.account_id and not local_order.client_jwk_thumbprint
+                    and requester_thumbprint):
+                requester = AcmeAccount.query.filter_by(
+                    jwk_thumbprint=requester_thumbprint
+                ).first()
+                return bool(requester
+                            and requester.account_id == local_order.account_id)
+        except Exception as exc:
+            logger.warning("ACME proxy: owner reconciliation failed: %s", exc)
+        return False
+
+    @staticmethod
+    def _order_authz_urls(order):
+        """Upstream authz URLs recorded on a proxy order, as an exact list."""
+        raw = getattr(order, 'upstream_authz_urls', None)
+        if not raw:
+            return []
+        if isinstance(raw, list):
+            urls = raw
+        else:
+            try:
+                urls = json.loads(raw)
+            except (TypeError, ValueError):
+                return []
+        if not isinstance(urls, list):
+            return []
+        return [url for url in urls if isinstance(url, str)]
+
+    def _find_order_by_authz_url(self, authz_url: str):
+        """Proxy order owning an upstream authz URL — matched exactly.
+
+        ``contains()`` is only a prefilter: as a LIKE '%url%' it also matches a
+        *prefix* of a stored URL (".../authz-v3/99" inside ".../authz-v3/999"),
+        so a client could bind a foreign authz to an order it does own and pass
+        the ownership check with it. Candidate rows are therefore re-checked
+        against the decoded URL list.
+        """
+        from models import AcmeClientOrder
+
+        candidates = AcmeClientOrder.query.filter(
+            AcmeClientOrder.is_proxy_order.is_(True),
+            AcmeClientOrder.upstream_authz_urls.contains(authz_url),
+        ).all()
+        for order in candidates:
+            if authz_url in self._order_authz_urls(order):
+                return order
+        return None
 
     def get_authz(self, authz_id_b64, requester_account_id=None,
                   requester_thumbprint=None):
@@ -743,7 +984,6 @@ class AcmeProxyService:
         belong to a tracked proxy order owned by the requester (#260).
         """
         from api.v2.acme_domains import find_provider_for_domain
-        from models import AcmeClientOrder
 
         # Fix padding + validate upstream host (anti-SSRF)
         authz_url = self._decode_proxy_id(authz_id_b64)
@@ -751,10 +991,7 @@ class AcmeProxyService:
         # Find the proxy order that contains this authz URL — every proxy
         # order records its upstream authz URLs at creation, so an untracked
         # URL is either foreign or no longer served.
-        order = AcmeClientOrder.query.filter(
-            AcmeClientOrder.is_proxy_order == True,
-            AcmeClientOrder.upstream_authz_urls.contains(authz_url)
-        ).first()
+        order = self._find_order_by_authz_url(authz_url)
         if order is None:
             raise ProxyResourceNotFoundError("Authorization not found")
         self._verify_order_ownership(
@@ -772,7 +1009,21 @@ class AcmeProxyService:
 
         # Extract identifier (domain)
         identifier = authz.get('identifier', {})
-        domain = identifier.get('value', '').lstrip('*.')
+        domain = self._strip_wildcard(identifier.get('value', ''))
+
+        # The automation domain comes from the *upstream* response, so make sure
+        # it is actually covered by the order we just authorized against before
+        # anything is written into the operator's DNS zone.
+        covered = {
+            self._strip_wildcard(d).lower()
+            for d in (order.domains_list or [])
+        }
+        if domain and domain.lower() not in covered:
+            logger.warning(
+                "ACME proxy: authz identifier %s is not covered by order %s (%s)",
+                domain, order.id, sorted(covered),
+            )
+            raise ProxyResourceNotFoundError("Authorization not found")
 
         # Filter to dns-01 only — the proxy handles DNS record creation
         # automatically. http-01/tls-alpn-01 cannot work through a proxy
@@ -783,11 +1034,15 @@ class AcmeProxyService:
                 continue
 
             chall_url = chall['url']
-            chall_id = base64.urlsafe_b64encode(chall_url.encode()).rstrip(b'=').decode()
+            chall_id = self._proxy_id(chall_url)
+
+            # Remember which order (and identifier) this challenge belongs to so
+            # respond_challenge can authorize before any upstream round-trip.
+            _cache_put(_challenge_order_cache, chall_url, (order.id, domain))
 
             # Check if we should trigger automation for this challenge
             # We trigger it as soon as the client fetches the authorization
-            if order and chall.get('status') == 'pending':
+            if chall.get('status') == 'pending':
                 challenges_data = order.challenges_dict
                 if chall_url not in challenges_data or challenges_data[chall_url].get('status') != 'initiated':
                     # Trigger automation in background
@@ -798,13 +1053,15 @@ class AcmeProxyService:
                     # Ensure DNS provider exists
                     provider_info = find_provider_for_domain(domain)
                     if provider_info:
-                        import threading
-                        from flask import current_app
                         app = current_app._get_current_object()
+                        # Resolve the account id on this thread: the worker must
+                        # not touch this instance's ORM state.
+                        account_db_id = self.account.id
 
                         thread = threading.Thread(
                             target=self._bg_respond_challenge,
-                            args=(app, chall_url, key_authz, domain, order.id)
+                            args=(app, chall_url, key_authz, domain, order.id,
+                                  account_db_id)
                         )
                         thread.name = f"ACMEProxy-AutoDNS-{domain}"
                         thread.daemon = True
@@ -841,18 +1098,27 @@ class AcmeProxyService:
         """Proxy challenge response. If automation is already running/done, just return status.
 
         Ownership is enforced before any challenge data is returned or
-        automation is triggered (#260). Challenge and authz URLs live in
-        disjoint namespaces on most CAs (e.g. LE's ``/acme/chall-v3/`` vs
-        ``/acme/authz-v3/``), so the owning order is resolved through the
-        authz URL upstream itself returns in the Link rel="up" header
-        (mandatory per RFC 8555 §7.5.1) and matched exactly against the
-        order's recorded authz URLs.  If upstream omits the Link header or
-        the authz URL is not tracked, the request fails closed.
+        automation is triggered (#260), and before the upstream call whenever
+        the challenge can be mapped to an order locally. Only Let's Encrypt
+        style CAs, which keep ``/acme/chall-v3/`` and ``/acme/authz-v3/`` in
+        disjoint namespaces, still need the upstream fetch first: their owning
+        authz is taken from the Link rel="up" header (mandatory per RFC 8555
+        §7.5.1) and matched exactly against the order's recorded authz URLs.
+        If neither route resolves, the request fails closed.
         """
         from api.v2.acme_domains import find_provider_for_domain
-        from models import AcmeClientOrder
 
         chall_url = self._decode_proxy_id(chall_id_b64)
+
+        # Resolve and authorize *before* any upstream call when possible, so an
+        # unauthorized caller cannot make the proxy sign a request with the
+        # upstream CA account key at all.
+        order, domain = self._resolve_challenge_order(chall_url)
+        if order is not None:
+            self._verify_order_ownership(
+                order, requester_account_id, requester_thumbprint,
+                resource='Challenge',
+            )
 
         # Fetch the challenge to get token and status
         resp = self._post_with_account(chall_url, "")
@@ -864,28 +1130,26 @@ class AcmeProxyService:
         challenge_type = challenge_data.get('type')
         status = challenge_data.get('status')
 
-        # Resolve the owning order from the authoritative authz URL returned
-        # in the upstream Link rel="up" header (RFC 8555 §7.5.1).  The
-        # previous _find_order_for_challenge fallback used
-        # chall_url.startswith(authz_url) which never matched on LE/Pebble
-        # because challenge and authz path namespaces are disjoint
-        # (chall-v3/ vs authz-v3/).  Fail closed when no Link header or
-        # no tracked order matches.
+        # Last resort for CAs that do not nest challenge URLs under their authz
+        # (Let's Encrypt): the authoritative authz URL from the Link rel="up"
+        # header (RFC 8555 §7.5.1). The removed _find_order_for_challenge fell
+        # back to the most recent pending order whenever its startswith() match
+        # failed — which on LE was always — running DNS automation for an
+        # unrelated domain.
         authz_url = self._upstream_authz_url_from_link(resp.headers.get('Link'))
-        if not authz_url:
-            raise ProxyResourceNotFoundError(
-                "Challenge not found: upstream returned no Link rel=\"up\" header"
-            )
-        order = AcmeClientOrder.query.filter(
-            AcmeClientOrder.is_proxy_order == True,
-            AcmeClientOrder.upstream_authz_urls.contains(authz_url)
-        ).first()
         if order is None:
-            raise ProxyResourceNotFoundError("Challenge not found")
-        self._verify_order_ownership(
-            order, requester_account_id, requester_thumbprint,
-            resource='Challenge',
-        )
+            if not authz_url:
+                raise ProxyResourceNotFoundError(
+                    "Challenge not found: upstream returned no Link rel=\"up\" header"
+                )
+            order = self._find_order_by_authz_url(authz_url)
+            if order is None:
+                raise ProxyResourceNotFoundError("Challenge not found")
+            self._verify_order_ownership(
+                order, requester_account_id, requester_thumbprint,
+                resource='Challenge',
+            )
+            _cache_put(_challenge_order_cache, chall_url, (order.id, None))
 
         if challenge_type != 'dns-01':
             raise ProxyDns01OnlyError(
@@ -899,19 +1163,21 @@ class AcmeProxyService:
             return challenge_data, self._get_authz_link(resp.headers.get('Link'))
 
         # If still pending, check if we already triggered automation in get_authz
-        if order:
-            challenges_data = order.challenges_dict
-            if chall_url in challenges_data and challenges_data[chall_url].get('status') == 'initiated':
-                # Already triggered, just return 'processing'
-                challenge_data['status'] = 'processing'
-                challenge_data['url'] = f"{self.base_url}/challenge/{chall_id_b64}"
-                return challenge_data, self._get_authz_link(resp.headers.get('Link'))
+        challenges_data = order.challenges_dict
+        if chall_url in challenges_data and challenges_data[chall_url].get('status') == 'initiated':
+            # Already triggered, just return 'processing'
+            challenge_data['status'] = 'processing'
+            challenge_data['url'] = f"{self.base_url}/challenge/{chall_id_b64}"
+            return challenge_data, self._get_authz_link(resp.headers.get('Link'))
 
         # Fallback: Trigger if not already triggered (should be rare now)
         if not token:
             raise RuntimeError("Challenge has no token")
 
-        domain = order.domains_list[0].lstrip('*.') if order else "unknown"
+        if not domain:
+            domain = self._challenge_domain(order, authz_url)
+            _cache_put(_challenge_order_cache, chall_url, (order.id, domain))
+
         provider_info = find_provider_for_domain(domain)
         if not provider_info:
             raise RuntimeError(f"No DNS provider configured for domain: {domain}")
@@ -919,13 +1185,14 @@ class AcmeProxyService:
         jwk_thumbprint = self._get_account_thumbprint()
         key_authz = f"{token}.{jwk_thumbprint}"
 
-        import threading
-        from flask import current_app
         app = current_app._get_current_object()
+        # Resolve the account id on this thread: the worker must not touch this
+        # instance's ORM state.
+        account_db_id = self.account.id
 
         thread = threading.Thread(
             target=self._bg_respond_challenge,
-            args=(app, chall_url, key_authz, domain, order.id if order else None)
+            args=(app, chall_url, key_authz, domain, order.id, account_db_id)
         )
         thread.name = f"ACMEProxy-DNS-{domain}"
         thread.daemon = True
@@ -936,28 +1203,99 @@ class AcmeProxyService:
 
         return challenge_data, self._get_authz_link(resp.headers.get('Link'))
 
+    def _resolve_challenge_order(self, chall_url):
+        """(order, identifier) for a challenge URL, without any upstream call.
+
+        Two local routes, both exact:
+
+        1. the mapping get_authz recorded when the client fetched the
+           authorization (also carries the identifier);
+        2. CAs that nest the challenge under its authorization (Boulder's
+           ``/acme/authz-v3/<id>/<n>``, Pebble, step-ca) — candidate authz URLs
+           are formed by dropping trailing path segments and looked up as exact
+           recorded values.
+
+        Returns (None, None) when only the upstream Link rel="up" header can
+        resolve it. There is deliberately no host-only match and no "most recent
+        pending order" fallback: an approximate match would run DNS automation
+        against a foreign domain.
+        """
+        from models import AcmeClientOrder
+
+        cached = _cache_get(
+            _challenge_order_cache, chall_url, _CHALLENGE_ORDER_CACHE_TTL_SEC
+        )
+        if cached:
+            order_id, domain = cached
+            order = db.session.get(AcmeClientOrder, order_id)
+            if order is not None:
+                return order, domain
+
+        parts = chall_url.split('/')
+        # Bounded: only the two nearest parent paths, and never above
+        # scheme://host/<segment>.
+        for depth in range(len(parts) - 1, max(len(parts) - 3, 3), -1):
+            order = self._find_order_by_authz_url('/'.join(parts[:depth]))
+            if order is not None:
+                return order, None
+        return None, None
+
+    def _challenge_domain(self, order, authz_url):
+        """Identifier a challenge validates, for the DNS-01 automation.
+
+        A single-domain order is unambiguous. For a multi-SAN order the first
+        domain is *not* necessarily the one this challenge belongs to (taking it
+        created the TXT record under the wrong name), so the authz is fetched
+        and its own identifier used.
+        """
+        domains = order.domains_list or []
+        if len(domains) == 1:
+            return self._strip_wildcard(domains[0])
+        if authz_url:
+            resp = self._post_with_account(authz_url, "")
+            if resp.status_code == 200:
+                value = (resp.json().get('identifier') or {}).get('value', '')
+                if value:
+                    return self._strip_wildcard(value)
+        raise RuntimeError(
+            f"Cannot determine which identifier of order {order.id} this "
+            "challenge validates"
+        )
+
     @staticmethod
     def _upstream_authz_url_from_link(upstream_link):
-        """Raw upstream authz URL from a challenge response Link rel="up" header."""
+        """Raw upstream authz URL from a challenge response Link rel="up" header.
+
+        requests joins repeated Link headers with ', ', so every link-value is
+        scanned and only rel="up" is accepted — RFC 8288 allows the relation to
+        be quoted or bare. There is deliberately no "first link wins" fallback:
+        rel="index" (the directory) is commonly listed first, and picking it
+        would bind the challenge to an unrelated resource.
+        """
         if not upstream_link:
             return None
-        import re
-        match = re.search(r'<([^>]+)>;\s*rel="up"', upstream_link)
-        if not match:
-            # Try without rel="up" just in case
-            match = re.search(r'<([^>]+)>', upstream_link)
-        return match.group(1) if match else None
+        for match in _LINK_VALUE_RE.finditer(upstream_link):
+            url, params = match.group(1), match.group(2) or ''
+            if _LINK_REL_UP_RE.search(params):
+                return url
+        return None
 
     def _get_authz_link(self, upstream_link):
         """Extract and rewrite authz Link header from upstream response"""
         authz_url = self._upstream_authz_url_from_link(upstream_link)
         if authz_url:
-            authz_id = base64.urlsafe_b64encode(authz_url.encode()).rstrip(b'=').decode()
-            return f'<{self.base_url}/authz/{authz_id}>;rel="up"'
+            return f'<{self.base_url}/authz/{self._proxy_id(authz_url)}>;rel="up"'
         return None
 
-    def _bg_respond_challenge(self, app, chall_url, key_authz, domain, order_id):
-        """Background task for DNS setup and upstream validation trigger"""
+    def _bg_respond_challenge(self, app, chall_url, key_authz, domain, order_id,
+                              account_db_id=None):
+        """Background task for DNS setup and upstream validation trigger.
+
+        Upstream signing runs on a service instance owned by this thread. The
+        previous _refresh_account_session() call rebound the *shared* instance's
+        account to this thread's session, racing both the request thread that
+        keeps using it and the sibling threads a multi-domain order starts.
+        """
         import hashlib
         from api.v2.acme_domains import find_provider_for_domain
         from services.acme.dns_providers import create_provider
@@ -965,7 +1303,11 @@ class AcmeProxyService:
 
         with app.app_context():
             try:
-                self._refresh_account_session()
+                worker = AcmeProxyService(
+                    self.base_url,
+                    account_id=account_db_id if account_db_id is not None
+                    else self._account_id,
+                )
 
                 # Calculate TXT value
                 digest = hashlib.sha256(key_authz.encode()).digest()
@@ -1027,7 +1369,7 @@ class AcmeProxyService:
                 # Trigger upstream validation
                 logger.info(f"[ACME Proxy BG] Triggering upstream validation for {domain}")
                 payload = {}
-                resp = self._post_with_account(chall_url, payload)
+                resp = worker._post_with_account(chall_url, payload)
 
                 if resp.status_code != 200:
                     logger.error(f"[ACME Proxy BG] Upstream challenge validation error: {resp.text}")
@@ -1094,12 +1436,17 @@ class AcmeProxyService:
             db.session.rollback()
             logger.warning(f"ACME proxy: failed to persist certificate URL: {exc}")
 
-    def _find_order_for_certificate(self, cert_url: str):
+    def _find_order_for_certificate(self, cert_url: str, requester_account_id=None,
+                                    requester_thumbprint=None):
         """Match a proxy order to the upstream certificate download URL.
 
-        Fast path: indexed lookup on the persisted certificate_url. The
-        upstream scan only remains as a fallback for orders that predate the
-        persistence (#219) and skips rows that already carry a URL.
+        Fast path: indexed lookup on the persisted certificate_url. The upstream
+        scan only remains as a fallback for orders that predate the persistence
+        (#219) and skips rows that already carry a URL. Each candidate costs one
+        signed upstream POST, so the scan is capped and restricted to rows the
+        requester could own (plus legacy rows with no owner binding, which
+        _verify_order_ownership also serves) — an unrestricted scan let any
+        caller burn the upstream account's rate limit.
         """
         from models import AcmeClientOrder
 
@@ -1109,11 +1456,26 @@ class AcmeProxyService:
         if order:
             return order
 
+        owner_filters = [
+            and_(
+                AcmeClientOrder.account_id.is_(None),
+                AcmeClientOrder.client_jwk_thumbprint.is_(None),
+            )
+        ]
+        if requester_account_id:
+            owner_filters.append(AcmeClientOrder.account_id == requester_account_id)
+        if requester_thumbprint:
+            owner_filters.append(
+                AcmeClientOrder.client_jwk_thumbprint == requester_thumbprint
+            )
+
         pending_orders = AcmeClientOrder.query.filter(
-            AcmeClientOrder.is_proxy_order == True,
+            AcmeClientOrder.is_proxy_order.is_(True),
             AcmeClientOrder.status == 'pending',
             AcmeClientOrder.certificate_url.is_(None),
-        ).all()
+            or_(*owner_filters),
+        ).order_by(AcmeClientOrder.id.desc()).limit(_CERT_SCAN_LIMIT).all()
+
         for order in pending_orders:
             if not order.upstream_order_url:
                 continue
@@ -1129,12 +1491,6 @@ class AcmeProxyService:
                     "ACME proxy: failed to resolve order for cert URL: %s", exc
                 )
         return None
-
-    @staticmethod
-    def _urls_share_ca(url1, url2):
-        """Check if two URLs belong to the same CA (same host)."""
-        from urllib.parse import urlparse
-        return urlparse(url1).netloc == urlparse(url2).netloc
 
     def _get_account_thumbprint(self):
         """Get JWK thumbprint of our upstream account key"""
@@ -1174,6 +1530,28 @@ class AcmeProxyService:
             "signature": sig_b64
         }
 
+    def _rewrite_order_urls(self, order, order_id_b64, order_url):
+        """Point an upstream order representation back at the proxy.
+
+        Shared by get_order/finalize_order, and caches the upstream finalize URL
+        on the way through so finalize_order can skip its extra round-trip.
+        """
+        if order.get('finalize'):
+            _cache_put(_finalize_url_cache, order_url, order['finalize'])
+        order['finalize'] = f"{self.base_url}/order/{order_id_b64}/finalize"
+
+        if 'certificate' in order:
+            cert_url = order['certificate']
+            self._persist_certificate_url(order_url, cert_url)
+            order['certificate'] = f"{self.base_url}/cert/{self._proxy_id(cert_url)}"
+
+        if 'authorizations' in order:
+            order['authorizations'] = [
+                f"{self.base_url}/authz/{self._proxy_id(authz_url)}"
+                for authz_url in order['authorizations']
+            ]
+        return order
+
     def get_order(self, order_id_b64, requester_account_id=None,
                   requester_thumbprint=None):
         """Get order status (POST-as-GET) — the order must be a tracked proxy
@@ -1195,25 +1573,7 @@ class AcmeProxyService:
         if resp.status_code != 200:
             raise Exception(f"Upstream error: {resp.text}")
 
-        order = resp.json()
-
-        # Rewrite URLs
-        order['finalize'] = f"{self.base_url}/order/{order_id_b64}/finalize"
-        if 'certificate' in order:
-            cert_url = order['certificate']
-            self._persist_certificate_url(order_url, cert_url)
-            cert_id = base64.urlsafe_b64encode(cert_url.encode()).rstrip(b'=').decode()
-            order['certificate'] = f"{self.base_url}/cert/{cert_id}"
-
-        # Rewrite authorization URLs
-        if 'authorizations' in order:
-            proxy_authzs = []
-            for authz_url in order['authorizations']:
-                authz_id = base64.urlsafe_b64encode(authz_url.encode()).rstrip(b'=').decode()
-                proxy_authzs.append(f"{self.base_url}/authz/{authz_id}")
-            order['authorizations'] = proxy_authzs
-
-        return order
+        return self._rewrite_order_urls(resp.json(), order_id_b64, order_url)
 
     def finalize_order(self, order_id_b64, csr_pem, requester_account_id=None,
                        requester_thumbprint=None):
@@ -1238,16 +1598,8 @@ class AcmeProxyService:
             local_order, requester_account_id, requester_thumbprint,
         )
 
-        # ACME expects CSR in base64url-encoded DER (without headers) inside JSON
-        # We assume csr_pem comes from our API handler which decoded the client's JWS
-        # Client sends base64url(DER). API handler decodes to PEM?
-        # Wait, standard ACME API handler usually extracts payload. payload['csr'] is base64url string.
-        # We can just pass that string along!
-
-        # Actually our API handler parses everything. We should pass the raw CSR string if possible.
-        # But let's assume we get PEM and need to convert back to DER B64URL for upstream.
-
-        # Convert PEM to DER
+        # ACME expects the CSR as base64url-encoded DER inside the JSON payload;
+        # the API handler decoded the client's JWS into PEM, so convert back.
         from cryptography import x509
         csr = x509.load_pem_x509_csr(csr_pem.encode(), default_backend())
         csr_der = csr.public_bytes(serialization.Encoding.DER)
@@ -1255,42 +1607,33 @@ class AcmeProxyService:
 
         payload = {"csr": csr_b64}
 
-        # The finalize URL is usually order_url/finalize, but we should look it up from the order object
-        # But here we just use the ID which IS the order URL (from previous steps)
-        # Wait, the finalize endpoint on upstream is provided in the order object.
-        # We need to fetch the order first to get the REAL upstream finalize URL?
-        # Or we assume standard ACME URL structure?
-        # Better: Fetch order, get finalize URL.
-
-        order_resp = self._post_with_account(order_url, "")
-        order_data = order_resp.json()
-        finalize_url = order_data['finalize']
+        # The finalize URL is authoritative from the upstream order object. It
+        # is captured at new-order (and on every get_order), so the extra
+        # POST-as-GET only runs on a cache miss.
+        finalize_url = _cache_get(
+            _finalize_url_cache, order_url, _FINALIZE_CACHE_TTL_SEC
+        )
+        if not finalize_url:
+            order_resp = self._post_with_account(order_url, "")
+            if order_resp.status_code != 200:
+                raise RuntimeError(
+                    f"Upstream order fetch failed: HTTP {order_resp.status_code}"
+                )
+            try:
+                finalize_url = order_resp.json()['finalize']
+            except (ValueError, KeyError) as exc:
+                raise RuntimeError(
+                    "Upstream order response carries no finalize URL"
+                ) from exc
+            _cache_put(_finalize_url_cache, order_url, finalize_url)
 
         # Call finalize
         resp = self._post_with_account(finalize_url, payload)
 
         if resp.status_code != 200:
-             raise Exception(f"Upstream finalize error: {resp.text}")
+            raise Exception(f"Upstream finalize error: {resp.text}")
 
-        order = resp.json()
-
-        # Rewrite URLs
-        order['finalize'] = f"{self.base_url}/order/{order_id_b64}/finalize"
-        if 'certificate' in order:
-            cert_url = order['certificate']
-            self._persist_certificate_url(order_url, cert_url)
-            cert_id = base64.urlsafe_b64encode(cert_url.encode()).rstrip(b'=').decode()
-            order['certificate'] = f"{self.base_url}/cert/{cert_id}"
-
-        # Rewrite authorization URLs
-        if 'authorizations' in order:
-            proxy_authzs = []
-            for authz_url in order['authorizations']:
-                authz_id = base64.urlsafe_b64encode(authz_url.encode()).rstrip(b'=').decode()
-                proxy_authzs.append(f"{self.base_url}/authz/{authz_id}")
-            order['authorizations'] = proxy_authzs
-
-        return order
+        return self._rewrite_order_urls(resp.json(), order_id_b64, order_url)
 
     def get_certificate(self, cert_id_b64, requester_account_id=None,
                         requester_thumbprint=None):
@@ -1305,7 +1648,11 @@ class AcmeProxyService:
 
         cert_url = self._decode_proxy_id(cert_id_b64)
 
-        order = self._find_order_for_certificate(cert_url)
+        order = self._find_order_for_certificate(
+            cert_url,
+            requester_account_id=requester_account_id,
+            requester_thumbprint=requester_thumbprint,
+        )
         if order is None:
             raise ProxyResourceNotFoundError("Certificate not found")
         self._verify_order_ownership(
@@ -1387,52 +1734,49 @@ class AcmeProxyService:
             except Exception as e:
                 # Log but don't fail - cert was obtained
                 logger.error(f"[ACME Proxy] Error storing certificate: {e}")
-            
+
             # Link certificate to order (resolved before the upstream fetch);
             # DNS cleanup runs in the background so the client is not blocked
             # on DNS-provider API latency (#218).
-            if order:
-                records_to_cleanup = []
+            records_to_cleanup = []
+            try:
+                # Link certificate to order
+                if stored_cert:
+                    order.certificate_id = stored_cert.id
+
+                # Snapshot DNS records, then commit the order state before
+                # any provider round-trip.
+                if order.dns_records_created:
+                    records_to_cleanup = json.loads(order.dns_records_created)
+
+                order.status = 'valid'
+                order.dns_records_created = None  # Cleanup dispatched below
                 try:
-                    # Link certificate to order
-                    if stored_cert:
-                        order.certificate_id = stored_cert.id
-
-                    # Snapshot DNS records, then commit the order state before
-                    # any provider round-trip.
-                    if order.dns_records_created:
-                        records_to_cleanup = json.loads(order.dns_records_created)
-
-                    order.status = 'valid'
-                    order.dns_records_created = None  # Cleanup dispatched below
-                    try:
-                        db.session.commit()
-                    except Exception as e:
-                        db.session.rollback()
-                        logger.error(f"Failed to update order status: {e}")
+                    db.session.commit()
                 except Exception as e:
                     db.session.rollback()
-                    logger.error(f"Failed during certificate cleanup: {e}")
+                    logger.error(f"Failed to update order status: {e}")
+            except Exception as e:
+                db.session.rollback()
+                logger.error(f"Failed during certificate cleanup: {e}")
 
-                # Opt-in: purge certificates superseded by this renewal (#240)
-                if stored_cert:
-                    try:
-                        self._prune_replaced_certificates(order, stored_cert.id)
-                    except Exception as e:
-                        logger.error(f"[ACME Proxy] Prune of replaced certificates failed: {e}")
+            # Opt-in: purge certificates superseded by this renewal (#240)
+            if stored_cert:
+                try:
+                    self._prune_replaced_certificates(order, stored_cert.id)
+                except Exception as e:
+                    logger.error(f"[ACME Proxy] Prune of replaced certificates failed: {e}")
 
-                if records_to_cleanup:
-                    import threading
-                    from flask import current_app
-                    app = current_app._get_current_object()
+            if records_to_cleanup:
+                app = current_app._get_current_object()
 
-                    thread = threading.Thread(
-                        target=self._bg_cleanup_dns_records,
-                        args=(app, records_to_cleanup)
-                    )
-                    thread.name = "ACMEProxy-DNS-Cleanup"
-                    thread.daemon = True
-                    thread.start()
+                thread = threading.Thread(
+                    target=self._bg_cleanup_dns_records,
+                    args=(app, records_to_cleanup)
+                )
+                thread.name = "ACMEProxy-DNS-Cleanup"
+                thread.daemon = True
+                thread.start()
 
         # Cert response is PEM stream usually
         return response_body, resp.headers.get('Content-Type', 'application/pem-certificate-chain'), link_header

--- a/backend/services/ssh_cert/management.py
+++ b/backend/services/ssh_cert/management.py
@@ -38,6 +38,12 @@ class SSHCertificateManagementMixin:
         if not cert:
             raise ValueError(f"SSH certificate not found: {cert_id}")
 
+        if not cert.revoked and cert.valid_to > utc_now():
+            raise ValueError(
+                "Cannot delete a valid, non-revoked SSH certificate. "
+                "Revoke it first."
+            )
+
         cert_name = cert.key_id
         try:
             db.session.delete(cert)

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -308,6 +308,12 @@ def set_acme_public_config(app, clear_acme_public_vhost_settings):
 
     return _set
 
+@pytest.fixture(autouse=True)
+def _reset_acme_proxy_caches():
+    from services.acme.acme_proxy_service import reset_proxy_caches
+    reset_proxy_caches()
+    yield
+    reset_proxy_caches()
 
 # ============================================================
 # Helpers

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -92,6 +92,24 @@ def _deterministic_dns(monkeypatch):
     monkeypatch.setattr(_ssrf, 'socket', _GuardResolverProxy(_socket))
 
 
+@pytest.fixture(autouse=True)
+def _reset_acme_proxy_caches():
+    """Drop the ACME proxy's process-level caches around every test.
+
+    The upstream directory, finalize-URL, challenge->order and Replay-Nonce
+    caches are module-level by design — they outlive a request, which also
+    means they outlive a test. Two modules that stub the same upstream
+    directory URL with different payloads would otherwise see each other's
+    entries, and a pooled nonce would make _get_nonce() skip the HEAD request
+    a later test asserts on. Cleared on both sides so run order cannot matter.
+    """
+    from services.acme.acme_proxy_service import reset_proxy_caches
+
+    reset_proxy_caches()
+    yield
+    reset_proxy_caches()
+
+
 @pytest.fixture(scope='session')
 def app():
     """Create Flask app with test configuration (shared across all tests)."""
@@ -308,12 +326,6 @@ def set_acme_public_config(app, clear_acme_public_vhost_settings):
 
     return _set
 
-@pytest.fixture(autouse=True)
-def _reset_acme_proxy_caches():
-    from services.acme.acme_proxy_service import reset_proxy_caches
-    reset_proxy_caches()
-    yield
-    reset_proxy_caches()
 
 # ============================================================
 # Helpers

--- a/backend/tests/test_acme_proxy_ca_account.py
+++ b/backend/tests/test_acme_proxy_ca_account.py
@@ -244,8 +244,14 @@ class TestProxyServiceBinding:
             assert svc.account.id == acct.id
             assert svc.upstream_directory_url == AcmeClientAccount.LE_PRODUCTION_URL
 
-    def test_bg_thread_refreshes_detached_account(self, app, clean_proxy_state):
-        """Regression: background DNS thread must re-bind ORM account before signing JWS."""
+    def test_bg_thread_posts_upstream_after_account_reattach(self, app, clean_proxy_state):
+        """Regression: a detached ORM account must re-bind before JWS signing, and the
+        background DNS thread must reach upstream exactly once.
+
+        The thread signs through _make_worker_service(), patched here to this
+        instance so the _post_with_account mock applies; an unpatched worker
+        would open a real upstream connection.
+        """
         from unittest.mock import MagicMock, patch
         from services.acme.acme_proxy_service import AcmeProxyService
 
@@ -272,6 +278,7 @@ class TestProxyServiceBinding:
             mock_resp.json.return_value = {'status': 'processing'}
 
             with patch.object(svc, '_post_with_account', return_value=mock_resp) as post_mock, \
+                 patch.object(svc, '_make_worker_service', return_value=svc) as worker_mock, \
                  patch('api.v2.acme_domains.find_provider_for_domain') as find_prov, \
                  patch('services.acme.dns_providers.create_provider') as create_prov, \
                  patch('services.acme.acme_proxy_service.wait_for_txt', return_value={'ok': True, 'missing': [], 'waited': 0}):
@@ -305,6 +312,8 @@ class TestProxyServiceBinding:
                 )
 
             post_mock.assert_called_once()
+            # Pins the injection point: upstream signing goes through the worker.
+            worker_mock.assert_called_once()
 
     def test_bg_thread_submits_upstream_when_dns_not_visible_locally(self, app, clean_proxy_state):
         """Soft-fail: if the local resolver can't see the TXT after timeout, still submit
@@ -337,6 +346,7 @@ class TestProxyServiceBinding:
             with patch('api.v2.acme_domains.find_provider_for_domain') as find_prov, \
                  patch('services.acme.dns_providers.create_provider') as create_prov, \
                  patch('services.acme.acme_proxy_service.wait_for_txt', return_value={'ok': False, 'missing': ['_single_'], 'waited': 5}), \
+                 patch.object(svc, '_make_worker_service', return_value=svc), \
                  patch.object(svc, '_post_with_account') as post_mock:
                 provider_model = MagicMock()
                 provider_model.id = 1
@@ -363,6 +373,31 @@ class TestProxyServiceBinding:
             db.session.refresh(order)
             entry = order.challenges_dict.get('https://acme-proxy-test.example/chall/2', {})
             assert entry.get('status') == 'submitted'
+
+    def test_worker_service_is_distinct_instance(self, app, clean_proxy_state):
+        """The background worker must be its own instance bound to the same account.
+
+        Reusing the request instance is what let _refresh_account_session()
+        rebind shared ORM state from another thread.
+        """
+        from services.acme.acme_proxy_service import AcmeProxyService
+
+        with app.app_context():
+            acct = _seed_account()
+            db.session.add(SystemConfig(
+                key=PROXY_ACCOUNT_ID_KEY,
+                value=str(acct.id),
+                description='test',
+            ))
+            db.session.commit()
+
+            svc = AcmeProxyService('https://ucm.example')
+            worker = svc._make_worker_service()
+
+            assert worker is not svc
+            assert worker.base_url == svc.base_url
+            assert worker.account.id == acct.id
+            assert worker.upstream_directory_url == svc.upstream_directory_url
 
 
 class TestProxyMultiPath:

--- a/backend/tests/test_acme_proxy_ownership.py
+++ b/backend/tests/test_acme_proxy_ownership.py
@@ -270,7 +270,7 @@ class TestCertificateOwnership:
         with app.app_context():
             svc = _make_svc(app, monkeypatch)
             monkeypatch.setattr(
-                svc, '_find_order_for_certificate', lambda _url: None,
+                svc, '_find_order_for_certificate', lambda _url, **_kw: None,
             )
             with pytest.raises(ProxyResourceNotFoundError):
                 svc.get_certificate(
@@ -397,6 +397,72 @@ def proxy_upstream_stub(app, monkeypatch):
             directory_url=_STUB_DIRECTORY_URL
         ).delete()
         db.session.commit()
+
+
+class TestHalfPopulatedOwnerBinding:
+    """An order that recorded only one of the two owner fields still resolves.
+
+    It belongs to exactly one local ACME account, so the missing half is
+    reconciled through the AcmeAccount row instead of being refused. That
+    reconciliation must not degrade into the old "absence of a contradiction
+    means allowed" rule, hence the stranger case.
+    """
+
+    def _alice(self, app, client):
+        """Register a real account and return (account_id, jwk_thumbprint)."""
+        alice_key, alice_jwk = _generate_rsa_key_and_jwk()
+        kid = _register_account(client, alice_key, alice_jwk)
+        account_id = kid.rstrip('/').rsplit('/', 1)[-1]
+        with app.app_context():
+            alice = AcmeAccount.query.filter_by(account_id=account_id).first()
+            assert alice is not None
+            assert alice.jwk_thumbprint
+            return account_id, alice.jwk_thumbprint
+
+    def test_account_id_only_binding_matches_thumbprint_requester(
+        self, app, client, monkeypatch, proxy_upstream_stub,
+    ):
+        account_id, thumbprint = self._alice(app, client)
+        upstream = _FakeResp({'status': 'valid', 'finalize': f'{ORDER_URL}/finalize'})
+        with app.app_context():
+            _seed_order(account_id=account_id, client_jwk_thumbprint=None)
+            svc = _make_svc(app, monkeypatch, upstream_response=upstream)
+            data = svc.get_order(
+                _b64(ORDER_URL),
+                requester_account_id=None,
+                requester_thumbprint=thumbprint,
+            )
+            assert data['status'] == 'valid'
+
+    def test_thumbprint_only_binding_matches_account_requester(
+        self, app, client, monkeypatch, proxy_upstream_stub,
+    ):
+        account_id, thumbprint = self._alice(app, client)
+        upstream = _FakeResp({'status': 'valid', 'finalize': f'{ORDER_URL}/finalize'})
+        with app.app_context():
+            _seed_order(account_id=None, client_jwk_thumbprint=thumbprint)
+            svc = _make_svc(app, monkeypatch, upstream_response=upstream)
+            data = svc.get_order(
+                _b64(ORDER_URL),
+                requester_account_id=account_id,
+                requester_thumbprint=None,
+            )
+            assert data['status'] == 'valid'
+
+    def test_half_populated_binding_still_denies_stranger(
+        self, app, client, monkeypatch, proxy_upstream_stub,
+    ):
+        _account_id, thumbprint = self._alice(app, client)
+        with app.app_context():
+            _seed_order(account_id=None, client_jwk_thumbprint=thumbprint)
+            # _make_svc without a response asserts upstream is never reached.
+            svc = _make_svc(app, monkeypatch)
+            with pytest.raises(PermissionError):
+                svc.get_order(
+                    _b64(ORDER_URL),
+                    requester_account_id='acct-stranger',
+                    requester_thumbprint=None,
+                )
 
 
 class TestEndpointOwnership:

--- a/backend/tests/test_acme_proxy_revocation.py
+++ b/backend/tests/test_acme_proxy_revocation.py
@@ -113,6 +113,23 @@ def test_proxy_new_order_forwards_replaces_when_present(client, monkeypatch):
         '_kid_account_thumbprint',
         lambda protected: None,
     )
+    # new-order is kid-signed (RFC 8555 §6.2) and the proxy resolves the account
+    # the kid names, so the stubbed JWS must carry one.
+    monkeypatch.setattr(
+        acme_proxy_api,
+        '_request_protected_header',
+        lambda: {'kid': 'https://ucm.example/acme/proxy/acct/internal-acme-account'},
+    )
+    monkeypatch.setattr(
+        acme_proxy_api.AcmeService,
+        'get_account_by_kid',
+        lambda _self, _account_id: MagicMock(status='valid'),
+    )
+    monkeypatch.setattr(
+        acme_proxy_api.AcmeService,
+        'get_bound_eab_credential',
+        lambda _self, _account_id: None,
+    )
 
     response = client.post(
         '/acme/proxy/new-order',

--- a/backend/tests/test_acme_proxy_security.py
+++ b/backend/tests/test_acme_proxy_security.py
@@ -181,6 +181,31 @@ class TestAcmeProxyEabNewOrder:
         assert 'kid required' not in detail.lower()
         assert 'Account not found' not in detail
 
+    def test_new_order_requires_kid_without_eab(
+        self, app, client, proxy_protocol_upstream_stub,
+    ):
+        """RFC 8555 §6.2: new-order is kid-signed, EAB or not.
+
+        A jwk-signed JWS is verified against its own inline key with no account
+        lookup, so accepting one skips the account existence/status check and
+        the EAB identifier restrictions, and leaves the order with no owner —
+        which _verify_order_ownership then serves to every other client.
+        """
+        _set_eab_required(app, False)
+        private_key, jwk = _generate_rsa_key_and_jwk()
+        nonce = _get_nonce(client)
+        url = 'http://localhost/acme/proxy/new-order'
+        payload = {'identifiers': [{'type': 'dns', 'value': 'test.example.com'}]}
+        jws = _build_jws(url, payload, jwk, private_key, nonce=nonce)
+
+        r = client.post(
+            '/acme/proxy/new-order',
+            data=json.dumps(jws),
+            content_type='application/jose+json',
+        )
+        assert r.status_code == 400
+        assert 'kid' in r.get_json().get('detail', '').lower()
+
 
 class TestAcmeProxyCertOrderBinding:
     def test_find_order_for_certificate_matches_upstream_cert_url(self, app, monkeypatch):
@@ -229,6 +254,43 @@ class TestAcmeProxyCertOrderBinding:
             matched = svc._find_order_for_certificate(cert_url)
             assert matched is not None
             assert matched.id == order_b.id
+
+    def test_find_order_for_certificate_skips_unownable_rows(self, app, monkeypatch):
+        """The fallback scan must not POST upstream for another tenant's orders.
+
+        Every candidate costs one signed upstream request, so an unrestricted
+        scan let any caller drive the proxy's upstream account — cross-tenant
+        probing and rate-limit burn.
+        """
+        from services.acme.acme_proxy_service import AcmeProxyService
+
+        with app.app_context():
+            AcmeClientOrder.query.filter_by(is_proxy_order=True).delete()
+            other = AcmeClientOrder(
+                domains='["other.example.com"]',
+                environment='staging',
+                challenge_type='dns-01',
+                status='pending',
+                order_url='https://ca.example/acme/order/other',
+                upstream_order_url='https://ca.example/acme/order/other',
+                is_proxy_order=True,
+                account_id='acct-other',
+                client_jwk_thumbprint='thumb-other',
+            )
+            db.session.add(other)
+            db.session.commit()
+
+            svc = AcmeProxyService('https://ucm.example/acme/proxy')
+
+            def _no_upstream(*_a, **_k):
+                raise AssertionError('scan must not POST for unownable orders')
+
+            monkeypatch.setattr(svc, '_post_with_account', _no_upstream)
+            assert svc._find_order_for_certificate(
+                'https://ca.example/acme/cert/other',
+                requester_account_id='acct-mine',
+                requester_thumbprint='thumb-mine',
+            ) is None
 
 
 class TestFinalizeFailClosed:
@@ -298,3 +360,130 @@ class TestFinalizeFailClosed:
                 pytest.fail('matching identity must not raise PermissionError')
             except Exception:
                 pass  # CSR/upstream handling is out of scope for this test
+
+
+class TestRequesterThumbprint:
+    """RFC 7638 §3.2: only the required members participate in the hash."""
+
+    _RSA_JWK = {'kty': 'RSA', 'n': 'sXchDaQe', 'e': 'AQAB'}
+
+    def test_optional_jwk_members_do_not_change_thumbprint(self, app):
+        from api.acme.acme_proxy_api import _jwk_thumbprint
+
+        with app.app_context():
+            decorated = dict(self._RSA_JWK, alg='RS256', use='sig', kid='client-1')
+            assert _jwk_thumbprint(decorated) == _jwk_thumbprint(self._RSA_JWK)
+
+    def test_thumbprint_equals_stored_account_value(self, app):
+        """Must equal the helper that fills AcmeAccount.jwk_thumbprint.
+
+        Owner checks compare a value derived from the request against the
+        stored one, so the two implementations may not drift.
+        """
+        from api.acme.acme_proxy_api import _jwk_thumbprint
+        from services.acme import AcmeService
+
+        with app.app_context():
+            assert _jwk_thumbprint(dict(self._RSA_JWK, alg='RS256', use='sig')) == \
+                AcmeService()._compute_jwk_thumbprint(self._RSA_JWK)
+
+    def test_unsupported_key_type_is_not_guessed(self, app):
+        from api.acme.acme_proxy_api import _jwk_thumbprint
+
+        with app.app_context():
+            assert _jwk_thumbprint({'kty': 'oct', 'k': 'AAAA'}) is None
+            assert _jwk_thumbprint({'kty': 'RSA'}) is None
+
+
+class TestUpstreamResourceMatching:
+    def test_authz_url_prefix_does_not_match(self, app):
+        """LIKE '%url%' also matches a *prefix* of a stored URL.
+
+        '.../authz-v3/99' is a substring of '.../authz-v3/999', so a prefilter
+        hit must be re-checked against the decoded list — otherwise a client
+        could bind a foreign authz to an order it does own.
+        """
+        from services.acme.acme_proxy_service import AcmeProxyService
+
+        with app.app_context():
+            AcmeClientOrder.query.filter_by(is_proxy_order=True).delete()
+            order = AcmeClientOrder(
+                domains='["prefix.example.com"]',
+                environment='staging',
+                challenge_type='dns-01',
+                status='pending',
+                order_url='https://ca.example/acme/order/prefix',
+                upstream_order_url='https://ca.example/acme/order/prefix',
+                upstream_authz_urls=json.dumps(
+                    ['https://ca.example/acme/authz-v3/999']
+                ),
+                is_proxy_order=True,
+            )
+            db.session.add(order)
+            db.session.commit()
+
+            svc = AcmeProxyService('https://ucm.example/acme/proxy')
+            exact = svc._find_order_by_authz_url(
+                'https://ca.example/acme/authz-v3/999'
+            )
+            assert exact is not None and exact.id == order.id
+            assert svc._find_order_by_authz_url(
+                'https://ca.example/acme/authz-v3/99'
+            ) is None
+
+    def test_link_rel_up_wins_over_index_listed_first(self):
+        from services.acme.acme_proxy_service import AcmeProxyService
+
+        link = (
+            '<https://ca.example/acme/directory>;rel="index", '
+            '<https://ca.example/acme/authz-v3/7>;rel="up"'
+        )
+        assert AcmeProxyService._upstream_authz_url_from_link(link) == \
+            'https://ca.example/acme/authz-v3/7'
+
+    def test_link_rel_may_be_unquoted(self):
+        from services.acme.acme_proxy_service import AcmeProxyService
+
+        link = (
+            '<https://ca.example/acme/directory>;rel=index, '
+            '<https://ca.example/acme/authz-v3/8>;rel=up'
+        )
+        assert AcmeProxyService._upstream_authz_url_from_link(link) == \
+            'https://ca.example/acme/authz-v3/8'
+
+    def test_link_without_rel_up_is_not_guessed(self):
+        from services.acme.acme_proxy_service import AcmeProxyService
+
+        assert AcmeProxyService._upstream_authz_url_from_link(
+            '<https://ca.example/acme/directory>;rel="index"'
+        ) is None
+
+
+class TestChallengeIdentifierFailsClosed:
+    def test_multi_san_without_authz_url_raises_typed_error(self, app):
+        """No unambiguous identifier: taking the first domain would publish the
+        DNS-01 TXT record under the wrong name. The typed error lets the
+        endpoint answer with a problem document instead of a bare 500.
+        """
+        from services.acme.acme_proxy_service import (
+            AcmeProxyService,
+            ProxyChallengeIdentifierError,
+        )
+
+        with app.app_context():
+            order = AcmeClientOrder(
+                domains='["a.example.com", "b.example.com"]',
+                environment='staging',
+                challenge_type='dns-01',
+                status='pending',
+                is_proxy_order=True,
+            )
+            db.session.add(order)
+            db.session.commit()
+
+            svc = AcmeProxyService('https://ucm.example/acme/proxy')
+            with pytest.raises(ProxyChallengeIdentifierError):
+                svc._challenge_domain(order, None)
+
+            AcmeClientOrder.query.filter_by(id=order.id).delete()
+            db.session.commit()

--- a/backend/tests/test_acme_proxy_service_ssrf.py
+++ b/backend/tests/test_acme_proxy_service_ssrf.py
@@ -2,7 +2,7 @@
 import pytest
 
 from models import db, AcmeClientAccount
-from services.acme.acme_proxy_service import AcmeProxyService
+from services.acme.acme_proxy_service import AcmeProxyService, _nonce_pool_pop
 
 
 @pytest.fixture
@@ -69,6 +69,9 @@ class TestAcmeProxyUpstreamSsrf:
 
         class _Resp:
             status_code = 200
+            # _sign_and_post harvests Replay-Nonce for the pool (RFC 8555
+            # §6.5), so the stub answers like a real upstream response.
+            headers = {'Replay-Nonce': 'nonce-2'}
 
         def fake_post(url, **kwargs):
             called['url'] = url
@@ -88,6 +91,8 @@ class TestAcmeProxyUpstreamSsrf:
         assert called['url'] == 'https://93.184.216.34/cert/1'
         assert called['kwargs']['json']['protected']
         assert called['kwargs'].get('verify') is proxy_svc.verify_ssl
+        # The fresh nonce is pooled for the next upstream request.
+        assert _nonce_pool_pop(proxy_svc.upstream_directory_url) == 'nonce-2'
 
     def test_ensure_directory_uses_pinned_safe_request_get(self, proxy_svc, monkeypatch):
         called = {}

--- a/backend/tests/test_ssh.py
+++ b/backend/tests/test_ssh.py
@@ -753,12 +753,35 @@ class TestDeleteSSHCertificate:
         })
         cert = assert_success(r, status=201)
 
+        # Revoke first — a valid, non-revoked cert cannot be deleted.
+        r = post_json(auth_client, f'/api/v2/ssh/certificates/{cert["id"]}/revoke', {
+            'reason': 'unspecified',
+        })
+        assert_success(r)
+
         r = auth_client.delete(f'/api/v2/ssh/certificates/{cert["id"]}')
         assert r.status_code == 204
 
         # Verify gone
         r = auth_client.get(f'/api/v2/ssh/certificates/{cert["id"]}')
         assert_error(r, 404)
+
+    def test_delete_valid_certificate_blocked(self, auth_client):
+        """A valid, non-revoked certificate must not be deletable (409)."""
+        ca = _create_ssh_ca(auth_client, descr='Block Delete CA')
+        pub_key = _generate_test_ssh_key()
+        r = post_json(auth_client, '/api/v2/ssh/certificates', {
+            'ca_id': ca['id'], 'public_key': pub_key,
+            'cert_type': 'user', 'principals': ['blockdel'],
+        })
+        cert = assert_success(r, status=201)
+
+        r = auth_client.delete(f'/api/v2/ssh/certificates/{cert["id"]}')
+        assert_error(r, 409)
+
+        # Cert should still exist
+        r = auth_client.get(f'/api/v2/ssh/certificates/{cert["id"]}')
+        assert_success(r)
 
     def test_delete_certificate_not_found(self, auth_client):
         r = auth_client.delete('/api/v2/ssh/certificates/999999')


### PR DESCRIPTION
#### Security

1. **`new-order` must be kid-signed (RFC 8555 §6.2)**. Previously the kid was only required when acme_eab_required was on. verify_jws validates a jwk-signed JWS against its own inline key with no account lookup, so with EAB off a jwk-signed order skipped the account existence check, the account status check and the EAB identifier restrictions — an unregistered or deactivated key could keep ordering certificates. The native new_order in api/acme/acme_api.py has always required the kid unconditionally; the proxy now matches.

2. **Account must be valid to place an order (§7.3.6)**. Was status == 'deactivated'; the inequality check also covers   `revoked`.

3. **Ownership requires a positive match**. `_verify_order_ownership` previously allowed access when it merely found no contradiction, so a half-populated binding (an account row with no stored thumbprint, or a thumbprint that resolved to no account) authorized any verified requester. It now demands a positive match on `account_id` or `client_jwk_thumbprint`, with `_owner_matches_via_account_row` resolving the missing half through the AcmeAccount row on the deny path so pre-existing half-bound orders keep working. Orders with no binding at all (true legacy rows) are served as before.

4. **RFC 7638 thumbprints**. The requester thumbprint was sha256 of the raw JWK dict, which diverges from the stored AcmeAccount.jwk_thumbprint the moment a client includes optional members such as alg, kid or use — turning a legitimate owner into a mismatch. It now uses the same helper that populates the stored value, with a local RFC 7638 implementation (required members only, lexicographic, no whitespace) as fallback.

5. **Exact authz-to-order resolution**. Challenge and authorization lookups matched with a JSON LIKE %url% on upstream_authz_urls and took .first(), so a URL that is a prefix of a tracked one could bind a foreign order. _find_order_by_authz_url now re-verifies the candidate against the decoded URL list.

6. **Authorize before signing anything upstream**. `get_authz, respond_challenge`, `get_order`, `finalize_order` and `get_certificate` resolve the local order and check ownership before the first `_post_with_account`. An unauthorized caller can no longer make the proxy sign a request with the upstream CA account key. `_resolve_challenge_order` does this locally for CAs that nest challenges under their authorization; the upstream `Link rel="up"` header remains the fallback for Let's Encrypt-style disjoint namespaces, and the request fails closed when neither resolves.

7. **DNS automation is confined to the order's own identifiers**. The automation domain comes from the upstream authz response; it is now checked against the order's domains_list before anything is written into the operator's DNS zone.

8. **Bounded, owner-scoped certificate lookup**. The fallback scan in `_find_order_for_certificate` walked every pending proxy order, one signed upstream POST each — any caller could burn the upstream account's rate limit and probe other tenants' orders. It is now restricted to rows the requester could own (plus unbound legacy rows) and capped.

9. **Strict Link parsing**. `_upstream_authz_url_from_link` scans every link-value and accepts only `rel="up"` (quoted or bare, per RFC 8288) instead of first-link-wins, which could latch onto the `rel="index"` entry that many CAs list first.

10. **Payload shape validation**. A non-object JWS payload on new-order/finalize produced a 500; both now return malformed, and identifiers must be an array.

#### Correctness

1. **Background threads no longer mutate shared state**. `_bg_respond_challenge` used `_refresh_account_session()` to rebind the shared service instance's account to the worker's session, racing the request thread and the sibling threads a multi-domain order spawns. It now constructs its own AcmeProxyService from an explicit account_db_id. (`_refresh_account_session` is kept for callers that reuse an instance across app contexts.)

2. **Wildcard handling uses a prefix strip instead of lstrip('*.')**, which strips characters rather than a prefix.

3. **Removed two unreachable duplicate except PermissionError** clauses in authz and challenge.

4. **Extracted `_rewrite_order_urls`, shared by `get_order` and `finalize_order`**.

#### Performance

1. **TTL caches for the upstream directory (5 min)**, the upstream finalize URL and the challenge-to-order map — thread-safe, bounded at 512 entries, every miss falls back to the previous behavior.

2. **Nonce pooling**. Every upstream response carries a fresh Replay-Nonce (§6.5); harvesting them removes one HEAD /new-nonce round-trip per proxied request. Pooled values are single-use and TTL-bounded, and the existing badNonce retry still covers a stale one.

3. **`finalize` skips its extra POST-as-GET** when the finalize URL was captured at `new-order` or a prior `get_order`.

4. **`reset_proxy_caches()` clears all process-level state**, for tests and for in-place directory URL changes.

#### Dead code removed
1. **self.nonces** — assigned in __init__, never read anywhere in the repo.

2. **_urls_share_ca** — orphaned when the _find_order_for_challenge fallback was removed; zero call sites.

#### Behaviour change to be aware of:

A jwk-signed new-order now returns urn:ietf:params:acme:error:malformed ("Account kid required in protected header") instead of being processed. This is what RFC 8555 §6.2 requires and what the native ACME server already enforced; certbot, acme.sh and win-acme all send the kid on new-order.
 

#### Testing

Verified against the existing suite: 
_test_new_order_requires_kid_when_eab_enabled, test_new_order_allows_kid_when_eab_enabled, test_find_order_for_certificate_matches_upstream_cert_url, test_find_order_fast_path_no_upstream_calls, test_fallback_scan_skips_rows_with_url, test_finalize_without_identity_rejected, test_finalize_with_matching_identity_passes_binding, test_rel_up_link_single_prefix, test_dns_cleanup_dispatched_to_background, test_upstream_link_header_not_forwarded, test_link_not_forwarded_on_upstream_error, plus the test_acme_proxy_ownership.py suite._

One test-infrastructure addition is required: an autouse fixture in backend/tests/conftest.py calling reset_proxy_caches(), because three proxy test modules stub the same upstream directory URL with different payloads and the new caches are process-level.

_______

_This PR has been sponsored by PMGA Tech LLP_