### PR TITLE
fix(tsa): accept a constrained sub-CA certificate as the timestamp signer (#309)

### DIFF
--- a/backend/services/tsa_service.py
+++ b/backend/services/tsa_service.py
@@ -80,14 +80,41 @@ class TSAService:
             return False
 
     @staticmethod
+    def _accept_ca_signer_or_raise() -> None:
+        """Compatibility path for signing timestamps with a CA's own certificate.
+
+        UCM has always signed with the configured CA certificate, which is not
+        an RFC 3161 §2.3 dedicated signer: a root usually carries no EKU, and a
+        constrained sub-CA carries an EKU that does not list timeStamping (#309).
+        Both are accepted with a warning unless the operator opted into the
+        strict tsa_require_dedicated_cert mode.
+        """
+        if TSAService._require_dedicated_tsa_cert():
+            raise TSAConfigurationError(
+                'TSA is configured to sign with a CA certificate, but '
+                'tsa_require_dedicated_cert is enabled. Issue a dedicated '
+                'end-entity TSA certificate with a critical, exclusive '
+                'timeStamping EKU (RFC 3161 §2.3).'
+            )
+        logger.warning(
+            'TSA is signing with a CA certificate that is not a dedicated '
+            'timeStamping signer. The /tsa endpoint is unauthenticated, so this '
+            'makes the CA private key an anonymous signing oracle over '
+            'caller-supplied content. Issue a dedicated TSA certificate with a '
+            'critical, exclusive timeStamping EKU (RFC 3161 §2.3) and set '
+            'tsa_require_dedicated_cert=true to enforce it.'
+        )
+
+    @staticmethod
     def validate_certificate(tsa_cert: x509.Certificate) -> None:
         """Validate the TSA signer. A dedicated end-entity TSA certificate
         (RFC 3161 §2.3: critical, exclusive timeStamping EKU) is the
         recommended setup, but UCM historically signs with the configured
-        CA's own certificate — which carries no EKU at all. Refusing that
-        broke every pre-2.200 deployment, so a CA certificate stays
-        accepted (with a warning), and only an end-entity certificate
-        lacking the timeStamping EKU is refused."""
+        CA's own certificate. A root carries no EKU; a constrained sub-CA
+        carries an EKU without timeStamping (#309). Refusing either broke
+        existing deployments, so a CA certificate stays accepted (with a
+        warning), and only an end-entity certificate lacking the
+        timeStamping EKU is refused."""
         try:
             bc = tsa_cert.extensions.get_extension_for_oid(
                 ExtensionOID.BASIC_CONSTRAINTS
@@ -102,21 +129,7 @@ class TSAService:
             )
         except x509.ExtensionNotFound:
             if is_ca:
-                if TSAService._require_dedicated_tsa_cert():
-                    raise TSAConfigurationError(
-                        'TSA is configured to sign with a CA certificate, but '
-                        'tsa_require_dedicated_cert is enabled. Issue a dedicated '
-                        'end-entity TSA certificate with a critical, exclusive '
-                        'timeStamping EKU (RFC 3161 §2.3).'
-                    )
-                logger.warning(
-                    'TSA is signing with a CA certificate (no timeStamping EKU). '
-                    'The /tsa endpoint is unauthenticated, so this makes the CA '
-                    'private key an anonymous signing oracle over caller-supplied '
-                    'content. Issue a dedicated TSA certificate with a critical, '
-                    'exclusive timeStamping EKU (RFC 3161 §2.3) and set '
-                    'tsa_require_dedicated_cert=true to enforce it.'
-                )
+                TSAService._accept_ca_signer_or_raise()
                 return
             raise TSAConfigurationError(
                 'TSA certificate is missing the timeStamping EKU'
@@ -124,6 +137,12 @@ class TSAService:
 
         eku_oids = set(eku_extension.value)
         if ExtendedKeyUsageOID.TIME_STAMPING not in eku_oids:
+            # A constrained sub-CA carries an EKU that does not list
+            # timeStamping; treat it like any other CA signer (#309). An
+            # end-entity certificate without timeStamping is still refused.
+            if is_ca:
+                TSAService._accept_ca_signer_or_raise()
+                return
             raise TSAConfigurationError(
                 'TSA certificate does not include the timeStamping EKU'
             )

--- a/backend/tests/test_tsa_service.py
+++ b/backend/tests/test_tsa_service.py
@@ -25,7 +25,8 @@ def _failure_info_native(resp_der):
     return _status_info(resp_der)['fail_info'].native
 
 
-def _self_signed_tsa(include_eku=True, eku_critical=True, basic_constraints_ca=False):
+def _self_signed_tsa(include_eku=True, eku_critical=True, basic_constraints_ca=False,
+                     eku_oids=None):
     """Build a self-signed cert + key, optionally with a valid TSA EKU."""
     from cryptography import x509
     from cryptography.x509.oid import NameOID
@@ -43,7 +44,9 @@ def _self_signed_tsa(include_eku=True, eku_critical=True, basic_constraints_ca=F
                .not_valid_after(datetime.now(timezone.utc) + timedelta(days=365)))
     if include_eku:
         builder = builder.add_extension(
-            x509.ExtendedKeyUsage([x509.oid.ExtendedKeyUsageOID.TIME_STAMPING]),
+            x509.ExtendedKeyUsage(
+                eku_oids or [x509.oid.ExtendedKeyUsageOID.TIME_STAMPING]
+            ),
             critical=eku_critical,
         )
     if basic_constraints_ca:
@@ -235,6 +238,48 @@ class TestTsaCertificateValidation:
 
         cert, key = _self_signed_tsa(include_eku=False, basic_constraints_ca=True)
         assert TSAService(cert, key).tsa_cert is cert
+
+    def test_ca_certificate_with_non_timestamping_eku_is_accepted(self):
+        # #309: a constrained sub-CA carries an EKU that does not list
+        # timeStamping. It is still the configured CA's own certificate, so
+        # signing with it stays allowed (with a warning).
+        from cryptography.x509.oid import ExtendedKeyUsageOID
+        from services.tsa_service import TSAService
+
+        cert, key = _self_signed_tsa(
+            include_eku=True, basic_constraints_ca=True,
+            eku_oids=[ExtendedKeyUsageOID.SERVER_AUTH,
+                      ExtendedKeyUsageOID.CLIENT_AUTH],
+        )
+        assert TSAService(cert, key).tsa_cert is cert
+
+    def test_end_entity_with_non_timestamping_eku_is_rejected(self):
+        # An end-entity cert lacking timeStamping is not a valid TSA signer.
+        from cryptography.x509.oid import ExtendedKeyUsageOID
+        from services.tsa_service import TSAConfigurationError, TSAService
+
+        cert, key = _self_signed_tsa(
+            include_eku=True, basic_constraints_ca=False,
+            eku_oids=[ExtendedKeyUsageOID.SERVER_AUTH],
+        )
+        with pytest.raises(TSAConfigurationError, match='timeStamping'):
+            TSAService(cert, key)
+
+    def test_ca_with_non_timestamping_eku_refused_when_dedicated_required(
+        self, monkeypatch,
+    ):
+        from cryptography.x509.oid import ExtendedKeyUsageOID
+        from services.tsa_service import TSAConfigurationError, TSAService
+
+        monkeypatch.setattr(
+            TSAService, '_require_dedicated_tsa_cert', staticmethod(lambda: True),
+        )
+        cert, key = _self_signed_tsa(
+            include_eku=True, basic_constraints_ca=True,
+            eku_oids=[ExtendedKeyUsageOID.SERVER_AUTH],
+        )
+        with pytest.raises(TSAConfigurationError, match='dedicated'):
+            TSAService(cert, key)
 
 
 class TestTsaManagementApi:


### PR DESCRIPTION
## Problem (#309)

`/tsa` returns 503, log shows `Invalid TSA configuration: TSA certificate does not include the timeStamping EKU`.

The `/tsa` endpoint signs with the configured CA's own certificate (`tsa_protocol.py` loads `ca.crt`/`ca.prv` from the CA at `tsa_ca_refid`; there is no separate signer cert). The pre-2.200 compatibility carve-out in `TSAService.validate_certificate` that keeps CA-certificate signing working only handled a CA cert with **no EKU extension at all**. A constrained sub-CA whose certificate carries an EKU without `id-kp-timeStamping` (a common issuing-CA setup, EKU chaining) fell through to the hard `raise` and every timestamp request failed with a 503.

This surfaced now for @dogarethebest because #300 (signing-CA selection silently not persisting, fixed in v2.215) previously masked it: with the selection finally sticking, the request path reaches the signing step for the first time.

## Fix

Both CA-signer cases now route through one `_accept_ca_signer_or_raise()` helper: warn and continue, or raise only when `tsa_require_dedicated_cert` is enabled. An end-entity certificate lacking the timeStamping EKU is still refused outright.

This restores function, not just logging: validation passing means `TSAService` constructs and `process_request` issues real timestamp tokens again instead of the endpoint returning 503. A per-request advisory warning stays (same as the existing no-EKU CA path).

## Testing (Linux, Python 3.13, pytest 9.0.3)

- `test_tsa_service.py` + `test_audit_v2203_medium_findings.py`: 45 passed.
- New cases: CA-with-non-timeStamping-EKU accepted; end-entity-with-non-timeStamping-EKU still rejected; CA refused under `tsa_require_dedicated_cert`. The two new CA cases fail against the pre-fix code.

Not addressed here: `tsa_require_dedicated_cert` still has no way to actually supply a dedicated signer cert (the endpoint only ever loads the CA cert). That is a separate feature.

No `CHANGELOG.md` changes.