### PR TITLE
feat(templates): offer RSA-3072 and EC-P521 in the template Key Type dropdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ Starting with v2.48, UCM uses Major.Build versioning (e.g., 2.48, 2.49). Earlier
 
 ---
 
+## [Unreleased]
+
+### Added
+- The certificate template editor's Key Type dropdown now offers `RSA-3072` and `EC-P521`. Both were already accepted by the template API and produced working certificates at issuance; only the dropdown was missing them (#318 follow-up)
+
 ## [2.219] - 2026-09-01
 
 ### Fixed

--- a/backend/tests/test_issue_226_template_extensions.py
+++ b/backend/tests/test_issue_226_template_extensions.py
@@ -201,6 +201,28 @@ class TestTemplateDefaultsAtIssuance:
         assert isinstance(pub, rsa.RSAPublicKey)
         assert pub.key_size == 4096
 
+    def test_rsa3072_and_ecp521_templates_issue(self, app, auth_client, create_ca):
+        """The Key Type options newly surfaced in the template editor
+        (RSA-3072, EC-P521) issue a certificate with the expected key."""
+        from cryptography.hazmat.primitives.asymmetric import ec, rsa
+        ca = create_ca(cn='Issue226 New Key Options CA')
+
+        tpl_rsa = _create_template(
+            auth_client, name='issue226-rsa3072', key_type='RSA-3072')
+        r = self._issue_raw(auth_client, {
+            'cn': 'rsa3072.test', 'ca_id': ca['id'], 'template_id': tpl_rsa['id']})
+        assert r.status_code in (200, 201), r.data
+        pub = _issued_cert_obj(app, get_json(r)['data']['id']).public_key()
+        assert isinstance(pub, rsa.RSAPublicKey) and pub.key_size == 3072
+
+        tpl_ec = _create_template(
+            auth_client, name='issue226-ecp521', key_type='EC-P521')
+        r = self._issue_raw(auth_client, {
+            'cn': 'ecp521.test', 'ca_id': ca['id'], 'template_id': tpl_ec['id']})
+        assert r.status_code in (200, 201), r.data
+        pub = _issued_cert_obj(app, get_json(r)['data']['id']).public_key()
+        assert isinstance(pub, ec.EllipticCurvePublicKey) and pub.curve.name == 'secp521r1'
+
     def test_explicit_request_values_override_template(self, app, auth_client, create_ca):
         from cryptography.hazmat.primitives.asymmetric import ec
         ca = create_ca(cn='Issue226 Override Defaults CA')

--- a/frontend/src/pages/TemplatesPage.jsx
+++ b/frontend/src/pages/TemplatesPage.jsx
@@ -660,7 +660,7 @@ const TEMPLATE_TYPE_OPTIONS = [
   'web_server', 'email', 'vpn_server', 'vpn_client',
   'code_signing', 'client_auth', 'ocsp_signing', 'custom'
 ]
-const KEY_TYPE_OPTIONS = ['RSA-2048', 'RSA-4096', 'EC-P256', 'EC-P384']
+const KEY_TYPE_OPTIONS = ['RSA-2048', 'RSA-3072', 'RSA-4096', 'EC-P256', 'EC-P384', 'EC-P521']
 const DIGEST_OPTIONS = ['sha256', 'sha384', 'sha512']
 const KEY_USAGE_OPTIONS = [
   'digitalSignature', 'keyEncipherment', 'contentCommitment',


### PR DESCRIPTION
Follow-up to #319 / issue #318, which NeySlim asked to keep as a separate small PR.

The template editor's Key Type dropdown offered RSA-2048, RSA-4096, EC-P256, EC-P384. This adds RSA-3072 and EC-P521.

Both were already fully supported below the UI: `_VALID_KEY_TYPES` in `api/v2/templates.py`, `parse_issue_key_type()`, and the RSA/EC generation in `cert_create.py` all accept them. Only the dropdown was missing them.

Verified end to end (new test in `test_issue_226_template_extensions.py`): a template with `key_type=RSA-3072` issues a 3072-bit RSA cert, one with `key_type=EC-P521` issues a `secp521r1` cert.

Deliberately out of scope, flagging so you can fold in or wave off:
- `PoliciesPage.jsx` keeps its own key-type list for the `allowed_key_types` rule (has EC-P521, not RSA-3072). That rule has no backend enforcement anywhere (grep of `allowed_key_types`), so it's inert today.
- `constants/config.js` has a dead `KEY_TYPE_OPTIONS` export nothing imports.
- ED25519 is in `_VALID_KEY_TYPES` but `parse_issue_key_type()` rejects it, so it would fail at issuance; not adding it here.

The dropdown renders raw values (`label: v`), so no i18n keys; `check:i18n` stays green.

CHANGELOG: `[Unreleased] > Added` (will conflict with #317/#319's entries the same way, whichever merges first).