### PR TITLE
fix(templates): reject ED25519 as a template key type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ Starting with v2.48, UCM uses Major.Build versioning (e.g., 2.48, 2.49). Earlier
 ### Added
 - PKCS#12 exports gained a compatibility mode. UCM's PKCS#12 archives use the OpenSSL 3 profile (PBES2 with AES-256-CBC, PBKDF2-SHA256 and an HMAC-SHA256 integrity check), which Android 15 and earlier, macOS 14 and earlier, Windows Server 2016 and earlier and Java before 8u301 / 11.0.1 cannot read and report as a wrong password. A Compatibility mode checkbox on the export dialogs (certificates, CAs, the user portal, mTLS downloads and key recovery) switches that archive to the 3DES/SHA-1 profile these importers accept, the same LegacyDES profile cert-manager and go-pkcs12 offer. The API takes it as `legacy: true` alongside `password`. AES-256 stays the default and the checkbox is a per-export choice, since the legacy profile protects the archive less well (#331, requested by @MakosHD)
 
+### Fixed
+- The certificate template API no longer accepts `ED25519` as a key type. It was allowed at save time but the issuance path cannot generate an Edwards key, so every certificate request from such a template failed with a 400. `POST` and `PUT /api/v2/templates` now reject it up front, and template import skips an `ED25519` entry with a reason string instead of storing a template that can never issue (#321 follow-up)
+
 ## [2.221] - 2026-09-05
 
 ### Added

--- a/backend/api/v2/templates.py
+++ b/backend/api/v2/templates.py
@@ -43,7 +43,8 @@ _MIN_VALIDITY_DAYS = 1
 _VALID_KEY_TYPES = {
     'RSA-2048', 'RSA-3072', 'RSA-4096',
     'EC-P256', 'EC-P384', 'EC-P521',
-    'ED25519',
+    # no ED25519: parse_issue_key_type() cannot generate an Edwards key, so a
+    # template saved with it fails every issuance with a 400
     # legacy lowercase forms used by some import payloads
     'rsa:2048', 'rsa:3072', 'rsa:4096',
     'ec:p256', 'ec:p384', 'ec:p521',

--- a/backend/tests/test_templates.py
+++ b/backend/tests/test_templates.py
@@ -241,6 +241,17 @@ class TestCreateTemplate:
                              content_type='application/json')
         assert_error(r, 400)
 
+    def test_create_rejects_ed25519_key_type(self, auth_client):
+        """ED25519 was accepted at save time but rejected by
+        parse_issue_key_type() at issuance, so the template could never
+        issue a certificate. It is now refused up front (#321 follow-up)."""
+        r = auth_client.post('/api/v2/templates',
+                             data=json.dumps({**VALID_TEMPLATE,
+                                              'name': 'Ed25519 Tpl',
+                                              'key_type': 'ED25519'}),
+                             content_type='application/json')
+        assert_error(r, 400)
+
     def test_create_duplicate_name(self, auth_client):
         name = 'Duplicate Name Check'
         _create_template(auth_client, name=name)
@@ -365,6 +376,16 @@ class TestUpdateTemplate:
                             content_type='application/json')
         data = assert_success(r)
         assert data['validity_days'] == 730
+
+    def test_update_rejects_ed25519_key_type(self, auth_client):
+        """A PUT that sets key_type to ED25519 is refused, same as create
+        (#321 follow-up)."""
+        r, created = _create_template(auth_client, name='Ed25519 Update Tpl')
+        tid = created['id']
+        r = auth_client.put(f'/api/v2/templates/{tid}',
+                            data=json.dumps({'key_type': 'ED25519'}),
+                            content_type='application/json')
+        assert_error(r, 400)
 
     def test_update_deactivate(self, auth_client):
         r, created = _create_template(auth_client, name='Deactivate Tpl')


### PR DESCRIPTION
## What

`ED25519` was in the template API's `_VALID_KEY_TYPES`, so `POST` / `PUT /api/v2/templates` accepted a template with `key_type: ED25519` and saved it. But `parse_issue_key_type()` has no branch for Edwards keys, so every certificate request from that template failed with a 400 at issuance. A saveable, unusable template.

This drops `ED25519` from the accepted set, per your #321 review: "ED25519 sitting in `_VALID_KEY_TYPES` while `parse_issue_key_type()` rejects it is a trap worth closing in a follow-up (drop it from the accepted set unless we implement it)."

## Change

- `_VALID_KEY_TYPES` in `backend/api/v2/templates.py`: remove `'ED25519'`, one WHY comment in its place.
- `backend/tests/test_templates.py`: `POST` and `PUT` with `key_type='ED25519'` now assert 400.
- CHANGELOG `[Unreleased] > Fixed`.

## Side effects (intended)

- Editing a pre-existing `ED25519` template through the UI now returns 400, because the editor posts the whole payload including `key_type`. This surfaces a template that could never issue rather than letting it sit.
- `import_template` skips an `ED25519` entry with a reason string instead of storing it.
- `_normalize_key_type_label` in `template_service.py` is left untouched. Its `ED25519` / `ED448` handling normalises a CSR's key for the divergence tracker (an ACME client can present an Edwards key), which is separate from what the template API accepts.
- `duplicate_template` copies a stored `key_type` without re-validating, so an existing `ED25519` row can still be cloned. Left as is: duplicate clones a stored row, it does not take user input.

## Testing

pytest on Linux / py3.13: `test_templates.py` 74 passed; with `test_issue_226_template_extensions.py`, `test_template_overrides.py`, `test_acme_profile_template.py` and `test_template_digest_usage.py`, 144 passed. No released CHANGELOG sections or version files touched.
