### PR TITLE
chore(frontend): drop the unused KEY_TYPE_OPTIONS export

### DIFF
--- a/frontend/src/constants/config.js
+++ b/frontend/src/constants/config.js
@@ -89,14 +89,6 @@ export const VALIDITY_OPTIONS = [
   { value: '1095', label: '3 years' },
 ]
 
-// Key Type Options
-export const KEY_TYPE_OPTIONS = [
-  { value: 'RSA-2048', label: 'RSA 2048' },
-  { value: 'RSA-4096', label: 'RSA 4096' },
-  { value: 'ECDSA-P256', label: 'ECDSA P-256' },
-  { value: 'ECDSA-P384', label: 'ECDSA P-384' },
-]
-
 // Status Colors (semantic)
 export const STATUS_COLORS = {
   valid: { bg: 'bg-green-500/10', text: 'text-green-500', border: 'border-green-500/30' },


### PR DESCRIPTION
## What

`KEY_TYPE_OPTIONS` in `frontend/src/constants/config.js` is exported but nothing imports it. `constants/index.js` re-exports it via `export * from './config'`, but no file references the name; `PoliciesPage.jsx` and `TemplatesPage.jsx` each declare their own local `KEY_TYPE_OPTIONS`. The exported values are also stale (`ECDSA-P256` label form, no `RSA-3072` / `EC-P521`).

Per your #321 review: "the dead `KEY_TYPE_OPTIONS` export can wait." Straight deletion, no behaviour change.

## Testing

`npm run lint` (0 errors) and `npm run build` both clean.
